### PR TITLE
feat(providers): add Test button to Edit Provider dialog

### DIFF
--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -349,16 +349,24 @@ providers.openapi(testRoute, async (c) => {
   const body = c.req.valid('json')
   const model = body.model || ''
 
+  // Merge optional draft config over the stored provider so the Edit Provider
+  // dialog can probe unsaved values. A blank api_key keeps the stored key.
+  const effective = {
+    provider_type: body.provider_type ?? provider.provider_type,
+    base_url: body.base_url ?? provider.base_url,
+    api_key: body.api_key ? body.api_key : provider.api_key,
+  }
+
   try {
     let res: Response
 
-    if (isAnthropicType(provider.provider_type)) {
-      const baseUrl = resolveAnthropicUrl(provider)
+    if (isAnthropicType(effective.provider_type)) {
+      const baseUrl = resolveAnthropicUrl(effective)
       res = await fetch(`${baseUrl}/v1/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-api-key': provider.api_key,
+          'x-api-key': effective.api_key,
           'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
@@ -367,11 +375,11 @@ providers.openapi(testRoute, async (c) => {
           messages: [{ role: 'user', content: 'hi' }],
         }),
       })
-    } else if (provider.provider_type === 'openai') {
-      const baseUrl = (provider.base_url || 'https://api.openai.com').replace(/\/+$/, '')
+    } else if (effective.provider_type === 'openai') {
+      const baseUrl = (effective.base_url || 'https://api.openai.com').replace(/\/+$/, '')
       const headers = {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${provider.api_key}`,
+        Authorization: `Bearer ${effective.api_key}`,
       }
       const testModel = model || 'gpt-4o-mini'
 
@@ -401,7 +409,7 @@ providers.openapi(testRoute, async (c) => {
       }
     } else {
       return c.json(
-        { ok: false, detail: `Unsupported provider type: ${provider.provider_type}` },
+        { ok: false, detail: `Unsupported provider type: ${effective.provider_type}` },
         200,
       )
     }

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -738,6 +738,13 @@ export const ModelProviderUpdateBodySchema = z
 
 export const ModelProviderTestBodySchema = z.object({
   model: z.string().optional(),
+  // Optional draft config: when present, probe these values instead of the
+  // stored ones (lets the Edit Provider dialog test before saving). Omitted
+  // fields fall back to the stored provider. A blank api_key keeps the stored
+  // key (mirrors the edit-mode "blank = unchanged" convention).
+  provider_type: z.string().optional(),
+  base_url: z.string().optional(),
+  api_key: z.string().optional(),
 })
 
 export const ModelListSchema = z.object({

--- a/web/src/components/management/ProvidersSection.tsx
+++ b/web/src/components/management/ProvidersSection.tsx
@@ -16,6 +16,7 @@ import { DocumentedDialog } from '@/components/ui/documented-dialog'
 import { EmptyHero } from '@/components/ui/empty-hero'
 import { EmptyIllustration } from '@/components/ui/empty-illustration'
 import { SaveButton } from '@/components/ui/save-button'
+import { TestButton, TestResult } from '@/components/workspace/agent-config/ModelPicker'
 import { useDialogStack } from '@/contexts/DialogStackContext'
 import { getProviderDoc, getProviderDocsHint } from '@/docs/inline-help/provider-docs'
 import { useDeleteProvider, useProviders, useUpdateProvider } from '@/hooks/useProviders'
@@ -76,6 +77,8 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [form, setForm] = useState<ProviderForm>(INITIAL_FORM)
+  const [testState, setTestState] = useState<'idle' | 'testing' | 'ok' | 'fail'>('idle')
+  const [testDetail, setTestDetail] = useState('')
 
   // Pre-load existing grants when opening edit dialog for a team-shared provider
   useEffect(() => {
@@ -107,7 +110,29 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
     setEditingId(p.id)
     setErrors({})
     setGeneralError(null)
+    setTestState('idle')
+    setTestDetail('')
     setDialogOpen(true)
+  }
+
+  // Probe the currently-edited (unsaved) config in place. A blank api_key keeps
+  // the stored key (mirrors the save-time "blank = unchanged" convention).
+  async function handleTest() {
+    if (!editingId) return
+    setTestState('testing')
+    setTestDetail('')
+    try {
+      const res = await api.testProvider(editingId, {
+        provider_type: form.provider_type,
+        base_url: form.base_url,
+        api_key: form.api_key,
+      })
+      setTestState(res.ok ? 'ok' : 'fail')
+      setTestDetail(res.detail || '')
+    } catch (err) {
+      setTestState('fail')
+      setTestDetail(err instanceof Error ? err.message : t('common.errors.requestFailed'))
+    }
   }
 
   async function handleSave() {
@@ -229,6 +254,12 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
         docsHint={getProviderDocsHint()}
         footer={
           <>
+            <TestButton
+              providerId={editingId ?? ''}
+              state={testState}
+              onRun={handleTest}
+              className="mr-auto"
+            />
             <Button type="button" size="sm" variant="ghost" onClick={() => setDialogOpen(false)}>
               {t('common.cancel')}
             </Button>
@@ -240,7 +271,22 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
           </>
         }
       >
-        <ProviderFormFields form={form} setForm={setForm} errors={localizedErrors} isEditing />
+        <ProviderFormFields
+          form={form}
+          setForm={(next) => {
+            // A config edit invalidates the previous probe result.
+            setTestState('idle')
+            setTestDetail('')
+            setForm(next)
+          }}
+          errors={localizedErrors}
+          isEditing
+        />
+        {testState !== 'idle' && (
+          <div className="mt-3">
+            <TestResult state={testState} detail={testDetail} />
+          </div>
+        )}
         {generalError && <div className="mt-3 text-xs text-destructive">{generalError}</div>}
       </DocumentedDialog>
     </>

--- a/web/src/components/workspace/agent-config/ModelPicker.tsx
+++ b/web/src/components/workspace/agent-config/ModelPicker.tsx
@@ -189,7 +189,7 @@ export function useProviderTest(providerId: string, model: string) {
     setState('testing')
     setDetail('')
     try {
-      const res = await api.testProvider(providerId, model || undefined)
+      const res = await api.testProvider(providerId, { model: model || undefined })
       setState(res.ok ? 'ok' : 'fail')
       setDetail(res.detail || '')
     } catch (e: any) {
@@ -232,9 +232,7 @@ export function TestButton({
 export function TestResult({ state, detail }: { state: TestState; detail: string }) {
   const { t } = useTranslation()
   if (state === 'ok') {
-    return (
-      <p className="text-xs text-success">{t('components.modelPicker.status.connected')}</p>
-    )
+    return <p className="text-xs text-success">{t('components.modelPicker.status.connected')}</p>
   }
   if (state === 'fail') {
     return (

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1302,10 +1302,20 @@ class ApiClient {
     return res.models ?? []
   }
 
-  async testProvider(id: string, model?: string): Promise<{ ok: boolean; detail?: string }> {
+  async testProvider(
+    id: string,
+    opts?: {
+      model?: string
+      /** Optional draft config to probe instead of the stored values (blank
+       * api_key keeps the stored key). */
+      provider_type?: string
+      base_url?: string
+      api_key?: string
+    },
+  ): Promise<{ ok: boolean; detail?: string }> {
     return this.request<{ ok: boolean; detail?: string }>(`/providers/${id}/test`, {
       method: 'POST',
-      body: JSON.stringify({ model }),
+      body: JSON.stringify(opts ?? {}),
     })
   }
 


### PR DESCRIPTION
## What

Adds a **Test** button to the Edit Provider dialog so users can validate a
provider's API key / base URL connectivity in place — including unsaved draft
values — instead of saving and round-tripping through a workspace's agent
settings to test, then coming back to fix.

## Changes

- **Backend** (`POST /providers/:id/test`): the request body now accepts
  optional draft `provider_type` / `base_url` / `api_key` (alongside the
  existing `model`). When present they override the stored provider config for
  the probe; omitted fields fall back to the stored values. A blank `api_key`
  keeps the stored key, mirroring the edit-mode "blank = unchanged" convention.
  All fields optional → backward compatible.
- **API client**: `testProvider(id, opts?)` now takes an opts object carrying
  the draft config.
- **Edit Provider dialog**: wires the existing `TestButton` / `TestResult`
  components to the current form values; editing a field clears the stale probe
  result.

## Notes

- Reuses the existing test components (`TestButton` / `TestResult` from the
  workspace model picker) rather than building new ones. They could later be
  extracted to a shared location since they're now used in two places.
- Verified: `tsc --noEmit` passes for both `web` and `control-plane`; biome clean.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
