### PR TITLE
docs: add repository governance and project README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill out the sections
+        below so we can reproduce and fix it quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected instead.
+      placeholder: When I do X, Y happens; I expected Z.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps for us to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      description: Which part of the platform is involved? (best guess is fine)
+      options:
+        - control-plane
+        - web
+        - channel-gateway
+        - scheduler
+        - browser-service
+        - sandbox-service
+        - skills-content-service
+        - memory-fuse
+        - agents (claude-code / codex)
+        - sandbox SDK (@neutree-ai/sandbox)
+        - self-host / deployment
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Version / commit, deployment profile (multi-node / single-node), OS, browser if relevant.
+      placeholder: |
+        - Version/commit:
+        - Deployment: self-host single-node
+        - OS / browser:
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / screenshots
+      description: Paste any relevant log output or attach screenshots. Redact secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Describing the problem behind the request
+        helps us find the best solution — which may differ from the one you
+        have in mind.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The use case or pain point motivating this request.
+      placeholder: I'm always frustrated when …
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about.
+    validations:
+      required: false
+  - type: dropdown
+    id: component
+    attributes:
+      label: Related component
+      options:
+        - control-plane
+        - web
+        - channel-gateway
+        - scheduler
+        - browser-service
+        - sandbox-service
+        - skills-content-service
+        - memory-fuse
+        - agents (claude-code / codex)
+        - sandbox SDK (@neutree-ai/sandbox)
+        - self-host / deployment
+        - other / not sure
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing! Please keep PRs focused — one logical change per PR.
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issues
+
+<!-- e.g. Fixes #123 — remove if none -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+-
+
+## Testing
+
+<!-- How did you verify this? Commands run, manual steps, new/updated tests. -->
+-
+
+## Checklist
+
+- [ ] PR is scoped to a single logical change
+- [ ] Type-check passes (`npx tsc --noEmit`) for the affected component(s)
+- [ ] Lint/format passes (`npx biome check .`)
+- [ ] Tests added/updated where it makes sense, and passing
+- [ ] Docs updated if behavior or configuration changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the maintainers responsible for enforcement through the repository's **Security → Report a vulnerability** form, which provides a confidential channel visible only to the maintainers. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Neutree Agent Platform
+
+Thanks for your interest in contributing! This document covers how to propose changes, the local development setup, and the conventions we follow.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report bugs** and **request features** via [GitHub Issues](../../issues) using the provided templates.
+- **Improve docs** — fixes to READMEs and inline docs are always welcome.
+- **Submit code** via pull requests (see below).
+
+For security vulnerabilities, **do not** open a public issue — follow [SECURITY.md](SECURITY.md).
+
+## Development workflow
+
+This project uses a **pull-request workflow**. Direct pushes to `main` are not accepted; all changes land through review.
+
+1. **Fork** the repository (or create a branch if you have write access).
+2. Create a topic branch: `git checkout -b feat/short-description`.
+3. Make your change, with tests where it makes sense.
+4. Run the relevant checks locally (see below).
+5. Open a pull request against `main`. Fill out the PR template — describe the change, how you tested it, and link any related issue.
+6. CI runs on the PR. Address review feedback by pushing follow-up commits.
+
+Keep PRs focused: one logical change per PR is much easier to review than a large mixed bag.
+
+## Local development
+
+The repo is a polyglot monorepo. Toolchain by component:
+
+- **`control-plane/` and `web/`** use **npm**.
+- Most other services (channel-gateway, scheduler, sandbox-service, browser-service, …) use **[Bun](https://bun.sh)**.
+- Linting/formatting is **[Biome](https://biomejs.dev)**; dead-code/dependency checks use **knip**. Both run in the pre-commit hook.
+
+Typical inner loop for a single component:
+
+```bash
+cd control-plane          # or web, channel-gateway, …
+npm install               # or: bun install
+npm run dev               # or: bun run dev
+```
+
+Before opening a PR, from the component you changed:
+
+```bash
+npx tsc --noEmit          # type-check
+npx biome check .         # lint + format
+# run the component's test command if it has one (npm test / bun test)
+```
+
+A PostgreSQL instance is required to run the control plane. The simplest path for an end-to-end environment is the [self-host installer](self-host/README.md).
+
+### Database migrations
+
+Control-plane schema changes are plain `.sql` files applied at startup. If you add one, **start numbering at `115_`** — lower numbers are reserved by the pre-squash history and reusing them silently diverges existing databases. See [`control-plane/migrations/README.md`](control-plane/migrations/README.md) for the runner's rules and the reasoning.
+
+## Commit and PR conventions
+
+- Write commit messages in **English**, present tense, with a concise summary line. We loosely follow [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`) — not enforced, but appreciated.
+- Keep the history readable: squash noisy fix-up commits before requesting review when practical.
+- Reference issues with `Fixes #123` / `Closes #123` so they auto-close on merge.
+
+## License of contributions
+
+This project is licensed under the [Apache License 2.0](LICENSE). By submitting a contribution, you agree that it is licensed under the same terms, and you certify that you have the right to submit it (per the Apache-2.0 inbound=outbound convention).
+
+## Questions
+
+Not sure where something belongs, or whether a change would be welcome? Open a [discussion or issue](../../issues) before investing a lot of work — we're happy to help you scope it.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Neutree Agent Platform
+Copyright 2026 Arcfra
+
+This product includes software developed at Arcfra.
+
+Licensed under the Apache License, Version 2.0. See the LICENSE file for the
+full license text.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+<h1 align="center">Neutree Agent Platform</h1>
+
+<p align="center">
+  Turn your expertise into agents — available anytime, anywhere, to anyone.<br/>
+  An open platform to <strong>build</strong>, <strong>distribute</strong>, and <strong>optimize</strong> AI agents, on infrastructure your team can host.
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
+  <a href="CONTRIBUTING.md"><img alt="Contributions welcome" src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg"></a>
+</p>
+
+---
+
+Neutree Agent Platform (NAP) turns AI agents into a hosted, multi-user service. Instead of every developer running an agent on their own laptop, a team gets one platform to **build** agents, **distribute** them through whatever channel users already live in, and **optimize** them as they run.
+
+## Build — more with less, on the platform
+
+- **Agent core** — a neutral, swappable frontier agent at the center. Claude Code and Codex are supported today, and the runtime extends to others. Shape its expertise with prompts, skills, and MCP.
+- **Agent middleware, batteries included** — sandbox, remote browser, agent-native shared filesystem, memory store, multi-agent orchestration, and MCP gateway are provided by the platform. Agents use them out of the box instead of each rebuilding them.
+- **Build it your way** — configure agents directly through the UI, or describe the expertise you want in natural language and let an agent assemble it for you.
+- **Custom human-in-the-loop UIs** — build UI plugins that place the right human checkpoints into an agent's workflow, so people can approve and steer at exactly the right moments.
+- **Resource library** — agent templates, prompts, and skills become shared, reusable assets, so a team standardizes and forks instead of starting over.
+
+## Distribute — build once, use everywhere
+
+- **Access entry points** — drive an agent from the built-in web UI, from message channels like Slack/IM through the channel gateway, or embed it in your own web app with the HTTP API and UI SDK.
+- **Run modes** — run agents **resident** (always-on, zero cold start, for latency-sensitive workloads) or **serverless** (scale from zero, start on demand, pay for what you use).
+
+## Optimize — agents that improve with use
+
+- **Autonomous tuning** — mine session history for where an agent underperforms and continuously refine its prompts and skills, so it gets cheaper and better the more it runs.
+- **Model swapping** *(planned)* — automatically evaluate against cheaper models and switch when quality holds, to keep pushing cost down.
+
+## Architecture
+
+NAP is a set of services that share a PostgreSQL control plane.
+
+| Component | Package | Role |
+| --- | --- | --- |
+| **control-plane** | `@neutree-ai/control-plane` | Core API + orchestrator: workspaces, sessions, agents, prompts, templates, skills, providers, credentials, teams. PostgreSQL-backed. |
+| **web** | `@neutree-ai/web` | React front-end (Vite + Tailwind + shadcn/ui). |
+| **channel-gateway** | `@neutree-ai/channel-gateway` | Bridges external channels into the platform. |
+| **scheduler** | `@neutree-ai/scheduler` | Runs scheduled / recurring agent tasks. |
+| **browser-service** | `@neutree-ai/browser-service` | Remote browser agents drive, streamed to users over WebRTC. |
+| **sandbox-service** | `@neutree-ai/sandbox-service` | Code sandbox control, backed by [OpenSandbox](https://github.com/alibaba/OpenSandbox). |
+| **skills-content-service** | `@neutree-ai/skills-content-service` | Serves agent skill content. |
+| **memory-fuse** | — | FUSE layer exposing agent memory as a filesystem. |
+| **agents/** | — | Agent runtime adapters (`claude-code`, `codex`). |
+| **internal/** | `@neutree-ai/*` | Shared libraries (client, types, oauth-client, theme, prompt, …). |
+
+## Quick start
+
+The fastest way to stand up the whole platform is the self-host installer, which deploys to a Kubernetes cluster (multi-node or a single k3s node):
+
+```bash
+cd self-host
+cp values.env.example values.env
+./gen-secrets.sh                 # fill random machine secrets
+vi values.env                    # set host, admin password, storage, …
+./install.sh
+```
+
+When it finishes, open the web UI and log in with the admin credentials from `values.env`. The Code Sandbox and Remote Browser capabilities are optional and can be enabled later without reinstalling — see [`self-host/README.md`](self-host/README.md) for the full guide, configuration reference, and optional-capability setup.
+
+## Container images
+
+First-party images are published to GitHub Container Registry under `ghcr.io/neutree-ai/agent-platform/` (e.g. `nap-cp`, `nap-cg`, `nap-scheduler`, `nap-browser`, `nap-sandbox`). Builds are driven by [`.github/workflows/build-images.yml`](.github/workflows/build-images.yml): images are built on demand (`workflow_dispatch`) or when a per-service release tag `<image>-v<x.y.z>` is pushed — services version independently.
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, branch/PR conventions, and local-dev setup, and note our [Code of Conduct](CODE_OF_CONDUCT.md). For security issues, see [SECURITY.md](SECURITY.md) — please do not open public issues for vulnerabilities.
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE). Copyright 2026 Arcfra.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+We take the security of Neutree Agent Platform seriously. Thank you for helping keep the project and its users safe.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please report it privately through **GitHub private vulnerability reporting**: open the repository's **Security** tab → **Report a vulnerability**. This creates a private advisory visible only to you and the maintainers.
+
+Please include, as far as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- Affected component(s) and version / commit.
+- Any suggested mitigation.
+
+## What to expect
+
+- We aim to acknowledge your report within a few business days.
+- We will investigate, keep you informed of progress, and coordinate a fix and disclosure timeline with you.
+- We are happy to credit reporters in the advisory unless you prefer to remain anonymous.
+
+## Scope
+
+Security issues in any first-party component of this repository are in scope. Vulnerabilities in third-party dependencies or external components (e.g. OpenSandbox) should be reported to their respective projects; if a NAP default or integration makes such an issue materially worse, we still want to hear about it.

--- a/control-plane/migrations/README.md
+++ b/control-plane/migrations/README.md
@@ -1,0 +1,36 @@
+# Control-plane database migrations
+
+Plain `.sql` files applied in lexical order at control-plane startup. There is no separate migration CLI — the runner lives in [`src/services/db/pool.ts`](../src/services/db/pool.ts).
+
+## How the runner works
+
+On boot the control-plane:
+
+1. Ensures a `schema_migrations(id, applied_at)` table exists.
+2. Loads the set of already-applied ids: `SELECT id FROM schema_migrations`.
+3. Reads every `*.sql` file in this directory, **sorted by filename**.
+4. For each file, `id = <filename without .sql>`. If `id` is already in `schema_migrations`, it is **skipped**; otherwise the file runs inside a transaction and the `id` is recorded.
+
+So a migration runs **exactly once per database**, keyed on its filename. The filename — not its contents — is the identity. Renaming an applied migration makes the runner think it is new and run it again.
+
+## The baseline: `001_init.sql`
+
+`001_init.sql` is a **squashed consolidation** of the original migration chain (historically `001_init` … `114_workspace_layout`). The schema it produces is identical to running that full chain.
+
+- On a **fresh** database it builds the entire schema in one step, then records `001_init`.
+- On an **existing** database (our production and every deployed self-host install) `001_init` is **already recorded**, so it is skipped — the schema is already there. The historical ids `002_…` through `114_…` also remain recorded on those databases; their files no longer exist here, and the runner only iterates over files that are present, so they are inert.
+
+It contains **pure schema only**. Bootstrap rows (the internal `system` user and the singleton `system_settings` row) are seeded by [`scripts/seed-admin.ts`](../scripts/seed-admin.ts), not by a migration.
+
+## Adding a new migration
+
+**Start numbering at `115_`.** The ids `001`–`114` are occupied on existing databases by the pre-squash chain. Reusing one of those stems would cause the migration to be **silently skipped** on existing installs while still running on fresh ones — a silent schema divergence with no error. Continuing from `115` avoids the entire collision surface.
+
+Rules of thumb:
+
+- **Filename**: `NNN_snake_case_description.sql`, three-digit zero-padded, strictly increasing. Next free number is **115**.
+- **Never rename or edit an applied migration.** To change something already shipped, add a new migration.
+- Each file runs once, in its own transaction. Write it to succeed against the schema as produced by every migration before it.
+- **No seed/bootstrap data here** — schema only. Data that every install needs goes into `scripts/seed-admin.ts` (idempotent, `ON CONFLICT DO NOTHING`).
+
+> Why 115 and not 002: a brand-new install's ledger only contains `001_init`, so `002_*` would look free there — but our production and customer databases still carry the `002`–`114` ids from before the squash. `115+` is the one numbering that is correct on **all** populations.

--- a/skills-content-service/README.md
+++ b/skills-content-service/README.md
@@ -87,7 +87,7 @@ talks to scs directly today.
 ## Local dev
 
 ```bash
-cd ~/workspace/fictors/skills-content-service
+cd skills-content-service   # from the repo root
 npm install
 cp .env.example .env
 npm run dev


### PR DESCRIPTION
Sets up the public-facing governance and front-door docs for the open-source repo.

## What's included
- **README** — project overview framed as **build → distribute → optimize**, architecture table, self-host quick start, container-images section.
- **CONTRIBUTING** — PR workflow (no direct pushes to `main`), monorepo toolchain (npm/bun, Biome/knip), and the migration numbering rule.
- **LICENSE** (Apache-2.0) + **NOTICE** (Copyright 2026 Arcfra).
- **SECURITY** — private vulnerability reporting via GitHub advisories (no email).
- **CODE_OF_CONDUCT** — Contributor Covenant 2.1.
- **.github** — PR template + bug/feature issue forms.
- **control-plane/migrations/README** — runner behavior and the `115+` numbering rule (post-squash baseline).

## Notes
- Issue-template `config.yml` (contact links / Discussions) intentionally left out until those URLs are decided.
- Product name stays **Neutree Agent Platform** / `@neutree-ai` namespace; legal copyright holder is **Arcfra**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)