### PR TITLE
feat(sessions): surface invoking agent in session view

### DIFF
--- a/control-plane/migrations/116_session_caller_agent.sql
+++ b/control-plane/migrations/116_session_caller_agent.sql
@@ -1,0 +1,7 @@
+-- Track which agent invoked a session via agent-to-agent (call_agent).
+-- Mirrors the existing `caller_user_id` (user-initiated) for the agent-initiated
+-- case: when `source = 'agent'`, this points at the calling agent's workspace so
+-- the session view can surface "invoked by <agent>". NULL for user/web/channel
+-- sessions. No FK — a caller workspace may be deleted later; the column then
+-- simply resolves to no badge rather than blocking the delete.
+ALTER TABLE public.sessions ADD COLUMN IF NOT EXISTS caller_workspace_id text;

--- a/control-plane/src/mcp/tools/agent.ts
+++ b/control-plane/src/mcp/tools/agent.ts
@@ -61,6 +61,12 @@ interface SubAgentHandle {
  */
 interface SubAgentPersistCtx {
   targetWorkspaceId: string
+  /**
+   * Workspace id of the calling agent (the `call_agent` invoker). Persisted on
+   * the new sub-session so the session view can show "invoked by <agent>".
+   * Null only if the caller workspace couldn't be resolved.
+   */
+  callerWorkspaceId?: string | null
   userPrompt: string
   state: MainTurnSharedState
   queue: SerialQueue
@@ -237,7 +243,14 @@ function createSubAgentPersistPlugin(ctx: SubAgentPersistCtx): TurnPlugin {
           const token = ctx.sessionToken
           queue.run(async () => {
             if (isNew) {
-              await createSession(targetWorkspaceId, newSid, '', undefined, 'agent')
+              await createSession(
+                targetWorkspaceId,
+                newSid,
+                '',
+                undefined,
+                'agent',
+                ctx.callerWorkspaceId,
+              )
             } else {
               await updateSessionActivity(newSid)
             }
@@ -381,6 +394,7 @@ function runSubAgentTurn(
   existingSessionId: string | null,
   onSessionPersisted?: (sessionId: string) => Promise<void>,
   sessionToken?: string | null,
+  callerWorkspaceId?: string | null,
 ): SubAgentHandle {
   // Shared state + queue coordinate the persist and broadcast plugins.
   // Broadcast reads `state.sessionId` (for re-keying) and `sessionEndedSeen`
@@ -420,6 +434,7 @@ function runSubAgentTurn(
 
   const persistPlugin = createSubAgentPersistPlugin({
     targetWorkspaceId,
+    callerWorkspaceId,
     userPrompt,
     state,
     queue,
@@ -647,6 +662,7 @@ Examples:
           session_id ?? null,
           onSessionPersisted,
           subSessionToken,
+          callerWorkspace.id,
         )
 
         if (mode === 'background') {

--- a/control-plane/src/routes/system-workspaces.ts
+++ b/control-plane/src/routes/system-workspaces.ts
@@ -212,6 +212,9 @@ function toApiSession(s: any): ApiSession {
     preview: s.preview ?? '',
     last_turn_stats: s.last_turn_stats,
     starred_at: s.starred_at ?? null,
+    caller_agent: s.caller_agent_name
+      ? { name: s.caller_agent_name, slug: s.caller_agent_slug ?? null }
+      : null,
   }
 }
 

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -29,6 +29,9 @@ function toApiSession(s: SessionWithPreview) {
     preview: s.preview,
     last_turn_stats: s.last_turn_stats as any,
     starred_at: s.starred_at,
+    caller_agent: s.caller_agent_name
+      ? { name: s.caller_agent_name, slug: s.caller_agent_slug }
+      : null,
   }
 }
 

--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -13,12 +13,13 @@ export async function createSession(
   name = '',
   callerUserId?: string,
   source = 'web',
+  callerWorkspaceId?: string | null,
 ): Promise<Session> {
   await pool.query(
-    `INSERT INTO sessions (id, workspace_id, name, caller_user_id, source)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO sessions (id, workspace_id, name, caller_user_id, source, caller_workspace_id)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (id) DO UPDATE SET last_active_at = NOW()`,
-    [sessionId, workspaceId, name, callerUserId ?? null, source],
+    [sessionId, workspaceId, name, callerUserId ?? null, source, callerWorkspaceId ?? null],
   )
   return (await getSession(sessionId))!
 }
@@ -43,7 +44,9 @@ export async function listSessions(
     pool.query(
       `SELECT s.*,
          COALESCE(mc.cnt, 0)::int AS message_count,
-         COALESCE(fm.content, '') AS preview
+         COALESCE(fm.content, '') AS preview,
+         cw.name AS caller_agent_name,
+         cw.slug AS caller_agent_slug
        FROM sessions s
        LEFT JOIN LATERAL (
          SELECT COUNT(*)::int AS cnt FROM messages m WHERE m.session_id = s.id
@@ -53,6 +56,7 @@ export async function listSessions(
          WHERE m.session_id = s.id AND m.role = 'user'
          ORDER BY m.created_at ASC LIMIT 1
        ) fm ON true
+       LEFT JOIN workspaces cw ON cw.id = s.caller_workspace_id
        WHERE s.workspace_id = $1 AND s.status = 'active'${starredClause}
        ORDER BY s.last_active_at DESC
        LIMIT $2 OFFSET $3`,
@@ -78,7 +82,9 @@ export async function listSessionsByCaller(
   const { rows } = await pool.query(
     `SELECT s.*,
        COALESCE(mc.cnt, 0)::int AS message_count,
-       COALESCE(fm.content, '') AS preview
+       COALESCE(fm.content, '') AS preview,
+       cw.name AS caller_agent_name,
+       cw.slug AS caller_agent_slug
      FROM sessions s
      LEFT JOIN LATERAL (
        SELECT COUNT(*)::int AS cnt FROM messages m WHERE m.session_id = s.id
@@ -88,6 +94,7 @@ export async function listSessionsByCaller(
        WHERE m.session_id = s.id AND m.role = 'user'
        ORDER BY m.created_at ASC LIMIT 1
      ) fm ON true
+     LEFT JOIN workspaces cw ON cw.id = s.caller_workspace_id
      WHERE s.workspace_id = $1 AND s.caller_user_id = $2 AND s.status = 'active'
      ORDER BY s.last_active_at DESC`,
     [workspaceId, callerUserId],

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -55,6 +55,8 @@ export interface Session {
   last_active_at: string
   last_turn_stats: SessionTurnStats | null
   caller_user_id: string | null
+  /** Calling agent's workspace id when `source = 'agent'`; null otherwise. */
+  caller_workspace_id: string | null
   pending_message: SessionPendingMessage | null
   /** When the session was starred, or null when it is not starred. */
   starred_at: string | null
@@ -157,6 +159,10 @@ export interface WorkspaceWithSessionCounts extends Workspace {
 export interface SessionWithPreview extends Session {
   message_count: number
   preview: string
+  /** Calling agent's display name, joined from its workspace; null when not agent-invoked. */
+  caller_agent_name: string | null
+  /** Calling agent's slug, joined from its workspace; null when not agent-invoked. */
+  caller_agent_slug: string | null
 }
 
 export interface PaginatedSessions {

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -196,6 +196,17 @@ export const ApiSessionSchema = z.object({
   last_turn_stats: ContextGaugeSchema.nullable(),
   /** When the session was starred, or null when it is not starred. */
   starred_at: z.string().nullable(),
+  /**
+   * The agent that invoked this session via agent-to-agent (`call_agent`).
+   * Null for user/web/channel-initiated sessions. Lets the session view show
+   * which agent the session originated from.
+   */
+  caller_agent: z
+    .object({
+      name: z.string(),
+      slug: z.string().nullable(),
+    })
+    .nullable(),
 })
 
 export type ApiSession = z.infer<typeof ApiSessionSchema>

--- a/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -56,6 +56,7 @@ import { useComposerInsertRequests } from '@/stores/composer-store'
 import { useDraft } from '@/stores/draft-store'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
+  Bot,
   ChevronDown,
   ChevronUp,
   ExternalLink,
@@ -338,6 +339,12 @@ export function WorkspaceChatPanel({
 
   // Session source (channel origin)
   const { data: sessionSource } = useSessionSource(activeSessionId)
+
+  // Agent-to-agent origin: the agent that invoked this session via `call_agent`.
+  const callerAgent = useMemo(
+    () => sessions.find((s) => s.id === activeSessionId)?.caller_agent ?? null,
+    [sessions, activeSessionId],
+  )
 
   // Session rename
   const [renameOpen, setRenameOpen] = useState(false)
@@ -657,6 +664,15 @@ export function WorkspaceChatPanel({
                   via {sessionSource.connector_name}
                 </span>
               ))}
+            {callerAgent && (
+              <span
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-mini font-medium text-primary"
+                title={t('components.workspaceChat.states.invokedBy', { agent: callerAgent.name })}
+              >
+                <Bot className="h-2.5 w-2.5" />
+                {t('components.workspaceChat.states.invokedBy', { agent: callerAgent.name })}
+              </span>
+            )}
             {isDeleting && (
               <span className="inline-flex shrink-0 items-center gap-1 text-mini text-muted-foreground">
                 <Spinner size="sm" className="h-3 w-3" />

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1370,7 +1370,8 @@
         "daysAgo": "{{count}}d ago"
       },
       "states": {
-        "resetting": "Resetting..."
+        "resetting": "Resetting...",
+        "invokedBy": "Invoked by {{agent}}"
       },
       "placeholders": {
         "searchMessages": "Search messages...",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1395,7 +1395,8 @@
         "daysAgo": "{{count}} 天前"
       },
       "states": {
-        "resetting": "重置中..."
+        "resetting": "重置中...",
+        "invokedBy": "由 {{agent}} 调用"
       },
       "placeholders": {
         "searchMessages": "搜索消息...",


### PR DESCRIPTION
Closes #19.

## Problem

When a session is created via agent-to-agent invocation (`call_agent`), the session view only shows the exchanged messages — there is no indication of *which* agent invoked it. An agent-initiated session looks identical to a user-initiated one.

## Approach

The `sessions.source` column already records the *kind* of origin (`'agent'`/`'web'`/`'slack'`/…), but not the identity. Since an agent is just a workspace living in the same control-plane DB, we don't need the heavier connector-style mapping table that Slack uses (that one exists only because connectors live in a separate service). We add one nullable column and resolve the display name with a JOIN.

- **migration 116**: `sessions.caller_workspace_id text` (nullable, no FK — a later-deleted caller simply resolves to no badge instead of blocking the delete).
- **write path**: `call_agent` threads the caller workspace id through `runSubAgentTurn` → persist plugin → `createSession()`.
- **read path**: session-list queries `LEFT JOIN workspaces` to resolve the caller's `name`/`slug`; `ApiSession` gains a nullable `caller_agent` object.
- **UI**: the chat header renders an "invoked by &lt;agent&gt;" badge from the active session, next to the existing channel "via &lt;connector&gt;" badge.

## Scope / known limits

- Tracks only the **immediate** caller, not the full A→B→C chain.
- Applies only to sessions created **after** this change; pre-existing agent sessions have a NULL caller and show no badge.
- The badge reads from the loaded session list; if the active session isn't in the loaded page (rare — it's normally on page 1) the badge is omitted. Same graceful-degradation as the existing rename path.

## Verification

`tsc --noEmit` and `biome check` pass in both `control-plane` and `web`. (The one pre-existing biome warning in `WorkspaceChatPanel.tsx:509` is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)