### PR TITLE
feat(browser-service): warm pool of pre-booted browser instances

### DIFF
--- a/browser-service/src/index.ts
+++ b/browser-service/src/index.ts
@@ -12,6 +12,7 @@ import browserRoutes from './routes/browsers'
 import cdpRoutes from './routes/cdp'
 import liveRoutes from './routes/live'
 import recRoutes from './routes/rec'
+import * as pool from './services/pool'
 import * as sandbox from './services/sandbox'
 
 process.on('uncaughtException', (err) => {
@@ -148,6 +149,8 @@ const port = Number.parseInt(process.env.PORT || '3005')
 
 const httpServer = serve({ fetch: app.fetch, port }, (info) => {
   console.log(`Browser service started on port ${info.port}`)
+  // Warm pool: no-op unless BROWSER_WARM_POOL_SIZE > 0.
+  pool.startPool().catch((e) => console.error('[pool] startup failed', e))
 })
 
 // ─── WebSocket upgrade dispatch ─────────────────────────────────────────────
@@ -253,7 +256,7 @@ httpServer.on('upgrade', async (req, socket, head) => {
       socket.destroy()
       return
     }
-    if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+    if (!pool.isOwnedBy(sbx, user.sub)) {
       socket.destroy()
       return
     }

--- a/browser-service/src/lib/proxy.ts
+++ b/browser-service/src/lib/proxy.ts
@@ -1,4 +1,5 @@
 import { getCookie } from 'hono/cookie'
+import * as pool from '../services/pool'
 import * as sandbox from '../services/sandbox'
 import { COOKIE_NAME, type SessionPayload, verifySessionToken } from './session'
 import { verifyServiceToken } from './token'
@@ -39,7 +40,7 @@ export async function resolveEndpoint(
     return c.json({ error: 'Browser not found' }, 404)
   }
 
-  if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+  if (!pool.isOwnedBy(sbx, user.sub)) {
     return c.json({ error: 'Not found' }, 404)
   }
 

--- a/browser-service/src/routes/browsers.ts
+++ b/browser-service/src/routes/browsers.ts
@@ -10,6 +10,7 @@ import {
   RenewBrowserBodySchema,
   RenewBrowserResponseSchema,
 } from '../schemas'
+import * as pool from '../services/pool'
 import * as sandbox from '../services/sandbox'
 
 const BROWSER_SERVICE_URL = process.env.BROWSER_SERVICE_URL || 'http://localhost:3005'
@@ -64,11 +65,18 @@ browsers.openapi(
     const body = c.req.valid('json')
     const timeoutSeconds = Math.max(60, Math.min(86400, body.timeout_seconds ?? 3600))
 
-    const sbx = await sandbox.createBrowser(user.sub, {
-      timeoutSeconds,
-      resource: body.resource,
-      metadata: body.metadata,
-    })
+    // Try the warm pool first. Only a custom `resource` bypasses it (that
+    // changes the instance build); `metadata` is just tags we record on the
+    // claim and merge virtually, so it's pool-compatible.
+    const canUsePool = pool.isPoolEnabled() && !body.resource
+    let sbx = canUsePool ? await pool.claim(user.sub, timeoutSeconds, body.metadata) : null
+    if (!sbx) {
+      sbx = await sandbox.createBrowser(user.sub, {
+        timeoutSeconds,
+        resource: body.resource,
+        metadata: body.metadata,
+      })
+    }
 
     return c.json(
       {
@@ -109,10 +117,34 @@ browsers.openapi(
         metadata[k.slice('metadata.'.length)] = v
       }
     }
-    const result = await sandbox.listBrowsers(
-      user.sub,
-      Object.keys(metadata).length > 0 ? metadata : undefined,
-    )
+    const metadataFilter = Object.keys(metadata).length > 0 ? metadata : undefined
+    const result = await sandbox.listBrowsers(user.sub, metadataFilter)
+
+    // Claimed pool instances carry no browser.user_id metadata, so the
+    // server-side filter above never returns them — add them from the claim map.
+    const known = new Set(result.items.map((s) => s.id))
+    for (const { id, metadata: claimMeta } of pool.ownedClaims(user.sub)) {
+      if (known.has(id)) continue
+      // Only a provable 404 releases the claim; a transient error keeps it so a
+      // routine list poll can never orphan a live browser.
+      let s: Awaited<ReturnType<typeof sandbox.getBrowserOrNull>>
+      try {
+        s = await sandbox.getBrowserOrNull(id)
+      } catch {
+        continue
+      }
+      if (s === null) {
+        pool.releaseClaim(id)
+        continue
+      }
+      // Pooled instances can't carry the caller's tags in sandbox metadata;
+      // merge the claim-time metadata so workspace-scoped filters still match.
+      const merged = { ...s.metadata, ...claimMeta }
+      if (metadataFilter && !Object.entries(metadataFilter).every(([k, v]) => merged[k] === v)) {
+        continue
+      }
+      result.items.push(s)
+    }
 
     return c.json(
       {
@@ -149,7 +181,7 @@ browsers.openapi(
     const user = c.get('user')
     const sbx = await sandbox.getBrowser(c.req.param('id'))
 
-    if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+    if (!pool.isOwnedBy(sbx, user.sub)) {
       return c.json({ error: 'Not found' }, 404)
     }
 
@@ -192,7 +224,7 @@ browsers.openapi(
     const user = c.get('user')
     const sbx = await sandbox.getBrowser(c.req.param('id'))
 
-    if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+    if (!pool.isOwnedBy(sbx, user.sub)) {
       return c.json({ error: 'Not found' }, 404)
     }
 
@@ -226,7 +258,7 @@ browsers.openapi(
 
     try {
       const sbx = await sandbox.getBrowser(c.req.param('id'))
-      if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+      if (!pool.isOwnedBy(sbx, user.sub)) {
         return c.json({ error: 'Not found' }, 404)
       }
     } catch {
@@ -238,6 +270,7 @@ browsers.openapi(
     } catch {
       // already gone
     }
+    pool.releaseClaim(c.req.param('id'))
 
     return c.json({ success: true as const }, 200)
   },
@@ -274,7 +307,7 @@ browsers.openapi(
   async (c) => {
     const user = c.get('user')
     const sbx = await sandbox.getBrowser(c.req.param('id'))
-    if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+    if (!pool.isOwnedBy(sbx, user.sub)) {
       return c.json({ error: 'Not found' }, 404)
     }
     const { path, pattern } = c.req.valid('query')
@@ -324,7 +357,7 @@ browsers.openapi(
   async (c) => {
     const user = c.get('user')
     const sbx = await sandbox.getBrowser(c.req.param('id'))
-    if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+    if (!pool.isOwnedBy(sbx, user.sub)) {
       return c.json({ error: 'Not found' }, 404)
     }
     const { path } = c.req.valid('query')

--- a/browser-service/src/routes/cdp.ts
+++ b/browser-service/src/routes/cdp.ts
@@ -3,6 +3,7 @@ import { getCookie } from 'hono/cookie'
 import { httpProxy } from '../lib/proxy'
 import { COOKIE_NAME, verifySessionToken } from '../lib/session'
 import { verifyServiceToken } from '../lib/token'
+import * as pool from '../services/pool'
 import * as sandbox from '../services/sandbox'
 
 const cdp = new Hono()
@@ -38,7 +39,7 @@ async function getEndpointWithAuth(c: any, port: number) {
     return { error: 'Browser not found', status: 404 }
   }
 
-  if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+  if (!pool.isOwnedBy(sbx, user.sub)) {
     return { error: 'Not found', status: 404 }
   }
 

--- a/browser-service/src/routes/rec.ts
+++ b/browser-service/src/routes/rec.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { httpProxy } from '../lib/proxy'
 import { verifyServiceToken } from '../lib/token'
+import * as pool from '../services/pool'
 import * as sandbox from '../services/sandbox'
 
 const rec = new Hono()
@@ -25,7 +26,7 @@ async function getEndpointWithAuth(c: any, port: number) {
     return { error: 'Browser not found', status: 404 }
   }
 
-  if (sbx.metadata?.['browser.user_id'] !== user.sub) {
+  if (!pool.isOwnedBy(sbx, user.sub)) {
     return { error: 'Not found', status: 404 }
   }
 

--- a/browser-service/src/services/pool.ts
+++ b/browser-service/src/services/pool.ts
@@ -1,0 +1,256 @@
+// In-memory warm pool of pre-booted browser instances.
+//
+// Why in-memory: browser-service is single-replica, and a warm instance only
+// matters until it is claimed. The pool (the unclaimed set) is fully
+// reconcilable from sandbox-service on boot. The claim map (claimed → owner) is
+// NOT durable: a restart loses it. Sandbox metadata is immutable (the
+// OpenSandbox API exposes no metadata update), so a claimed instance keeps its
+// `browser.pool=warm` tag forever and we cannot stamp an owner onto it. If we
+// kept such instances around across a restart, reconcile would see them as
+// available warm again and could hand one to a different user. To stay safe we
+// reap every pre-existing warm instance on startup (see startPool): active
+// sessions die on deploy, but there is never a cross-user leak (fail closed).
+
+import * as sandbox from './sandbox'
+
+interface SandboxInfo {
+  id: string
+  status: { state: string }
+  expiresAt: string
+  createdAt: string
+  metadata?: Record<string, string>
+}
+
+const POOL_SIZE = Number.parseInt(process.env.BROWSER_WARM_POOL_SIZE || '0', 10)
+const RECONCILE_MS = Number.parseInt(process.env.BROWSER_POOL_RECONCILE_MS || '10000', 10)
+// Warm instances are created with this TTL and renewed once they get within
+// RENEW_THRESHOLD_MS of expiry, so an idle pool never reaps itself.
+const WARM_TIMEOUT_SECONDS = Number.parseInt(process.env.BROWSER_POOL_WARM_TIMEOUT || '1800', 10)
+const RENEW_THRESHOLD_MS = Number.parseInt(
+  process.env.BROWSER_POOL_RENEW_THRESHOLD_MS || '600000',
+  10,
+)
+
+interface PoolEntry {
+  ready: boolean
+  expiresAt: number // epoch ms
+}
+
+interface Claim {
+  userId: string
+  // Metadata the caller requested at claim time (e.g. browser.workspace_id).
+  // Sandbox metadata is immutable, so a pooled instance can't carry these tags;
+  // we virtually merge them on read paths (list filtering) instead.
+  metadata: Record<string, string>
+}
+
+const pool = new Map<string, PoolEntry>() // unclaimed warm instances
+const claims = new Map<string, Claim>() // sandboxId → claim (claimed pool instances)
+
+export function isPoolEnabled(): boolean {
+  return POOL_SIZE > 0
+}
+
+function parseExpiry(iso: string): number {
+  const t = new Date(iso).getTime()
+  return Number.isNaN(t) ? Date.now() + WARM_TIMEOUT_SECONDS * 1000 : t
+}
+
+// Single source of truth for "does userId own this browser?". Claimed pool
+// instances live in the claim map (their metadata has no browser.user_id);
+// on-demand instances carry browser.user_id in their sandbox metadata.
+export function isOwnedBy(
+  sbx: { id: string; metadata?: Record<string, string> },
+  userId: string,
+): boolean {
+  if (claims.get(sbx.id)?.userId === userId) return true
+  return sbx.metadata?.['browser.user_id'] === userId
+}
+
+// Pooled instances currently claimed by userId, with the metadata recorded at
+// claim time (for the list union — these don't appear in the metadata-filtered
+// server-side list since their sandbox metadata has no browser.user_id).
+export function ownedClaims(
+  userId: string,
+): Array<{ id: string; metadata: Record<string, string> }> {
+  const out: Array<{ id: string; metadata: Record<string, string> }> = []
+  for (const [id, claim] of claims) {
+    if (claim.userId === userId) out.push({ id, metadata: claim.metadata })
+  }
+  return out
+}
+
+export function releaseClaim(sandboxId: string): void {
+  claims.delete(sandboxId)
+}
+
+// Claim a ready warm instance for userId. The pick + reserve is synchronous (no
+// await before claims.set) so concurrent requests can never grab the same id.
+// Returns the renewed SandboxInfo, or null if nothing is ready (caller then
+// falls back to an on-demand create).
+export async function claim(
+  userId: string,
+  timeoutSeconds: number,
+  metadata?: Record<string, string>,
+): Promise<SandboxInfo | null> {
+  let picked: string | undefined
+  for (const [id, entry] of pool) {
+    if (entry.ready) {
+      picked = id
+      break
+    }
+  }
+  if (!picked) {
+    const pending = [...pool.values()].filter((e) => !e.ready).length
+    console.log(
+      `[pool] claim miss for ${userId} — no ready instance (pending=${pending}), falling back to on-demand`,
+    )
+    return null
+  }
+  pool.delete(picked)
+  claims.set(picked, { userId, metadata: metadata ?? {} })
+
+  try {
+    await sandbox.renewBrowser(picked, timeoutSeconds)
+    const info = await sandbox.getBrowser(picked)
+    console.log(`[pool] claim hit ${picked} for ${userId}`)
+    void reconcile() // refill in the background
+    return info as SandboxInfo
+  } catch (e) {
+    // Instance died between pick and renew — drop the claim and let the caller
+    // fall back to an on-demand create.
+    claims.delete(picked)
+    console.error('[pool] claim failed for', picked, e)
+    return null
+  }
+}
+
+let reconciling = false
+
+async function reconcile(): Promise<void> {
+  if (!isPoolEnabled() || reconciling) return
+  reconciling = true
+  try {
+    const { items } = await sandbox.listPool()
+    const live = new Set(items.map((s) => s.id))
+    let changed = 0
+
+    // Drop tracking for instances that no longer exist (expired / killed).
+    for (const id of [...pool.keys()]) {
+      if (!live.has(id)) {
+        pool.delete(id)
+        changed++
+        console.log(`[pool] dropped warm ${id} (gone from sandbox-service)`)
+      }
+    }
+    // A claimed instance keeps its browser.pool=warm tag, so it should always
+    // appear in listPool. If it's missing, the warm-filtered list may just be
+    // momentarily inconsistent — confirm the instance is provably gone (404)
+    // before dropping the claim, or we'd orphan a live browser (404 on delete).
+    for (const id of [...claims.keys()]) {
+      if (live.has(id)) continue
+      try {
+        if ((await sandbox.getBrowserOrNull(id)) === null) {
+          claims.delete(id)
+          console.log(`[pool] released claim ${id} (instance gone)`)
+        }
+      } catch {
+        // transient — keep the claim, re-check next round
+      }
+    }
+
+    // Track live, unclaimed warm instances. Claimed ones stay out of the pool.
+    for (const s of items) {
+      if (claims.has(s.id)) continue
+      const existing = pool.get(s.id)
+      if (existing) existing.expiresAt = parseExpiry(s.expiresAt)
+      else pool.set(s.id, { ready: false, expiresAt: parseExpiry(s.expiresAt) })
+    }
+
+    // Probe not-yet-ready instances (CDP up = browser actually driveable).
+    await Promise.all(
+      [...pool.entries()]
+        .filter(([, e]) => !e.ready)
+        .map(async ([id, e]) => {
+          if (await sandbox.probeReady(id)) {
+            e.ready = true
+            changed++
+            console.log(`[pool] warm ${id} ready`)
+          }
+        }),
+    )
+
+    // Renew instances nearing expiry so an idle pool never reaps itself.
+    const now = Date.now()
+    await Promise.all(
+      [...pool.entries()]
+        .filter(([, e]) => e.expiresAt - now < RENEW_THRESHOLD_MS)
+        .map(async ([id, e]) => {
+          try {
+            const r = await sandbox.renewBrowser(id, WARM_TIMEOUT_SECONDS)
+            e.expiresAt = parseExpiry(r.expiresAt)
+            changed++
+            console.log(`[pool] renewed warm ${id}`)
+          } catch {
+            // leave it; next reconcile re-evaluates
+          }
+        }),
+    )
+
+    // Create the deficit. pool.size counts ready + pending, so we never
+    // over-provision while instances are still warming up.
+    const deficit = POOL_SIZE - pool.size
+    if (deficit > 0) {
+      console.log(`[pool] deficit ${deficit}, creating warm instance(s)`)
+      await Promise.all(
+        Array.from({ length: deficit }, async () => {
+          try {
+            const info = await sandbox.createWarmBrowser({ timeoutSeconds: WARM_TIMEOUT_SECONDS })
+            pool.set(info.id, { ready: false, expiresAt: parseExpiry(info.expiresAt) })
+            changed++
+            console.log(`[pool] created warm ${info.id}`)
+          } catch (e) {
+            console.error('[pool] create warm failed', e)
+          }
+        }),
+      )
+    }
+
+    // Summary only when something changed this round (avoids 10s no-op spam).
+    if (changed > 0) {
+      const ready = [...pool.values()].filter((e) => e.ready).length
+      console.log(
+        `[pool] state: ready=${ready} pending=${pool.size - ready} claimed=${claims.size} target=${POOL_SIZE}`,
+      )
+    }
+  } catch (e) {
+    console.error('[pool] reconcile error', e)
+  } finally {
+    reconciling = false
+  }
+}
+
+// Kill every pre-existing warm instance. See the file header for why this is
+// required for correctness, not just cleanup.
+async function reapExisting(): Promise<void> {
+  try {
+    const { items } = await sandbox.listPool()
+    if (items.length) {
+      console.log(`[pool] reaping ${items.length} stale warm instance(s) on startup`)
+    }
+    await Promise.all(items.map((s) => sandbox.deleteBrowser(s.id).catch(() => {})))
+  } catch (e) {
+    console.error('[pool] reap on startup failed', e)
+  }
+}
+
+export async function startPool(): Promise<void> {
+  if (!isPoolEnabled()) {
+    console.log('[pool] warm pool disabled (BROWSER_WARM_POOL_SIZE=0)')
+    return
+  }
+  console.log(`[pool] starting warm pool, target=${POOL_SIZE}`)
+  await reapExisting()
+  await reconcile()
+  setInterval(() => void reconcile(), RECONCILE_MS)
+}

--- a/browser-service/src/services/sandbox.ts
+++ b/browser-service/src/services/sandbox.ts
@@ -33,14 +33,7 @@ async function api<T>(path: string, opts?: RequestInit): Promise<T> {
   return res.json() as T
 }
 
-export async function createBrowser(
-  userId: string,
-  opts?: {
-    timeoutSeconds?: number
-    resource?: Record<string, string>
-    metadata?: Record<string, string>
-  },
-): Promise<SandboxInfo> {
+function browserEnv(): Record<string, string> {
   const iceservers = buildIceServers()
 
   const env: Record<string, string> = {
@@ -56,6 +49,17 @@ export async function createBrowser(
     env.NEKO_WEBRTC_IP_RETRIEVAL_URL = 'http://0.0.0.0/none'
   }
 
+  return env
+}
+
+export async function createBrowser(
+  userId: string,
+  opts?: {
+    timeoutSeconds?: number
+    resource?: Record<string, string>
+    metadata?: Record<string, string>
+  },
+): Promise<SandboxInfo> {
   return api<SandboxInfo>('/api/sandboxes', {
     method: 'POST',
     body: JSON.stringify({
@@ -63,7 +67,7 @@ export async function createBrowser(
       timeoutSeconds: opts?.timeoutSeconds ?? 3600,
       entrypoint: ['/wrapper.sh'],
       resource: opts?.resource ?? { cpu: '2', memory: '2Gi' },
-      env,
+      env: browserEnv(),
       ownerId: userId,
       metadata: {
         'browser.user_id': userId,
@@ -72,6 +76,54 @@ export async function createBrowser(
       },
     }),
   })
+}
+
+// Create an unclaimed warm instance for the pool: no owner, no browser.user_id,
+// tagged browser.pool=warm. Ownership is assigned in-memory on claim (see
+// services/pool.ts) — sandbox metadata cannot be mutated after creation.
+export async function createWarmBrowser(opts?: {
+  timeoutSeconds?: number
+  resource?: Record<string, string>
+}): Promise<SandboxInfo> {
+  return api<SandboxInfo>('/api/sandboxes', {
+    method: 'POST',
+    body: JSON.stringify({
+      image: BROWSER_IMAGE,
+      timeoutSeconds: opts?.timeoutSeconds ?? 1800,
+      entrypoint: ['/wrapper.sh'],
+      resource: opts?.resource ?? { cpu: '2', memory: '2Gi' },
+      env: browserEnv(),
+      metadata: {
+        'browser.pool': 'warm',
+        'browser.service': 'tos',
+      },
+    }),
+  })
+}
+
+// List warm-pool instances (service-scoped; sandbox-service returns all warm
+// instances when called with the service key).
+export async function listPool(): Promise<{ items: SandboxInfo[] }> {
+  const params = new URLSearchParams({
+    'metadata.browser.pool': 'warm',
+    'metadata.browser.service': 'tos',
+  })
+  return api<{ items: SandboxInfo[] }>(`/api/sandboxes?${params.toString()}`)
+}
+
+// Readiness probe: the browser is claimable once Chrome DevTools (port 9222)
+// answers — i.e. Chromium is up and CDP-controllable. This is what pays down
+// the ~30s neko/Chromium boot before a user ever connects.
+export async function probeReady(sandboxId: string): Promise<boolean> {
+  try {
+    const { endpoint } = await getEndpoint(sandboxId, 9222)
+    const res = await fetch(`http://${endpoint}/json/version`, {
+      signal: AbortSignal.timeout(3000),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
 }
 
 export async function listBrowsers(
@@ -93,6 +145,18 @@ export async function listBrowsers(
 
 export async function getBrowser(sandboxId: string): Promise<SandboxInfo> {
   return api<SandboxInfo>(`/api/sandboxes/${sandboxId}`)
+}
+
+// Like getBrowser but returns null when the instance is *provably* gone (404),
+// and throws on any other (transient) error. Used to decide whether a pooled
+// claim may be safely dropped — a generic error must never drop a live claim.
+export async function getBrowserOrNull(sandboxId: string): Promise<SandboxInfo | null> {
+  const res = await fetch(`${SANDBOX_SERVICE_URL}/api/sandboxes/${sandboxId}`, {
+    headers: headers(),
+  })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`Sandbox service ${res.status}: ${await res.text()}`)
+  return (await res.json()) as SandboxInfo
 }
 
 export async function deleteBrowser(sandboxId: string): Promise<void> {


### PR DESCRIPTION
## Problem

Creating a browser waits ~30s for Chromium/CDP to boot inside a fresh sandbox before it's usable. The sandbox itself starts quickly; the browser readiness is the slow part.

## Approach

Maintain a small pool of pre-booted, CDP-ready browser instances so a create request claims one instantly. Falls back to on-demand create on a pool miss, so there's no regression.

- **`pool.ts`** — in-memory warm set + claim map. A reconcile loop probes CDP readiness (`/json/version` on 9222 — i.e. the browser is actually driveable), renews aging instances, and refills the deficit to the target size. All pre-existing warm instances are reaped on startup.
- **Ownership** — a claimed instance's owner is tracked in-memory. Sandbox metadata is immutable (no update API), so a pooled instance can't be re-tagged with an owner on claim. `isOwnedBy()` centralizes the owner check that was previously duplicated across every route (list/get/renew/delete/files, cdp, rec, live, ws-upgrade).
- **Claim safety** — a claim is only released on explicit delete or a confirmed 404 (instance provably gone), never on a transient or filtered query, so a routine list poll can't orphan a live browser.
- **Metadata** — caller-supplied tags (e.g. workspace id) are recorded on the claim and merged virtually on read paths, since they can't live on the immutable sandbox metadata. Only a custom `resource` request bypasses the pool.

## Config

Disabled by default — no behavior change unless `BROWSER_WARM_POOL_SIZE > 0`. Tunables: `BROWSER_POOL_RECONCILE_MS`, `BROWSER_POOL_WARM_TIMEOUT`, `BROWSER_POOL_RENEW_THRESHOLD_MS`.

## Notes

- Single-replica assumption: the maintainer loop has no leader election. Deployment should use `Recreate` so two replicas never run at once (the new pod's startup reap would kill the old pod's live sessions).
- In-memory claim state: on a pod restart, in-flight sessions are dropped (fail-closed — never a cross-user leak). Acceptable given browsers are ephemeral; a durable claim store is a possible later upgrade.

## Verification

`tsc --noEmit` + biome clean. Deployed and validated: claim hits return instantly, the pool auto-refills after a claim, and delete works for pooled instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)