### PR TITLE
fix(web): resolve agent skill /tmp file links to the workspace drive

### DIFF
--- a/web/src/components/ui/markdown.tsx
+++ b/web/src/components/ui/markdown.tsx
@@ -1,7 +1,9 @@
 import { PlatformCmd } from "@/components/ui/platform-cmd";
+import { useSkillsBasePath } from "@/hooks/useSkillsBasePath";
 import { useWorkspaceFileLink } from "@/hooks/useWorkspaceFileLink";
 import { type DriveKind, fileUrl } from "@/lib/api/agent-files";
 import { cn } from "@/lib/utils";
+import { canonicalizeAgentPath, isSkillTmpPath } from "@/lib/workspace-file-link";
 import { ChevronDown, ExternalLink, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, type ReactNode, memo, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -74,15 +76,20 @@ function WorkspaceFileLink({ href, children, ...props }: ComponentPropsWithoutRe
 // agent-files endpoint so the image actually loads.
 function WorkspaceFileImg({ src, alt, ...props }: ComponentPropsWithoutRef<"img">) {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
+  // Resolve the agent's skills root only when this src is a skill `/tmp` path.
+  const skillsBasePath = useSkillsBasePath(workspaceId, isSkillTmpPath(src));
   if (workspaceId && src) {
+    // Rewrite skill `/tmp` extraction paths onto the workspace drive first, in
+    // lockstep with the link parser (see `lib/workspace-file-link.ts`).
+    const canonical = canonicalizeAgentPath(src, skillsBasePath);
     let drive: DriveKind | null = null;
     let rawPath: string | null = null;
-    if (src.startsWith("/workspace/")) {
+    if (canonical.startsWith("/workspace/")) {
       drive = "workspace";
-      rawPath = src.slice("/workspace".length);
-    } else if (src.startsWith("/mnt/afs/")) {
+      rawPath = canonical.slice("/workspace".length);
+    } else if (canonical.startsWith("/mnt/afs/")) {
       drive = "afs";
-      rawPath = src.slice("/mnt/afs".length);
+      rawPath = canonical.slice("/mnt/afs".length);
     }
     if (drive && rawPath) {
       let path: string;

--- a/web/src/hooks/useSkillsBasePath.ts
+++ b/web/src/hooks/useSkillsBasePath.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_SKILLS_BASE_PATH } from '@/lib/workspace-file-link'
+import { useQuery } from '@tanstack/react-query'
+
+export const skillsBasePathQueryKey = (workspaceId: string) =>
+  ['skills-base-path', workspaceId] as const
+
+/**
+ * Resolve the workspace-relative skills root the agent reports as
+ * `filesBrowsePath` — `/.claude/skills` (claude-code) or `/.home/.codex/skills`
+ * (codex). Used to rewrite agent-emitted `/tmp/skill-<name>` links onto the
+ * right workspace-drive path so they resolve in the file viewer.
+ *
+ * `enabled` gates the fetch so unrelated markdown (the overwhelming majority,
+ * with no skill `/tmp` link) never pokes the agent skills endpoint. The value
+ * is stable for the life of a workspace, so it's cached indefinitely. Falls
+ * back to the claude-code layout until the value lands (or if the fetch fails).
+ */
+export function useSkillsBasePath(workspaceId: string | undefined, enabled: boolean): string {
+  const { data } = useQuery({
+    queryKey: skillsBasePathQueryKey(workspaceId ?? ''),
+    queryFn: async () => {
+      // Canonical agent skills endpoint (same as the skill browser uses).
+      const resp = await fetch(`/_proxy/agent/${workspaceId}/skills`, { credentials: 'include' })
+      if (!resp.ok) throw new Error(`fetch skills failed: ${resp.status}`)
+      const json = (await resp.json()) as { filesBrowsePath?: string }
+      return json.filesBrowsePath ?? DEFAULT_SKILLS_BASE_PATH
+    },
+    enabled: enabled && !!workspaceId,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  })
+  return data ?? DEFAULT_SKILLS_BASE_PATH
+}

--- a/web/src/hooks/useWorkspaceFileLink.ts
+++ b/web/src/hooks/useWorkspaceFileLink.ts
@@ -1,9 +1,10 @@
 import { useSlotContext } from '@/contexts/SlotContext'
 import { type DriveKind, dirListUrl } from '@/lib/api/agent-files'
-import { parseWorkspaceFileHref } from '@/lib/workspace-file-link'
+import { isSkillTmpPath, parseWorkspaceFileHref } from '@/lib/workspace-file-link'
 import { setPersistentInstanceStateMany } from '@/stores/instance-state-store'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
+import { useSkillsBasePath } from './useSkillsBasePath'
 
 interface WorkspaceFileLinkHandlers {
   /** Inline click → swap the slotted Files panel to this file/dir. */
@@ -57,7 +58,10 @@ function probeIsDir(
 export function useWorkspaceFileLink(href: string | undefined): WorkspaceFileLinkHandlers | null {
   const slotCtx = useSlotContext()
   const { workspaceId } = useParams<{ workspaceId?: string }>()
-  const parsed = useMemo(() => parseWorkspaceFileHref(href), [href])
+  // Only the workspace-drive skills root differs per agent; fetch it lazily,
+  // and only when this href is actually a skill `/tmp` path to resolve.
+  const skillsBasePath = useSkillsBasePath(workspaceId, isSkillTmpPath(href))
+  const parsed = useMemo(() => parseWorkspaceFileHref(href, skillsBasePath), [href, skillsBasePath])
 
   return useMemo(() => {
     // Bail out entirely when there's no slot context or workspace to route

--- a/web/src/lib/workspace-file-link.test.ts
+++ b/web/src/lib/workspace-file-link.test.ts
@@ -68,4 +68,49 @@ describe('parseWorkspaceFileHref', () => {
   it('keeps the afs drive distinct from a workspace path that happens to contain "mnt/afs"', () => {
     expect(parseWorkspaceFileHref('/workspace/mnt/afs/x.md')?.drive).toBe('workspace')
   })
+
+  it('rewrites a skill /tmp extraction path onto the workspace drive', () => {
+    // Agents report the symlink target (`/tmp/skill-<name>/...`); it must
+    // resolve to the workspace-drive skills path the file viewer can serve.
+    expect(parseWorkspaceFileHref('/tmp/skill-nightly-build-monitor/SKILL.md')).toEqual({
+      drive: 'workspace',
+      filePath: '/.claude/skills/nightly-build-monitor/SKILL.md',
+      viewingLine: undefined,
+      viewingColumn: undefined,
+    })
+  })
+
+  it('rewrites a bare skill /tmp dir and preserves trailing slash', () => {
+    expect(parseWorkspaceFileHref('/tmp/skill-my-skill/')?.filePath).toBe(
+      '/.claude/skills/my-skill/',
+    )
+  })
+
+  it('keeps :line anchors when rewriting a skill /tmp path', () => {
+    expect(parseWorkspaceFileHref('/tmp/skill-my-skill/script.ts:12:3')).toMatchObject({
+      drive: 'workspace',
+      filePath: '/.claude/skills/my-skill/script.ts',
+      viewingLine: 12,
+      viewingColumn: 3,
+    })
+  })
+
+  it('rewrites against a codex skills root when supplied', () => {
+    expect(parseWorkspaceFileHref('/tmp/skill-my-skill/SKILL.md', '/.home/.codex/skills')).toEqual({
+      drive: 'workspace',
+      filePath: '/.home/.codex/skills/my-skill/SKILL.md',
+      viewingLine: undefined,
+      viewingColumn: undefined,
+    })
+  })
+
+  it('tolerates a trailing slash on the supplied skills root', () => {
+    expect(
+      parseWorkspaceFileHref('/tmp/skill-my-skill/SKILL.md', '/.claude/skills/')?.filePath,
+    ).toBe('/.claude/skills/my-skill/SKILL.md')
+  })
+
+  it('does not rewrite unrelated /tmp paths', () => {
+    expect(parseWorkspaceFileHref('/tmp/scratch/note.md')).toBeNull()
+  })
 })

--- a/web/src/lib/workspace-file-link.ts
+++ b/web/src/lib/workspace-file-link.ts
@@ -16,24 +16,73 @@ const DRIVE_PREFIXES: Array<{ prefix: string; drive: DriveKind }> = [
   { prefix: '/mnt/afs/', drive: 'afs' },
 ]
 
+// Skills are extracted to `/tmp/skill-<name>` (a tmpfs working copy) and
+// symlinked into the workspace skills dir; see `internal/agent-skills`. Agents
+// frequently report the extraction path (the symlink *target*), which lives
+// outside every drive root and so dead-links to the site origin. Rewrite it to
+// the workspace-drive symlink path, which dufs serves (it follows the symlink —
+// that's how the skill editor reads these files).
+const SKILL_TMP_PREFIX = '/tmp/skill-'
+
+// Workspace-relative skills root the agent reports as `filesBrowsePath`. It's
+// agent-specific (claude-code `/.claude/skills`, codex `/.home/.codex/skills`),
+// so callers resolve the live value via `useSkillsBasePath` and pass it in; this
+// default matches `DEFAULT_SKILLS_BASE_PATH` in the skill browser and is only
+// used as a fallback before the value loads.
+export const DEFAULT_SKILLS_BASE_PATH = '/.claude/skills'
+
+/** True if `path` is an agent skill `/tmp` extraction path needing a rewrite. */
+export function isSkillTmpPath(path: string | undefined | null): boolean {
+  return !!path && path.startsWith(SKILL_TMP_PREFIX)
+}
+
+/**
+ * Normalize a container-absolute path agents emit into one rooted at a drive
+ * the file viewer can serve. Currently only rewrites skill `/tmp` extraction
+ * paths; everything else passes through unchanged. Shared by the link parser
+ * and the markdown image rewriter so both stay in lockstep.
+ *
+ * `skillsBasePath` is the workspace-relative skills root for the current
+ * workspace's agent (see `useSkillsBasePath`); defaults to the claude-code
+ * layout when not supplied.
+ */
+export function canonicalizeAgentPath(
+  path: string,
+  skillsBasePath: string = DEFAULT_SKILLS_BASE_PATH,
+): string {
+  if (path.startsWith(SKILL_TMP_PREFIX)) {
+    // `/tmp/skill-<name>/<rest>` → `/workspace<base>/<name>/<rest>`, e.g.
+    // `/workspace/.claude/skills/<name>/<rest>`. Also handles the bare skill
+    // dir (`/tmp/skill-<name>`).
+    const base = skillsBasePath.replace(/\/+$/, '')
+    return `/workspace${base}/${path.slice(SKILL_TMP_PREFIX.length)}`
+  }
+  return path
+}
+
 /**
  * Parse an href emitted by an agent into the drive + workspace-relative path
  * we need to drive the Files panel / FileApp.
+ *
+ * `skillsBasePath` lets the caller resolve skill `/tmp` paths against the live
+ * agent layout (claude-code vs codex); omit it to fall back to the default.
  *
  * Returns `null` if the href doesn't look like a workspace file reference, so
  * callers can fall through to default `<a>` behaviour.
  */
 export function parseWorkspaceFileHref(
   href: string | undefined | null,
+  skillsBasePath?: string,
 ): ParsedWorkspaceFileHref | null {
   if (!href) return null
+  const canonical = canonicalizeAgentPath(href, skillsBasePath)
   let drive: DriveKind | null = null
   let rawPath: string | null = null
   for (const { prefix, drive: d } of DRIVE_PREFIXES) {
-    if (href.startsWith(prefix)) {
+    if (canonical.startsWith(prefix)) {
       drive = d
       // Keep the leading `/` (strip only the prefix sans trailing slash).
-      rawPath = href.slice(prefix.length - 1)
+      rawPath = canonical.slice(prefix.length - 1)
       break
     }
   }


### PR DESCRIPTION
## Problem

When developing/editing a skill in a conversation, agents report file locations using the extraction path, e.g. `[SKILL.md](/tmp/skill-nightly-build-monitor/SKILL.md)`. Clicking it dead-links (the browser resolves `/tmp/...` against the site origin → `https://<host>/tmp/...`).

Skills are extracted to `/tmp/skill-<name>` (a tmpfs working copy) and symlinked into the workspace skills dir (see `internal/agent-skills`). The agent reports the symlink *target*. `/tmp` sits under no drive root the file viewer serves (dufs serves `/workspace` and `/mnt/afs`), so the markdown link parser falls through to a plain `<a>`.

## Fix

Rewrite `/tmp/skill-<name>/<rest>` onto the workspace-drive skills path the file viewer can serve — dufs follows the symlink, which is exactly how the skill editor already reads these files.

The workspace-relative skills root is agent-specific (claude-code `/.claude/skills`, codex `/.home/.codex/skills`), so resolve the live value the agent reports as `filesBrowsePath` rather than hard-coding it:

- **`lib/workspace-file-link.ts`** — `canonicalizeAgentPath(path, skillsBasePath?)` performs the rewrite; exports `isSkillTmpPath()` and `DEFAULT_SKILLS_BASE_PATH`; `parseWorkspaceFileHref` takes an optional `skillsBasePath`.
- **`hooks/useSkillsBasePath.ts`** (new) — fetches `filesBrowsePath` via react-query, **gated** on the href/src actually being a skill `/tmp` path so unrelated markdown never pokes the skills endpoint. Cached indefinitely (stable per workspace); falls back to the claude-code layout until it lands.
- **`useWorkspaceFileLink` + `WorkspaceFileImg`** (image rewriter) thread the resolved root through, staying in lockstep.

## Test

- `npx tsc --noEmit` clean.
- `vitest run src/lib/workspace-file-link.test.ts` — 15/15, covering both agent layouts, `:line` anchors, trailing slashes, and that unrelated `/tmp` paths are left alone.
- biome clean.

## Note

`useSkillsBasePath` is async; on the very first render containing a skill link the base path may not have loaded yet (falls back to the claude-code default). By click/probe time it has normally resolved. A workspace-entry prefetch could close that window but was left out to avoid extra coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)