### PR TITLE
refactor(self-host): parameterize manifests for naming and third-party images

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -50,17 +50,38 @@ set +a
 
 # --- Image registry --------------------------------------------------------
 # Every first-party service image lives as a sub-path under one public registry
-# path, e.g. ghcr.io/neutree-ai/agent-platform/nap-cp:<tag>. Third-party images
-# (postgres, coturn, gotenberg, language runtimes, …) are pulled from their own
-# upstream public locations and are hardcoded in the manifests, not under
-# ${REGISTRY}.
+# path, e.g. ghcr.io/neutree-ai/agent-platform/${APP_PREFIX}-cp:<tag>. Third-party
+# images (coturn, gotenberg, language runtimes, …) default to their public
+# upstreams (see "Third-party images" below) — an offline/mirrored install
+# overrides each to a path under ${REGISTRY}.
 export REGISTRY="${REGISTRY:-ghcr.io/neutree-ai/agent-platform}"
 # Tag applied to every first-party image. Default :latest; pin to a release tag
 # for reproducible installs.
 export IMAGE_TAG="${IMAGE_TAG:-latest}"
 
+# --- Naming -----------------------------------------------------------------
+# Prefix on every first-party k8s object name (${APP_PREFIX}-cp, ${APP_PREFIX}-pg,
+# …) and on the first-party image sub-paths (${REGISTRY}/${APP_PREFIX}-cp). A
+# redistribution can rebrand by overriding this; existing installs keep their
+# names by pinning it. DB_NAME is the application database created in postgres.
+export APP_PREFIX="${APP_PREFIX:-nap}"
+export DB_NAME="${DB_NAME:-nap}"
+
+# --- Third-party images -----------------------------------------------------
+# Non-first-party images (language runtimes, pause, gotenberg, coturn, nfs).
+# Default to their public upstreams; an offline/mirrored install overrides each
+# to a ${REGISTRY}/... path that resolves inside an air-gapped registry.
+export POSTGRES_IMAGE="${POSTGRES_IMAGE:-ghcr.io/cloudnative-pg/postgresql:16}"
+export GOTENBERG_IMAGE="${GOTENBERG_IMAGE:-docker.io/gotenberg/gotenberg:8}"
+export COTURN_IMAGE="${COTURN_IMAGE:-docker.io/coturn/coturn:4.6}"
+export NFS_SERVER_IMAGE="${NFS_SERVER_IMAGE:-ghcr.io/obeone/nfs-server:2.2.3}"
+export RUNTIME_NODE_IMAGE="${RUNTIME_NODE_IMAGE:-docker.io/library/node:22-bookworm}"
+export RUNTIME_PYTHON_IMAGE="${RUNTIME_PYTHON_IMAGE:-docker.io/library/python:3.12-bookworm}"
+export RUNTIME_GOLANG_IMAGE="${RUNTIME_GOLANG_IMAGE:-docker.io/library/golang:1.23}"
+export PAUSE_IMAGE="${PAUSE_IMAGE:-registry.k8s.io/pause:3.9}"
+
 # Resolve AGENT_IMAGE_PREFIX if it references REGISTRY
-AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/nap-agent}"
+AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}-agent}"
 export AGENT_IMAGE_PREFIX
 
 export KUBECONFIG="${KUBECONFIG:-./kubeconfig.yaml}"
