### PR TITLE
fix(agents): restore vim arrow keys in web terminal

### DIFF
--- a/agents/claude-code/Dockerfile
+++ b/agents/claude-code/Dockerfile
@@ -102,6 +102,10 @@ COPY --from=ttyd /usr/bin/ttyd /usr/local/bin/ttyd
 # Shared tmux config (enables mouse scrolling in web terminal)
 COPY agents/tmux.conf /etc/tmux.conf
 
+# System vimrc — vim-tiny launched as `vi` runs vi-compatible by default,
+# which breaks arrow keys in insert mode (inserts A/B/C/D). nocompatible fixes it.
+COPY agents/vimrc /etc/vim/vimrc
+
 # Create workspace directory (home lives inside workspace for single-PV persistence)
 # usermod -d updates /etc/passwd so openssh resolves ~ to the new home (ssh ignores $HOME)
 RUN mkdir -p /workspace/.home && chown -R node:node /workspace \

--- a/agents/codex/Dockerfile
+++ b/agents/codex/Dockerfile
@@ -122,6 +122,10 @@ COPY --from=ttyd /usr/bin/ttyd /usr/local/bin/ttyd
 # Shared tmux config (enables mouse scrolling in web terminal)
 COPY agents/tmux.conf /etc/tmux.conf
 
+# System vimrc — vim-tiny launched as `vi` runs vi-compatible by default,
+# which breaks arrow keys in insert mode (inserts A/B/C/D). nocompatible fixes it.
+COPY agents/vimrc /etc/vim/vimrc
+
 # Create workspace directory
 RUN mkdir -p /workspace/.home && chown -R node:node /workspace \
     && usermod -d /workspace/.home node

--- a/agents/vimrc
+++ b/agents/vimrc
@@ -1,0 +1,8 @@
+" System vimrc for the web terminal's vim-tiny.
+" vim-tiny launched as `vi` defaults to vi-compatible mode, where cursor
+" keys aren't recognized in insert mode — pressing the arrows leaves insert
+" mode and inserts A/B/C/D instead of moving the cursor. nocompatible
+" restores normal arrow-key behavior; backspace makes <BS> delete across
+" indent/eol/insert-start as users expect.
+set nocompatible
+set backspace=indent,eol,start


### PR DESCRIPTION
## Problem

In the web terminal, editing a file with `vi` and pressing the arrow keys inserts `A`/`B`/`C`/`D` instead of moving the cursor.

## Root cause

The agent images ship `vim-tiny`. Launched as `vi`, vim-tiny runs in **vi-compatible** mode, which doesn't bind the cursor-key escape sequences in insert mode: `ESC [ A` makes vim leave insert mode, then `[`/`A` are interpreted as commands/characters. The escape sequences are transmitted correctly (`TERM=xterm-256color`, WS is a byte passthrough) — it's purely vim-tiny's compatible-mode default.

## Fix

Ship a system vimrc (`/etc/vim/vimrc`) with `set nocompatible` (and `set backspace=indent,eol,start`) into both agent images. Arrow keys and backspace then behave as expected in `vi`.

## Verify

After rollout, in a workspace terminal: run `vi`, enter insert mode, arrow keys move the cursor; `:set compatible?` reports `nocompatible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)