### PR TITLE
refactor(self-host): parameterize the workspace-pod imagePullSecret

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -84,6 +84,10 @@ export PAUSE_IMAGE="${PAUSE_IMAGE:-registry.k8s.io/pause:3.9}"
 AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}-agent}"
 export AGENT_IMAGE_PREFIX
 
+# imagePullSecret name cp injects into spawned workspace pods. Empty on a
+# connected install (public agent images); a mirror/offline install sets it.
+export IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-}"
+
 export KUBECONFIG="${KUBECONFIG:-./kubeconfig.yaml}"
 
 export ADMIN_DISPLAY_NAME="${ADMIN_DISPLAY_NAME:-Admin}"
@@ -241,6 +245,7 @@ render_manifests() {
   # Explicit variable list — prevents envsubst from replacing k8s $(VAR)
   # references like $(POSTGRES_PASSWORD)
   local VARS='${NAMESPACE}${REGISTRY}${IMAGE_TAG}${APP_PREFIX}${DB_NAME}${TOS_HOST}${TOS_NODE_PORT}'
+  VARS+='${IMAGE_PULL_SECRET}'
   VARS+='${POSTGRES_IMAGE}${GOTENBERG_IMAGE}${COTURN_IMAGE}${NFS_SERVER_IMAGE}'
   VARS+='${RUNTIME_NODE_IMAGE}${RUNTIME_PYTHON_IMAGE}${RUNTIME_GOLANG_IMAGE}${PAUSE_IMAGE}'
   VARS+='${PG_USERNAME}${PG_PASSWORD}${PG_INSTANCES}${PG_STORAGE_SIZE}${PG_STORAGE_CLASS}'

--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -90,10 +90,12 @@ spec:
               value: "${AGENT_IMAGE_TAG}"
             - name: AGENT_STORAGE_CLASS
               value: "${AGENT_STORAGE_CLASS}"
-            # Public registry: agent pods need no pull secret. cp injects this
-            # into spawned workspace PodSpecs — empty means "no imagePullSecrets".
+            # imagePullSecret name that cp injects into spawned workspace
+            # PodSpecs. Empty (the connected default) means "no imagePullSecrets"
+            # — agent images come from the public registry. A mirrored/offline
+            # install sets IMAGE_PULL_SECRET so workspace pods can pull too.
             - name: IMAGE_PULL_SECRET
-              value: ""
+              value: "${IMAGE_PULL_SECRET}"
             - name: AGENT_NODE_SELECTOR
               value: "${AGENT_NODE_SELECTOR}"
             - name: POSTGRES_PASSWORD


### PR DESCRIPTION
Follow-up to the self-host manifest parameterization.

`cp` injects `IMAGE_PULL_SECRET` into the PodSpecs of the workspace pods it spawns. It was hardcoded to `""` — correct for a connected install (agent images come from the public registry, so no pull secret is needed). This makes it the `${IMAGE_PULL_SECRET}` variable (default empty) so a mirrored/offline distribution can set it and let workspace pods pull from a private registry too.

The connected default renders `value: ""` **exactly as before** — no change to a default install (verified by rendering `control-plane.yaml` with the empty default).