### PR TITLE
feat(web): add word-wrap toggle to file preview

### DIFF
--- a/web/src/components/workspace/file-preview/CodePreview.tsx
+++ b/web/src/components/workspace/file-preview/CodePreview.tsx
@@ -99,6 +99,8 @@ interface CodePreviewProps {
   content: string
   isEditing: boolean
   onChange?: (value: string) => void
+  /** When true, long lines soft-wrap to the viewport width instead of scrolling. */
+  wrap?: boolean
   /** 1-based; scrolls and briefly highlights when set. */
   viewingLine?: number
   /** 1-based; positions cursor within the highlighted line. */
@@ -110,6 +112,7 @@ export function CodePreview({
   content,
   isEditing,
   onChange,
+  wrap = false,
   viewingLine,
   viewingColumn,
 }: CodePreviewProps) {
@@ -122,9 +125,10 @@ export function CodePreview({
   const langExt = useMemo(() => getLanguageExtension(filename), [filename])
   const extensions = useMemo(() => {
     const exts = [cmThemeOverride, jumpHighlightField]
+    if (wrap) exts.push(EditorView.lineWrapping)
     if (langExt) exts.push(langExt)
     return exts
-  }, [langExt])
+  }, [langExt, wrap])
 
   const viewRef = useRef<EditorView | null>(null)
   const fadeTimerRef = useRef<number | null>(null)

--- a/web/src/components/workspace/file-preview/FilePreview.tsx
+++ b/web/src/components/workspace/file-preview/FilePreview.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { useMarkdownPreferencesStore } from '@/stores/markdown-preferences-store'
-import { Code, Eye, FileText, Table } from 'lucide-react'
+import { Code, Eye, FileText, Table, WrapText } from 'lucide-react'
 import { Suspense, lazy, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { isImageFile } from './file-types'
@@ -109,6 +109,9 @@ export function FilePreview({
   // the plumbing in place so we can revisit when we have a better converter
   // (or the spreadsheet view hits a limitation that's worth the tradeoff).
   const [xlsxOfficeMode, setXlsxOfficeMode] = useState(false)
+  // Soft-wrap long lines in the CodeMirror surface. Off by default so the
+  // default reading experience stays faithful to the file's real line breaks.
+  const [wrap, setWrap] = useState(false)
 
   // Which surface to render:
   //   - image / office: always rendered (no source view exists)
@@ -123,6 +126,9 @@ export function FilePreview({
     (showRendered && (isCanvasEditor || !isEditing))
   const showSourceToggle = hasSourceToggle && (isCanvasEditor || !isEditing)
   const showTocToggle = previewType === 'markdown' && useRendered
+  // The wrap toggle only makes sense for the CodeMirror surface, which renders
+  // whenever no rendered preview is active (code files + any "source" view).
+  const showWrapToggle = !useRendered
   const tocVisible = useMarkdownPreferencesStore((s) => s.tocVisible)
   const setTocVisible = useMarkdownPreferencesStore((s) => s.setTocVisible)
   // Office-mode toggle is intentionally suppressed — see xlsxOfficeMode comment.
@@ -130,7 +136,7 @@ export function FilePreview({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {(showSourceToggle || showTocToggle) && (
+      {(showSourceToggle || showTocToggle || showWrapToggle) && (
         <div className="flex shrink-0 items-center gap-2 border-b border-border/50 px-3 py-0.5">
           {showSourceToggle && (
             <Button
@@ -148,6 +154,17 @@ export function FilePreview({
                   <Eye className="h-3 w-3" /> {t('components.filePreview.actions.preview')}
                 </>
               )}
+            </Button>
+          )}
+          {showWrapToggle && (
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-pressed={wrap}
+              className={`h-6 gap-1 px-2 text-xs ${wrap ? 'text-foreground' : 'text-muted-foreground'}`}
+              onClick={() => setWrap((v) => !v)}
+            >
+              <WrapText className="h-3 w-3" /> {t('components.filePreview.actions.wrap')}
             </Button>
           )}
           {showTocToggle && (
@@ -215,6 +232,7 @@ export function FilePreview({
             content={content}
             isEditing={isEditing}
             onChange={onChange}
+            wrap={wrap}
             viewingLine={viewingLine}
             viewingColumn={viewingColumn}
           />

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2501,7 +2501,8 @@
         "preview": "Preview",
         "spreadsheet": "Spreadsheet view",
         "officeMode": "Office mode",
-        "toc": "Outline"
+        "toc": "Outline",
+        "wrap": "Wrap"
       },
       "toc": {
         "label": "On this page",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2525,7 +2525,8 @@
         "preview": "预览",
         "spreadsheet": "表格视图",
         "officeMode": "Office 模式",
-        "toc": "目录"
+        "toc": "目录",
+        "wrap": "自动换行"
       },
       "toc": {
         "label": "本页目录",


### PR DESCRIPTION
## Summary

Long single-line content (minified JSON, long URLs, single-line config dumps) overflows horizontally in the file preview, forcing constant left/right scrolling. This adds a **Wrap** toggle to the preview toolbar that soft-wraps long lines to the viewport width via CodeMirror's `lineWrapping`.

- Defaults to **off** so the default view stays faithful to the file's real line breaks.
- The toggle appears whenever the CodeMirror surface is active — i.e. code files and any "source" view (previously code files had no toolbar at all; they now get a one-row toolbar to host the toggle).
- New i18n key `components.filePreview.actions.wrap` (en/zh).

## Changes
- `CodePreview.tsx` — new `wrap?: boolean` prop; pushes `EditorView.lineWrapping` into the extensions when true.
- `FilePreview.tsx` — local `wrap` state + toolbar button (`WrapText` icon, `aria-pressed`, highlights when on); passes `wrap` down.
- `en-US.json` / `zh-CN.json` — `wrap` label.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)