### PR TITLE
build: publish @neutree-ai/theme and @neutree-ai/oauth-client to npm

### DIFF
--- a/internal/oauth-client/package.json
+++ b/internal/oauth-client/package.json
@@ -1,15 +1,29 @@
 {
   "name": "@neutree-ai/oauth-client",
   "version": "0.1.0",
-  "private": true,
+  "description": "Neutree Agent Platform OAuth client — shared scaffolding for services acting as OAuth consumers of the control plane.",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build"
+  },
+  "license": "Apache-2.0",
   "dependencies": {
     "hono": "^4.7.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "typescript": "~5.6.2"
   }
 }

--- a/internal/oauth-client/tsconfig.build.json
+++ b/internal/oauth-client/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/internal/theme/package.json
+++ b/internal/theme/package.json
@@ -1,19 +1,35 @@
 {
   "name": "@neutree-ai/theme",
   "version": "0.1.0",
-  "private": true,
+  "description": "Neutree Agent Platform shared theme — React theme provider, toggle, and toaster with design-token CSS variables.",
   "type": "module",
-  "types": "./index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "default": "./src/index.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
-    "./variables.css": "./src/variables.css"
+    "./variables.css": "./dist/variables.css"
   },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && cp src/variables.css dist/variables.css",
+    "prepublishOnly": "npm run build"
+  },
+  "license": "Apache-2.0",
   "peerDependencies": {
     "lucide-react": "*",
     "react": "^18.0.0",
     "sonner": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "lucide-react": "*",
+    "react": "^18.0.0",
+    "sonner": "^2.0.0",
+    "typescript": "~5.6.2"
   }
 }

--- a/internal/theme/tsconfig.build.json
+++ b/internal/theme/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/knip.json
+++ b/knip.json
@@ -10,7 +10,8 @@
         "src/components/ui/**/*.{ts,tsx}",
         "src/**/*.test.{ts,tsx}"
       ],
-      "project": ["src/**/*.{ts,tsx,mdx}"]
+      "project": ["src/**/*.{ts,tsx,mdx}"],
+      "ignoreDependencies": ["@neutree-ai/theme"]
     },
     "browser-service": {
       "project": ["src/**/*.ts"]


### PR DESCRIPTION
Makes the two shared libraries in `internal/` installable from npm, so downstream repos can depend on them as normal packages instead of via source.

## Changes
- **`@neutree-ai/oauth-client`** and **`@neutree-ai/theme`**: drop `private`, add dist-based `main`/`types`/`exports` + `files`, a `tsc` build (`tsconfig.build.json`) emitting JS + `.d.ts`. theme builds `.tsx` with `react-jsx` and ships `variables.css`. Licensed Apache-2.0.
- `web` continues to consume `@neutree-ai/theme` from local source via its vite / tsconfig aliases (and the in-repo `index.d.ts`); added to knip's `web.ignoreDependencies` now that the package resolves to `dist`.

## Published
Both are already live on npm at **0.1.0**:
- `@neutree-ai/oauth-client@0.1.0`
- `@neutree-ai/theme@0.1.0`

(react / sonner / lucide-react resolve via `peerDependencies` in consumers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)