@@ -219,7 +240,9 @@ render_manifests() {
 
   # Explicit variable list — prevents envsubst from replacing k8s $(VAR)
   # references like $(POSTGRES_PASSWORD)
-  local VARS='${NAMESPACE}${REGISTRY}${IMAGE_TAG}${TOS_HOST}${TOS_NODE_PORT}'
+  local VARS='${NAMESPACE}${REGISTRY}${IMAGE_TAG}${APP_PREFIX}${DB_NAME}${TOS_HOST}${TOS_NODE_PORT}'
+  VARS+='${POSTGRES_IMAGE}${GOTENBERG_IMAGE}${COTURN_IMAGE}${NFS_SERVER_IMAGE}'
+  VARS+='${RUNTIME_NODE_IMAGE}${RUNTIME_PYTHON_IMAGE}${RUNTIME_GOLANG_IMAGE}${PAUSE_IMAGE}'
   VARS+='${PG_USERNAME}${PG_PASSWORD}${PG_INSTANCES}${PG_STORAGE_SIZE}${PG_STORAGE_CLASS}'
   VARS+='${NFS_SERVER}${NFS_PATH}${NFS_STORAGE_CLASS}'
   VARS+='${JWT_SECRET}${CREDENTIAL_ENCRYPTION_KEY}'

--- a/self-host/manifests/browser-service.yaml
+++ b/self-host/manifests/browser-service.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-browser
+  name: ${APP_PREFIX}-browser
   namespace: ${NAMESPACE}
   labels:
-    app: nap-browser
+    app: ${APP_PREFIX}-browser
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nap-browser
+      app: ${APP_PREFIX}-browser
   template:
     metadata:
       labels:
-        app: nap-browser
+        app: ${APP_PREFIX}-browser
     spec:
       containers:
         - name: browser
-          image: ${REGISTRY}/nap-browser:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-browser:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3005
@@ -28,22 +28,22 @@ spec:
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: nap-browser-secret
+                  name: ${APP_PREFIX}-browser-secret
                   key: JWT_SECRET
             - name: NAP_OAUTH_URL
               value: "http://${TOS_HOST}:${TOS_NODE_PORT}"
             - name: NAP_INTERNAL_URL
-              value: "http://nap-cp:3000"
+              value: "http://${APP_PREFIX}-cp:3000"
             - name: OAUTH_CLIENT_ID
               value: "browser-service"
             - name: BROWSER_SERVICE_URL
               value: "${BROWSER_SERVICE_URL_RESOLVED}"
             - name: SANDBOX_SERVICE_URL
-              value: "http://nap-sandbox:3006"
+              value: "http://${APP_PREFIX}-sandbox:3006"
             - name: SANDBOX_SERVICE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: nap-sandbox-secret
+                  name: ${APP_PREFIX}-sandbox-secret
                   key: SERVICE_KEY
             - name: BROWSER_IMAGE
               value: "${REGISTRY}/chromium-headful:${IMAGE_TAG}"
@@ -54,7 +54,7 @@ spec:
             - name: TURN_AUTH_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: nap-browser-secret
+                  name: ${APP_PREFIX}-browser-secret
                   key: TURN_AUTH_SECRET
           resources:
             requests:
@@ -79,14 +79,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-browser
+  name: ${APP_PREFIX}-browser
   namespace: ${NAMESPACE}
   labels:
-    app: nap-browser
+    app: ${APP_PREFIX}-browser
 spec:
   type: ${SERVICE_TYPE}
   selector:
-    app: nap-browser
+    app: ${APP_PREFIX}-browser
   ports:
     - port: 3005
       targetPort: 3005

--- a/self-host/manifests/channel-gateway.yaml
+++ b/self-host/manifests/channel-gateway.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-cg
+  name: ${APP_PREFIX}-cg
   namespace: ${NAMESPACE}
   labels:
-    app: nap-cg
+    app: ${APP_PREFIX}-cg
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nap-cg
+      app: ${APP_PREFIX}-cg
   template:
     metadata:
       labels:
-        app: nap-cg
+        app: ${APP_PREFIX}-cg
     spec:
       containers:
         - name: channel-gateway
-          image: ${REGISTRY}/nap-cg:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-cg:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3002
@@ -28,17 +28,17 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: JWT_SECRET
             - name: NAP_API_URL
-              value: "http://nap-cp:3000"
+              value: "http://${APP_PREFIX}-cp:3000"
           resources:
             requests:
               memory: "128Mi"
@@ -62,14 +62,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-cg
+  name: ${APP_PREFIX}-cg
   namespace: ${NAMESPACE}
   labels:
-    app: nap-cg
+    app: ${APP_PREFIX}-cg
 spec:
   type: ClusterIP
   selector:
-    app: nap-cg
+    app: ${APP_PREFIX}-cg
   ports:
     - port: 3002
       targetPort: 3002

--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nap-cp
+  name: ${APP_PREFIX}-cp
   namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: nap-cp
+  name: ${APP_PREFIX}-cp
   namespace: ${NAMESPACE}
 rules:
   - apiGroups: [""]
@@ -20,21 +20,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: nap-cp
+  name: ${APP_PREFIX}-cp
   namespace: ${NAMESPACE}
 subjects:
   - kind: ServiceAccount
-    name: nap-cp
+    name: ${APP_PREFIX}-cp
     namespace: ${NAMESPACE}
 roleRef:
   kind: Role
-  name: nap-cp
+  name: ${APP_PREFIX}-cp
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nap-cp-node-reader
+  name: ${APP_PREFIX}-cp-node-reader
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -43,38 +43,38 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nap-cp-node-reader
+  name: ${APP_PREFIX}-cp-node-reader
 subjects:
   - kind: ServiceAccount
-    name: nap-cp
+    name: ${APP_PREFIX}-cp
     namespace: ${NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: nap-cp-node-reader
+  name: ${APP_PREFIX}-cp-node-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-cp
+  name: ${APP_PREFIX}-cp
   namespace: ${NAMESPACE}
   labels:
-    app: nap-cp
+    app: ${APP_PREFIX}-cp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nap-cp
+      app: ${APP_PREFIX}-cp
   template:
     metadata:
       labels:
-        app: nap-cp
+        app: ${APP_PREFIX}-cp
     spec:
-      serviceAccountName: nap-cp
+      serviceAccountName: ${APP_PREFIX}-cp
       terminationGracePeriodSeconds: 150
       containers:
         - name: control-plane
-          image: ${REGISTRY}/nap-cp:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
@@ -99,18 +99,18 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             - name: CONTROL_PLANE_URL
-              value: "http://nap-cp.${NAMESPACE}.svc.cluster.local:3000"
+              value: "http://${APP_PREFIX}-cp.${NAMESPACE}.svc.cluster.local:3000"
             - name: BROWSER_SERVICE_URL
-              value: "http://nap-browser:3005"
+              value: "http://${APP_PREFIX}-browser:3005"
             - name: BROWSER_PUBLIC_URL
               value: "http://${TOS_HOST}:${BROWSER_NODE_PORT}"
             - name: SANDBOX_SERVICE_URL
-              value: "http://nap-sandbox:3006"
+              value: "http://${APP_PREFIX}-sandbox:3006"
             - name: SANDBOX_PUBLIC_URL
               value: "http://${TOS_HOST}:${SANDBOX_NODE_PORT}"
             - name: AFS_ENABLED
@@ -120,9 +120,9 @@ spec:
             - name: AFS_CONTROLLER_ADDR
               value: "afs-controller.${NAMESPACE}.svc:9100"
             - name: MEMORY_FUSE_IMAGE
-              value: "${REGISTRY}/nap-memory-fuse:${IMAGE_TAG}"
+              value: "${REGISTRY}/${APP_PREFIX}-memory-fuse:${IMAGE_TAG}"
             - name: OFFICE_CONVERTER_URL
-              value: "http://nap-office-converter:3007"
+              value: "http://${APP_PREFIX}-office-converter:3007"
             - name: WEB_PUBLIC_URL
               value: "http://${TOS_HOST}:${TOS_NODE_PORT}"
             - name: FILES_PUBLIC_URL
@@ -130,59 +130,59 @@ spec:
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: JWT_SECRET
             - name: CREDENTIAL_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: CREDENTIAL_ENCRYPTION_KEY
             - name: LDAP_URL
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_URL
                   optional: true
             - name: LDAP_BIND_DN
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_BIND_DN
                   optional: true
             - name: LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_BIND_PASSWORD
                   optional: true
             - name: LDAP_SEARCH_BASE
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_SEARCH_BASE
                   optional: true
             - name: LDAP_SEARCH_FILTER
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_SEARCH_FILTER
                   optional: true
             - name: LDAP_ATTR_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_ATTR_USERNAME
                   optional: true
             - name: LDAP_ATTR_NAME
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_ATTR_NAME
                   optional: true
             - name: LDAP_ATTR_EMAIL
               valueFrom:
                 secretKeyRef:
-                  name: nap-cp-secret
+                  name: ${APP_PREFIX}-cp-secret
                   key: LDAP_ATTR_EMAIL
                   optional: true
           resources:
@@ -208,14 +208,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-cp
+  name: ${APP_PREFIX}-cp
   namespace: ${NAMESPACE}
   labels:
-    app: nap-cp
+    app: ${APP_PREFIX}-cp
 spec:
   type: ${SERVICE_TYPE}
   selector:
-    app: nap-cp
+    app: ${APP_PREFIX}-cp
   ports:
     - port: 3000
       targetPort: 3000

--- a/self-host/manifests/coturn.yaml
+++ b/self-host/manifests/coturn.yaml
@@ -1,6 +1,6 @@
 # TURN server for WebRTC relay (browser sandbox live view).
 # hostNetwork=true so external browsers and internal pods reach the same address.
-# TURN_AUTH_SECRET is read from nap-browser-secret (already created by secrets.yaml).
+# TURN_AUTH_SECRET is read from ${APP_PREFIX}-browser-secret (already created by secrets.yaml).
 #
 # Connected variant: pulled straight from Docker Hub's public coturn image.
 #
@@ -31,7 +31,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: coturn
-          image: docker.io/coturn/coturn:4.6
+          image: ${COTURN_IMAGE}
           args:
             - "--listening-port=3478"
             # Pin to a single IP. Without --listening-ip coturn enumerates
@@ -59,7 +59,7 @@ spec:
             - name: TURN_AUTH_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: nap-browser-secret
+                  name: ${APP_PREFIX}-browser-secret
                   key: TURN_AUTH_SECRET
           ports:
             - name: turn-tcp

--- a/self-host/manifests/nfs-server.yaml
+++ b/self-host/manifests/nfs-server.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: nap-nfs-server-data
+  name: ${APP_PREFIX}-nfs-server-data
   namespace: ${NAMESPACE}
 spec:
   accessModes:
@@ -33,10 +33,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-nfs-server
+  name: ${APP_PREFIX}-nfs-server
   namespace: ${NAMESPACE}
   labels:
-    app: nap-nfs-server
+    app: ${APP_PREFIX}-nfs-server
 spec:
   replicas: 1
   # Recreate: the PVC is RWO; rolling update would deadlock waiting for the
@@ -45,15 +45,15 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: nap-nfs-server
+      app: ${APP_PREFIX}-nfs-server
   template:
     metadata:
       labels:
-        app: nap-nfs-server
+        app: ${APP_PREFIX}-nfs-server
     spec:
       containers:
         - name: nfs-server
-          image: ghcr.io/obeone/nfs-server:2.2.3
+          image: ${NFS_SERVER_IMAGE}
           imagePullPolicy: IfNotPresent
           env:
             # One export, root-squash off so the provisioner can chown subdirs.
@@ -79,17 +79,17 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: nap-nfs-server-data
+            claimName: ${APP_PREFIX}-nfs-server-data
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-nfs-server
+  name: ${APP_PREFIX}-nfs-server
   namespace: ${NAMESPACE}
 spec:
   type: ClusterIP
   selector:
-    app: nap-nfs-server
+    app: ${APP_PREFIX}-nfs-server
   ports:
     - name: nfs
       port: 2049

--- a/self-host/manifests/office-converter.yaml
+++ b/self-host/manifests/office-converter.yaml
@@ -8,23 +8,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-office-converter
+  name: ${APP_PREFIX}-office-converter
   namespace: ${NAMESPACE}
   labels:
-    app: nap-office-converter
+    app: ${APP_PREFIX}-office-converter
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nap-office-converter
+      app: ${APP_PREFIX}-office-converter
   template:
     metadata:
       labels:
-        app: nap-office-converter
+        app: ${APP_PREFIX}-office-converter
     spec:
       containers:
         - name: gotenberg
-          image: docker.io/gotenberg/gotenberg:8
+          image: ${GOTENBERG_IMAGE}
           args:
             - "gotenberg"
             - "--api-timeout=120s"
@@ -54,14 +54,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-office-converter
+  name: ${APP_PREFIX}-office-converter
   namespace: ${NAMESPACE}
   labels:
-    app: nap-office-converter
+    app: ${APP_PREFIX}-office-converter
 spec:
   type: ClusterIP
   selector:
-    app: nap-office-converter
+    app: ${APP_PREFIX}-office-converter
   ports:
     - port: 3007
       targetPort: 3000

--- a/self-host/manifests/postgres.yaml
+++ b/self-host/manifests/postgres.yaml
@@ -1,12 +1,12 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: nap-pg
+  name: ${APP_PREFIX}-pg
   namespace: ${NAMESPACE}
 spec:
   instances: ${PG_INSTANCES}
-  # Connected variant: pulled straight from CNPG's public GHCR image.
-  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  # Defaults to CNPG's public GHCR image; override POSTGRES_IMAGE for a mirror.
+  imageName: ${POSTGRES_IMAGE}
 
   minSyncReplicas: ${PG_SYNC_REPLICAS}
   maxSyncReplicas: ${PG_SYNC_REPLICAS}
@@ -32,10 +32,10 @@ spec:
 
   bootstrap:
     initdb:
-      database: nap
+      database: ${DB_NAME}
       owner: ${PG_USERNAME}
       secret:
-        name: nap-pg-user
+        name: ${APP_PREFIX}-pg-user
 
   storage:
     size: ${PG_STORAGE_SIZE}
@@ -48,7 +48,7 @@ spec:
         login: true
         createdb: true
         passwordSecret:
-          name: nap-pg-user
+          name: ${APP_PREFIX}-pg-user
 
   postgresql:
     shared_preload_libraries:

--- a/self-host/manifests/sandbox-image-warmer.yaml
+++ b/self-host/manifests/sandbox-image-warmer.yaml
@@ -28,14 +28,21 @@ spec:
               cpu: 1m
               memory: 1Mi
         - name: pull-node-22
-          image: docker.io/library/node:22-bookworm
+          image: ${RUNTIME_NODE_IMAGE}
           command: ["true"]
           resources:
             requests:
               cpu: 1m
               memory: 1Mi
         - name: pull-python-3-12
-          image: docker.io/library/python:3.12-bookworm
+          image: ${RUNTIME_PYTHON_IMAGE}
+          command: ["true"]
+          resources:
+            requests:
+              cpu: 1m
+              memory: 1Mi
+        - name: pull-golang-1-23
+          image: ${RUNTIME_GOLANG_IMAGE}
           command: ["true"]
           resources:
             requests:
@@ -43,7 +50,7 @@ spec:
               memory: 1Mi
       containers:
         - name: pause
-          image: registry.k8s.io/pause:3.9
+          image: ${PAUSE_IMAGE}
           resources:
             requests:
               cpu: 1m

--- a/self-host/manifests/sandbox-service.yaml
+++ b/self-host/manifests/sandbox-service.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-sandbox
+  name: ${APP_PREFIX}-sandbox
   namespace: ${NAMESPACE}
   labels:
-    app: nap-sandbox
+    app: ${APP_PREFIX}-sandbox
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nap-sandbox
+      app: ${APP_PREFIX}-sandbox
   template:
     metadata:
       labels:
-        app: nap-sandbox
+        app: ${APP_PREFIX}-sandbox
     spec:
       containers:
         - name: sandbox
-          image: ${REGISTRY}/nap-sandbox:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-sandbox:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3006
@@ -28,24 +28,24 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: nap-sandbox-secret
+                  name: ${APP_PREFIX}-sandbox-secret
                   key: JWT_SECRET
             - name: SERVICE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: nap-sandbox-secret
+                  name: ${APP_PREFIX}-sandbox-secret
                   key: SERVICE_KEY
             - name: NAP_OAUTH_URL
               value: "http://${TOS_HOST}:${TOS_NODE_PORT}"
             - name: NAP_URL
-              value: "http://nap-cp:3000"
+              value: "http://${APP_PREFIX}-cp:3000"
             - name: OAUTH_CLIENT_ID
               value: "sandbox-service"
             - name: SANDBOX_SERVICE_URL
@@ -77,14 +77,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-sandbox
+  name: ${APP_PREFIX}-sandbox
   namespace: ${NAMESPACE}
   labels:
-    app: nap-sandbox
+    app: ${APP_PREFIX}-sandbox
 spec:
   type: ${SERVICE_TYPE}
   selector:
-    app: nap-sandbox
+    app: ${APP_PREFIX}-sandbox
   ports:
     - port: 3006
       targetPort: 3006

--- a/self-host/manifests/scheduler.yaml
+++ b/self-host/manifests/scheduler.yaml
@@ -1,36 +1,36 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-scheduler
+  name: ${APP_PREFIX}-scheduler
   namespace: ${NAMESPACE}
   labels:
-    app: nap-scheduler
+    app: ${APP_PREFIX}-scheduler
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nap-scheduler
+      app: ${APP_PREFIX}-scheduler
   template:
     metadata:
       labels:
-        app: nap-scheduler
+        app: ${APP_PREFIX}-scheduler
     spec:
       containers:
         - name: scheduler
-          image: ${REGISTRY}/nap-scheduler:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-scheduler:${IMAGE_TAG}
           imagePullPolicy: Always
           env:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             - name: NAP_API_URL
-              value: "http://nap-cp:3000"
+              value: "http://${APP_PREFIX}-cp:3000"
             - name: CG_API_URL
-              value: "http://nap-cg:3002"
+              value: "http://${APP_PREFIX}-cg:3002"
           resources:
             requests:
               memory: "128Mi"

--- a/self-host/manifests/secrets.yaml
+++ b/self-host/manifests/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nap-pg-user
+  name: ${APP_PREFIX}-pg-user
   namespace: ${NAMESPACE}
 type: kubernetes.io/basic-auth
 stringData:
@@ -11,7 +11,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nap-cp-secret
+  name: ${APP_PREFIX}-cp-secret
   namespace: ${NAMESPACE}
 type: Opaque
 stringData:
@@ -29,7 +29,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nap-browser-secret
+  name: ${APP_PREFIX}-browser-secret
   namespace: ${NAMESPACE}
 type: Opaque
 stringData:
@@ -39,7 +39,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nap-sandbox-secret
+  name: ${APP_PREFIX}-sandbox-secret
   namespace: ${NAMESPACE}
 type: Opaque
 stringData:

--- a/self-host/manifests/seed-admin-job.yaml
+++ b/self-host/manifests/seed-admin-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nap-seed-admin
+  name: ${APP_PREFIX}-seed-admin
   namespace: ${NAMESPACE}
 spec:
   ttlSecondsAfterFinished: 300
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: ${REGISTRY}/nap-cp:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-admin.js"]
           args:
             - "--username"
@@ -23,7 +23,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"

--- a/self-host/manifests/seed-mcp-job.yaml
+++ b/self-host/manifests/seed-mcp-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nap-seed-mcp
+  name: ${APP_PREFIX}-seed-mcp
   namespace: ${NAMESPACE}
 spec:
   ttlSecondsAfterFinished: 300
@@ -10,13 +10,13 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: ${REGISTRY}/nap-cp:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-mcp-catalog-core.js"]
           env:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"

--- a/self-host/manifests/seed-oauth-clients-job.yaml
+++ b/self-host/manifests/seed-oauth-clients-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nap-seed-oauth-clients
+  name: ${APP_PREFIX}-seed-oauth-clients
   namespace: ${NAMESPACE}
 spec:
   ttlSecondsAfterFinished: 300
@@ -10,16 +10,16 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: ${REGISTRY}/nap-cp:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-oauth-clients.js"]
           env:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             # Empty for disabled modules — the seed script skips those clients.
             - name: SANDBOX_OAUTH_REDIRECT_URI
               value: "${SANDBOX_OAUTH_REDIRECT_URI}"

--- a/self-host/manifests/skills-content-service.yaml
+++ b/self-host/manifests/skills-content-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nap-skills
+  name: ${APP_PREFIX}-skills
   namespace: ${NAMESPACE}
   labels:
-    app: nap-skills
+    app: ${APP_PREFIX}-skills
 spec:
   # Must stay at 1: dufs caches unpacked skill content on local disk; multiple
   # replicas would each maintain an independent cache with no coherency.
@@ -13,15 +13,15 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: nap-skills
+      app: ${APP_PREFIX}-skills
   template:
     metadata:
       labels:
-        app: nap-skills
+        app: ${APP_PREFIX}-skills
     spec:
       containers:
         - name: skills-content-service
-          image: ${REGISTRY}/nap-skills-content-service:${IMAGE_TAG}
+          image: ${REGISTRY}/${APP_PREFIX}-skills-content-service:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3008
@@ -32,10 +32,10 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nap-pg-user
+                  name: ${APP_PREFIX}-pg-user
                   key: password
             - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@nap-pg-rw:5432/nap"
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             - name: CACHE_DIR
               value: /var/cache/skills-content
           volumeMounts:
@@ -69,14 +69,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nap-skills
+  name: ${APP_PREFIX}-skills
   namespace: ${NAMESPACE}
   labels:
-    app: nap-skills
+    app: ${APP_PREFIX}-skills
 spec:
   type: ClusterIP
   selector:
-    app: nap-skills
+    app: ${APP_PREFIX}-skills
   ports:
     - port: 3008
       targetPort: 3008

--- a/self-host/values.env.example
+++ b/self-host/values.env.example
@@ -18,6 +18,29 @@ REGISTRY=ghcr.io/neutree-ai/agent-platform
 # tag (e.g. v4.2.0) for a reproducible install.
 IMAGE_TAG=latest
 
+# --- Advanced: naming & third-party images ----------------------------------
+# These have sane defaults for a connected install — leave them commented out
+# unless you are rebranding the deployment or mirroring third-party images into
+# your own registry (e.g. an air-gapped site).
+#
+# Prefix on every first-party k8s object name and image sub-path. Pin this to
+# keep object names stable across a rebrand; an existing install must NOT change
+# it (it would rebuild every Deployment/Service/PVC under new names).
+# APP_PREFIX=nap
+# Application database created in postgres.
+# DB_NAME=nap
+#
+# Third-party images. Default to their public upstreams; point each at a
+# ${REGISTRY}/... path to pull everything from one mirror instead.
+# POSTGRES_IMAGE=ghcr.io/cloudnative-pg/postgresql:16
+# GOTENBERG_IMAGE=docker.io/gotenberg/gotenberg:8
+# COTURN_IMAGE=docker.io/coturn/coturn:4.6
+# NFS_SERVER_IMAGE=ghcr.io/obeone/nfs-server:2.2.3
+# RUNTIME_NODE_IMAGE=docker.io/library/node:22-bookworm
+# RUNTIME_PYTHON_IMAGE=docker.io/library/python:3.12-bookworm
+# RUNTIME_GOLANG_IMAGE=docker.io/library/golang:1.23
+# PAUSE_IMAGE=registry.k8s.io/pause:3.9
+
 # --- Cluster & Access -------------------------------------------------------
 NAMESPACE=nap
 KUBECONFIG=./kubeconfig.yaml


### PR DESCRIPTION
## Why

The self-host manifests currently get **copied** into the downstream offline/air-gapped installer with only branding + image-source differences, so every manifest is maintained twice and drifts. This makes the OSS `self-host/manifests/` a **single source** a downstream distribution can consume by overriding values — no manifest fork.

## What

- **Naming** — every first-party k8s object name and image sub-path uses `${APP_PREFIX}` (default `nap`); the application DB is `${DB_NAME}` (default `nap`). Pinning these keeps an existing install's object names stable across a rebrand (no Deployment/Service/PVC churn).
- **Third-party images** — postgres/cnpg, gotenberg, coturn, nfs-server, node, python, golang, pause are now variables defaulting to their **public upstreams**; a mirrored/offline install points each at a `${REGISTRY}/...` path.
- **install.sh** — exports all new vars with the connected defaults and adds them to the `envsubst` allow-list.
- **values.env.example** — documents the new knobs as commented advanced overrides.

## Behavior change

The sandbox image warmer now also pre-pulls a **golang** runtime (`RUNTIME_GOLANG_IMAGE`, default `docker.io/library/golang:1.23`) — one extra init image, matching the language runtimes a sandbox can use.

## Verification

- A plain connected install (all defaults) renders **byte-for-byte identical** k8s objects to before — verified by rendering every manifest against `HEAD` with the default values; the only diffs are the intended golang init-container and one comment line.
- Rendered with downstream (offline) values, the remaining differences collapse to exactly: `imagePullSecrets`/`regcred` (injected post-render by the offline installer), `TOS_*`→`NAP_*` env names (already correct in current images), and the now-variabilized opensandbox URL — i.e. no logic divergence.
- `bash -n install.sh` passes; no bare `nap` literals remain in the manifests.