### PR TITLE
fix(channel-gateway): create jobs as route owner, not connector owner

### DIFF
--- a/channel-gateway/src/connectors/slack.ts
+++ b/channel-gateway/src/connectors/slack.ts
@@ -406,8 +406,25 @@ Indexes are 1-based and match the attached images order.
     // Chat API requires non-empty message; substitute a placeholder when the user sent only images.
     if (!cleanText && allImages.length) cleanText = '[image]'
 
+    // Create the job as the route owner (route.user_id), not the connector
+    // owner. The job targets route.workspace_id; with a shared connector whose
+    // route points at another user's workspace, calling cp as the connector
+    // owner gets scoped out → 404 "Workspace not found". Reuse the connector
+    // client when owners match to avoid an extra token lookup per message.
+    let jobClient = tosClient
+    if (route.user_id !== connector.user_id) {
+      const routeToken = await db.getPlatformToken(route.user_id)
+      if (!routeToken) {
+        console.error(
+          `[Slack] ${connector.name}: no platform token for route owner=${route.user_id}`,
+        )
+        return
+      }
+      jobClient = new TosClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
+    }
+
     try {
-      const result = await tosClient.jobs.create(route.workspace_id, {
+      const result = await jobClient.jobs.create(route.workspace_id, {
         prompt: cleanText,
         trigger: {
           type: 'slack',

--- a/channel-gateway/src/connectors/webhook.ts
+++ b/channel-gateway/src/connectors/webhook.ts
@@ -194,9 +194,13 @@ export async function handleWebhookPayload(opts: {
     : typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body, null, 2)
 
   // --- Get platform token and create job ---
-  const platformToken = await db.getPlatformToken(connector.user_id)
+  // Use the route owner's token (route.user_id), not the connector owner's.
+  // The job is created against route.workspace_id, so the caller identity must
+  // be the workspace owner — otherwise cp scopes by connector owner and 404s
+  // ("Workspace not found") when the connector is shared across users.
+  const platformToken = await db.getPlatformToken(route.user_id)
   if (!platformToken) {
-    console.error(`[Webhook] ${connector.name}: no platform token for user=${connector.user_id}`)
+    console.error(`[Webhook] ${connector.name}: no platform token for user=${route.user_id}`)
     return { ok: false, error: 'connector not configured (missing platform token)' }
   }
 

--- a/channel-gateway/src/connectors/wecom.ts
+++ b/channel-gateway/src/connectors/wecom.ts
@@ -523,8 +523,23 @@ async function handleMessage(
     )
   }
 
+  // Create the job as the route owner (route.user_id), not the connector owner.
+  // The job targets route.workspace_id; with a shared connector whose route
+  // points at another user's workspace, calling cp as the connector owner gets
+  // scoped out → 404 "Workspace not found". Reuse the connector client when
+  // owners match to avoid an extra token lookup per message.
+  let jobClient = tosClient
+  if (route.user_id !== connector.user_id) {
+    const routeToken = await db.getPlatformToken(route.user_id)
+    if (!routeToken) {
+      console.error(`[WeCom] ${connector.name}: no platform token for route owner=${route.user_id}`)
+      return
+    }
+    jobClient = new TosClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
+  }
+
   try {
-    const result = await tosClient.jobs.create(route.workspace_id, {
+    const result = await jobClient.jobs.create(route.workspace_id, {
       prompt: cleanText,
       trigger: {
         type: 'wecom',


### PR DESCRIPTION
## Problem

Channel-gateway creates jobs against `route.workspace_id`, but resolves the platform token from `connector.user_id`. When a connector is shared across users — a route binds the connector to a workspace owned by someone other than the connector owner — control-plane scopes the request by the connector owner, finds the workspace doesn't belong to them, and returns `404 "Workspace not found"`. The gateway surfaces this to the caller as a `500`.

Reproduced via a GitLab webhook connector shared across users: posting to another user's route 500s even though the workspace exists and works for its owner.

## Fix

Resolve the token from `route.user_id` (the route/workspace owner, already stored on the route) instead of the connector owner:

- **webhook**: switch `getPlatformToken(connector.user_id)` → `route.user_id`. The webhook handler already resolves the token per-request, so it's a direct swap.
- **slack / wecom**: these build a connector-owner `TosClient` once at connector startup. Build a route-scoped client from `route.user_id`'s token at job-create time **only when** the route owner differs from the connector owner; otherwise reuse the existing client to avoid a token lookup per message. ASR stays on the connector token (no workspace scope; in wecom it runs before route lookup anyway).

## Test

- `tsc --noEmit` clean on channel-gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)