### PR TITLE
fix(claude-code): return interrupted sessions to idle

### DIFF
--- a/agents/claude-code/src/agent.ts
+++ b/agents/claude-code/src/agent.ts
@@ -437,7 +437,18 @@ export async function chat(
     console.log(`[chat] Query completed, total=${Date.now() - chatStartedAt}ms`)
     await callbacks.onComplete(stats)
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    // A user interrupt (interruptSession → controller.abort()) can surface in
+    // two shapes: a DOMException-style `AbortError`, or — when the SDK's native
+    // child process is killed mid-turn — a plain `Error` whose message is
+    // "Claude Code process aborted by user" (minified class, name === 'Error').
+    // The latter must NOT be treated as a failure: route both through
+    // onComplete (reason 'interrupted') so server.ts emits session.ended and
+    // the control-plane transitions the session out of the running state.
+    if (
+      abortController.signal.aborted ||
+      (error instanceof Error &&
+        (error.name === 'AbortError' || /aborted by user/i.test(error.message)))
+    ) {
       console.log('[chat] Aborted')
       await callbacks.onComplete()
     } else {

--- a/agents/claude-code/src/server.ts
+++ b/agents/claude-code/src/server.ts
@@ -223,8 +223,24 @@ app.post('/chat', async (c) => {
           await sink.write('message', JSON.stringify(evt))
         },
         onError: async (error) => {
-          const evt = translator.error(error.message)
-          await sink.write('message', JSON.stringify(evt))
+          await sink.write('message', JSON.stringify(translator.error(error.message)))
+          // Emit a terminal session.ended so the control-plane stops treating
+          // the session as running, then perform the same teardown as
+          // onComplete. Without the terminal event + keepalive clear the agent
+          // SSE stream stays open with no end marker, and the session leaks in
+          // the running state until the 24h timeout or a CP restart.
+          await sink.write('message', JSON.stringify(translator.sessionEnded('error')))
+          if (currentSessionId) {
+            if (sink.disconnected) {
+              console.log(
+                `[agent] Turn errored but CP disconnected, keeping sink for reconnect session=${currentSessionId}`,
+              )
+            } else {
+              activeSinks.delete(currentSessionId)
+            }
+          }
+          doneResolve()
+          clearInterval(keepaliveTimer)
         },
         onComplete: async (stats) => {
           const reason = stats ? 'completed' : 'interrupted'


### PR DESCRIPTION
## Summary

Pressing **stop** left a session stuck in the running state (UI shows perpetual "running", no output, further stop actions are no-ops) until the 24h idle timeout or a control-plane restart — even though the Claude child process had already exited.

Two defects on the claude-code agent:

- **`agents/claude-code/src/agent.ts`** — the interrupt was only recognized via `error.name === 'AbortError'`. A user interrupt actually surfaces as a plain `Error` with message `Claude Code process aborted by user` (`name === 'Error'`), so it fell through to `onError` (failure) instead of `onComplete` (normal end). Now classified robustly via `abortController.signal.aborted` (set by `interruptSession`) plus a message fallback, so it routes through `onComplete` → `session.ended(reason: 'interrupted')`.

- **`agents/claude-code/src/server.ts` (`onError`)** — unlike `onComplete`, it emitted only an `error` event: no terminal `session.ended`, no `doneResolve()`, no `clearInterval(keepaliveTimer)`, no sink release. The agent SSE stream never closed, so cp's `for await` never ended and its idle fallback (`transitionSessionStatus(idle)`) never fired; the session leaked in the running state. (This affected *any* error, not just the misclassified interrupt.) Now emits `session.ended('error')` and performs the same teardown as `onComplete`, mirroring the already-correct `internal/acp-adapter/acp-server.ts`.

## Testing

- `tsc --noEmit` clean
- `biome check` clean

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)