### PR TITLE
feat(web): add spreadsheet-style row/column labels to CSV preview

### DIFF
--- a/web/src/components/workspace/file-preview/CsvPreview.tsx
+++ b/web/src/components/workspace/file-preview/CsvPreview.tsx
@@ -1,4 +1,5 @@
 import { ScrollBar } from '@/components/ui/scroll-area'
+import { colLabel } from '@/lib/spreadsheet'
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
 import Papa from 'papaparse'
 import { useMemo } from 'react'
@@ -6,18 +7,21 @@ import { useTranslation } from 'react-i18next'
 
 export function CsvPreview({ content, filename }: { content: string; filename: string }) {
   const { t } = useTranslation()
-  const { headers, rows } = useMemo(() => {
+  const { rows, columnCount } = useMemo(() => {
     const ext = filename.split('.').pop()?.toLowerCase()
     const result = Papa.parse<string[]>(content, {
       delimiter: ext === 'tsv' ? '\t' : undefined,
       skipEmptyLines: true,
     })
     const data = result.data
-    if (data.length === 0) return { headers: [], rows: [] }
-    return { headers: data[0], rows: data.slice(1) }
+    // Ragged CSVs are common; size the grid to the widest row so no cell is
+    // silently dropped.
+    let columnCount = 0
+    for (const row of data) if (row.length > columnCount) columnCount = row.length
+    return { rows: data, columnCount }
   }, [content, filename])
 
-  if (headers.length === 0) {
+  if (rows.length === 0 || columnCount === 0) {
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
         {t('components.csvPreview.empty')}
@@ -32,12 +36,13 @@ export function CsvPreview({ content, filename }: { content: string; filename: s
           <table className="text-xs border-collapse">
             <thead>
               <tr>
-                {headers.map((h, i) => (
+                <th className="sticky top-0 left-0 z-20 bg-muted border border-border" />
+                {Array.from({ length: columnCount }, (_, ci) => (
                   <th
-                    key={i}
-                    className="sticky top-0 bg-muted px-2 py-1.5 text-left font-medium text-muted-foreground border border-border whitespace-nowrap"
+                    key={colLabel(ci)}
+                    className="sticky top-0 z-10 bg-muted px-2 py-1 text-center font-mono text-[11px] font-medium text-muted-foreground border border-border whitespace-nowrap"
                   >
-                    {h}
+                    {colLabel(ci)}
                   </th>
                 ))}
               </tr>
@@ -45,7 +50,10 @@ export function CsvPreview({ content, filename }: { content: string; filename: s
             <tbody>
               {rows.map((row, ri) => (
                 <tr key={ri} className="hover:bg-muted/50">
-                  {headers.map((_, ci) => (
+                  <td className="sticky left-0 z-10 bg-muted px-2 py-1 text-center font-mono text-[11px] text-muted-foreground/80 border border-border">
+                    {ri + 1}
+                  </td>
+                  {Array.from({ length: columnCount }, (_, ci) => (
                     <td key={ci} className="px-2 py-1 border border-border/50 whitespace-nowrap">
                       {row[ci] ?? ''}
                     </td>
@@ -55,7 +63,7 @@ export function CsvPreview({ content, filename }: { content: string; filename: s
             </tbody>
           </table>
           <div className="mt-2 text-mini text-muted-foreground">
-            {t('components.csvPreview.summary', { rows: rows.length, columns: headers.length })}
+            {t('components.csvPreview.summary', { rows: rows.length, columns: columnCount })}
           </div>
         </div>
       </ScrollAreaPrimitive.Viewport>

--- a/web/src/components/workspace/file-preview/XlsxPreview.tsx
+++ b/web/src/components/workspace/file-preview/XlsxPreview.tsx
@@ -1,6 +1,7 @@
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Spinner } from '@/components/ui/spinner'
 import { isComposing } from '@/lib/keyboard'
+import { colLabel } from '@/lib/spreadsheet'
 import { cn } from '@/lib/utils'
 import type { Cell, CellValue, Color, Workbook } from 'hucre'
 import type { RoundtripWorkbook } from 'hucre/xlsx'
@@ -251,18 +252,6 @@ function buildParsedSheets(wb: Workbook): ParsedSheet[] {
     }
     return { name: sheet.name, rows, columnWidths, rowHeights }
   })
-}
-
-// Column letter for the column-header row (A, B, ..., Z, AA, AB, ...).
-function colLabel(idx: number): string {
-  let n = idx + 1
-  let s = ''
-  while (n > 0) {
-    const r = (n - 1) % 26
-    s = String.fromCharCode(65 + r) + s
-    n = Math.floor((n - 1) / 26)
-  }
-  return s
 }
 
 // User input goes through a tiny coercion ladder so numeric strings round-trip

--- a/web/src/hooks/useSkillsBasePath.ts
+++ b/web/src/hooks/useSkillsBasePath.ts
@@ -1,8 +1,7 @@
 import { DEFAULT_SKILLS_BASE_PATH } from '@/lib/workspace-file-link'
 import { useQuery } from '@tanstack/react-query'
 
-export const skillsBasePathQueryKey = (workspaceId: string) =>
-  ['skills-base-path', workspaceId] as const
+const skillsBasePathQueryKey = (workspaceId: string) => ['skills-base-path', workspaceId] as const
 
 /**
  * Resolve the workspace-relative skills root the agent reports as

--- a/web/src/lib/spreadsheet.ts
+++ b/web/src/lib/spreadsheet.ts
@@ -1,0 +1,11 @@
+/** Column letter for spreadsheet-style headers (A, B, ..., Z, AA, AB, ...). */
+export function colLabel(idx: number): string {
+  let n = idx + 1
+  let s = ''
+  while (n > 0) {
+    const r = (n - 1) % 26
+    s = String.fromCharCode(65 + r) + s
+    n = Math.floor((n - 1) / 26)
+  }
+  return s
+}


### PR DESCRIPTION
Closes #17

## What

- CSV/TSV previews now render like Excel opens a CSV: a sticky **A/B/C…** column-letter header row and a sticky **1/2/3…** row-number gutter (fixed during horizontal scroll), matching the xlsx preview, so cell coordinates like `B12` can be located directly.
- `colLabel` is extracted from `XlsxPreview` into a shared `lib/spreadsheet.ts` helper used by both previews.
- Also unexports an unused query-key factory that was tripping the knip pre-commit gate (separate commit).

## Behavior changes

- The first CSV row is no longer promoted to a styled header — all rows render as data rows numbered from 1, keeping coordinates consistent with Excel.
- The grid is sized to the widest row, so ragged CSVs no longer silently drop cells beyond the first row's width; the summary line now counts all rows.

## Verification

- `tsc --noEmit` and biome pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)