### PR TITLE
fix(control-plane): expose last_active_at on lite session endpoint

### DIFF
--- a/control-plane/src/routes/workspaces/sessions.ts
+++ b/control-plane/src/routes/workspaces/sessions.ts
@@ -35,7 +35,7 @@ const getSessionRoute = createRoute({
   tags: ['workspaces'],
   summary: 'Get a single session (lightweight, sidebar shape)',
   description:
-    'Returns a lite shape with id, name, chat_status, status, and a 40-char preview of the first user message. Use GET /workspaces/:id/sessions for the full ApiSession list.',
+    'Returns a lite shape with id, name, chat_status, status, last_active_at, and a 40-char preview of the first user message. Use GET /workspaces/:id/sessions for the full ApiSession list.',
   security: [{ bearerAuth: [] }],
   request: { params: SessionScopedParam },
   responses: {
@@ -77,6 +77,7 @@ sessions.openapi(getSessionRoute, async (c) => {
       name: session.name,
       chat_status: session.chat_status,
       status: session.status,
+      last_active_at: session.last_active_at,
       preview: rows[0]?.preview ?? '',
       pending_message: session.pending_message ?? null,
     },

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -228,6 +228,10 @@ export const ApiSessionLiteSchema = z.object({
   name: z.string(),
   chat_status: z.string(),
   status: z.string(),
+  /** Last time the session produced or received any message. Advances on every
+   * persisted turn event, so consumers can detect liveness mid-turn rather than
+   * only at turn boundaries. */
+  last_active_at: z.string(),
   preview: z.string(),
   /** Queued follow-up draft, or null when there is none. */
   pending_message: ApiPendingMessageSchema.nullable(),


### PR DESCRIPTION
## What

The lite `GET /workspaces/:id/sessions/:sessionId` endpoint returned `chat_status` but no activity timestamp. Consumers (e.g. board orchestration that polls a session to decide whether to keep waiting or fail it) could tell *whether* a turn was running, but not whether it was actually **making progress**.

Detecting progress only at turn boundaries is fragile: a single long turn (clone + build + edit can easily exceed a stall timeout) is indistinguishable from a genuinely wedged session, so a working agent gets killed as "stalled".

## Change

- Add `last_active_at` to `ApiSessionLiteSchema`.
- Return `session.last_active_at` from the lite session route (zero extra query — `getSession` already `SELECT *`s the row).

`last_active_at` is already bumped on every persisted turn event (assistant text, `tool_result`, …) via `addMessage`, so consumers can now measure real mid-turn liveness instead of only turn-boundary activity.

Backward compatible: additive field on a response shape; existing consumers ignore it.

## Test

- `tsc --noEmit` passes for control-plane.
- No other producer of the lite shape exists (single route), so no missing-field risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)