### PR TITLE
fix(settings): widen center content area in settings panel

### DIFF
--- a/web/src/components/workspace/WorkspaceSettingsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSettingsPanel.tsx
@@ -1053,7 +1053,7 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
 
       <div className="flex flex-1 min-h-0">
         {/* Left nav — single flat list */}
-        <div className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border/60 px-2 py-3">
+        <div className="flex w-36 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border/60 px-2 py-3">
           {navItems.map((item) => {
             const Icon = item.icon
             const active = activeSection === item.key
@@ -1108,7 +1108,7 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
         </ScrollArea>
 
         {/* Right docs */}
-        <ScrollArea className="hidden w-80 shrink-0 border-l border-border/60 lg:block">
+        <ScrollArea className="hidden w-64 shrink-0 border-l border-border/60 lg:block">
           <div className="px-4 py-5">
             <Markdown
               key={activeSection}


### PR DESCRIPTION
## What

Shrink the settings panel's left nav (`w-44`→`w-36`, 176→144px) and right docs (`w-80`→`w-64`, 320→256px), giving the center content area **+112px**.

## Why

User feedback that the center content area in the workspace settings panel felt too cramped, while the two fixed side columns (496px combined) ate into it. Keeps the 3-column layout intact — pure CSS class change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)