### PR TITLE
feat(browser-service): persist warm-pool claims to survive restarts

### DIFF
--- a/browser-service/migrations/001_init.sql
+++ b/browser-service/migrations/001_init.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS browser;
+
+-- Durable record of warm-pool instances claimed by a user.
+--
+-- The warm pool is reconcilable from sandbox-service on boot, but the claim map
+-- (claimed instance -> owner) is not: sandbox metadata is immutable, so a
+-- claimed warm instance keeps its `browser.pool=warm` tag forever and cannot be
+-- stamped with an owner. Without this table a restart loses every claim, and
+-- the pool must reap all warm instances on startup to avoid handing one user's
+-- instance to another (fail closed). Persisting claims here lets startup keep
+-- already-claimed instances alive and reap only genuine orphans.
+CREATE TABLE browser.claims (
+  sandbox_id  TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  metadata    JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX claims_user_idx ON browser.claims (user_id);

--- a/browser-service/package-lock.json
+++ b/browser-service/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "tos-browser-service",
+  "name": "@neutree-ai/browser-service",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tos-browser-service",
+      "name": "@neutree-ai/browser-service",
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.19.14",
         "@hono/zod-openapi": "^1.2.4",
         "@scalar/hono-api-reference": "^0.10.7",
         "hono": "^4.7.0",
+        "pg": "^8.21.0",
         "tsx": "^4.21.0",
         "ws": "^8.18.0",
         "zod": "^4.0.0"
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
         "@types/node": "^25.6.0",
+        "@types/pg": "^8.20.0",
         "@types/ws": "^8.5.13",
         "esbuild": "^0.28.0",
         "typescript": "^6.0.2"
@@ -743,6 +745,18 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -857,6 +871,134 @@
         "yaml": "^2.8.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmmirror.com/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmmirror.com/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -864,6 +1006,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/tagged-tag": {
@@ -1409,6 +1560,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yaml": {

--- a/browser-service/package.json
+++ b/browser-service/package.json
@@ -16,6 +16,7 @@
     "@hono/zod-openapi": "^1.2.4",
     "@scalar/hono-api-reference": "^0.10.7",
     "hono": "^4.7.0",
+    "pg": "^8.21.0",
     "tsx": "^4.21.0",
     "ws": "^8.18.0",
     "zod": "^4.0.0"
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@types/node": "^25.6.0",
+    "@types/pg": "^8.20.0",
     "@types/ws": "^8.5.13",
     "esbuild": "^0.28.0",
     "typescript": "^6.0.2"

--- a/browser-service/src/index.ts
+++ b/browser-service/src/index.ts
@@ -5,6 +5,7 @@ import { Scalar } from '@scalar/hono-api-reference'
 import { getCookie } from 'hono/cookie'
 import { logger } from 'hono/logger'
 import { WebSocket, WebSocketServer } from 'ws'
+import { initDb } from './lib/db'
 import { COOKIE_NAME, verifySessionToken } from './lib/session'
 import { verifyServiceToken } from './lib/token'
 import authRoutes from './routes/auth'
@@ -146,6 +147,13 @@ app.use('/favicon.svg', serveStatic({ root: './web/dist', path: '/favicon.svg' }
 app.get('*', serveStatic({ root: './web/dist', path: 'index.html' }))
 
 const port = Number.parseInt(process.env.PORT || '3005')
+
+// Claims are persisted in Postgres so a restart can keep already-claimed warm
+// instances alive instead of reaping them (see services/pool.ts). Skip when the
+// pool is disabled — no claims to persist, no DB needed.
+if (pool.isPoolEnabled()) {
+  await initDb()
+}
 
 const httpServer = serve({ fetch: app.fetch, port }, (info) => {
   console.log(`Browser service started on port ${info.port}`)

--- a/browser-service/src/lib/db.ts
+++ b/browser-service/src/lib/db.ts
@@ -1,0 +1,52 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import pg from 'pg'
+
+export const pool = new pg.Pool({
+  connectionString:
+    process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/postgres',
+})
+
+const MIGRATIONS_TABLE = 'browser.schema_migrations'
+
+export async function initDb() {
+  await pool.query('CREATE SCHEMA IF NOT EXISTS browser')
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      id TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `)
+
+  const { rows } = await pool.query(`SELECT id FROM ${MIGRATIONS_TABLE} ORDER BY id`)
+  const applied = new Set(rows.map((r: { id: string }) => r.id))
+
+  const migrationsDir = join(process.cwd(), 'migrations')
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+
+  let newCount = 0
+  for (const file of files) {
+    const id = file.replace('.sql', '')
+    if (applied.has(id)) continue
+
+    const sql = readFileSync(join(migrationsDir, file), 'utf-8')
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(sql)
+      await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (id) VALUES ($1)`, [id])
+      await client.query('COMMIT')
+      console.log(`[db] migration applied: ${file}`)
+      newCount++
+    } catch (e) {
+      await client.query('ROLLBACK')
+      console.error(`[db] migration failed: ${file}`, e)
+      throw e
+    } finally {
+      client.release()
+    }
+  }
+  console.log(`[db] migrations: ${applied.size} existing, ${newCount} new, ${files.length} total`)
+}

--- a/browser-service/src/services/pool.ts
+++ b/browser-service/src/services/pool.ts
@@ -2,15 +2,21 @@
 //
 // Why in-memory: browser-service is single-replica, and a warm instance only
 // matters until it is claimed. The pool (the unclaimed set) is fully
-// reconcilable from sandbox-service on boot. The claim map (claimed → owner) is
-// NOT durable: a restart loses it. Sandbox metadata is immutable (the
+// reconcilable from sandbox-service on boot.
+//
+// The claim map (claimed → owner) is the hot path for ownership, but it is also
+// mirrored to Postgres (browser.claims). Sandbox metadata is immutable (the
 // OpenSandbox API exposes no metadata update), so a claimed instance keeps its
-// `browser.pool=warm` tag forever and we cannot stamp an owner onto it. If we
-// kept such instances around across a restart, reconcile would see them as
-// available warm again and could hand one to a different user. To stay safe we
-// reap every pre-existing warm instance on startup (see startPool): active
-// sessions die on deploy, but there is never a cross-user leak (fail closed).
+// `browser.pool=warm` tag forever and we cannot stamp an owner onto it. Without
+// a durable record, a restart would lose every claim and reconcile could hand a
+// claimed instance to a different user — so the pool used to reap ALL warm
+// instances on startup, killing live sessions on every deploy. Now reconcile-
+// Existing() restores claims from browser.claims and keeps those instances
+// alive, reaping only warm instances with no claim record. Cross-user leak is
+// still impossible (claimed instances are never re-handed-out; an instance with
+// no claim row is reaped — fail closed), but owned sessions survive a restart.
 
+import { pool as db } from '../lib/db'
 import * as sandbox from './sandbox'
 
 interface SandboxInfo {
@@ -51,6 +57,36 @@ export function isPoolEnabled(): boolean {
   return POOL_SIZE > 0
 }
 
+// Durable claim record (browser.claims). The in-memory `claims` map stays the
+// hot path for ownership; these mirror it to Postgres so startup can keep
+// already-claimed warm instances alive across a restart instead of reaping
+// them. All writes are best-effort: if a persist fails the worst case is the
+// old behaviour (instance reaped on next restart), so we never fail a claim or
+// a delete on a DB error — fail closed, never fail open.
+async function persistClaim(
+  sandboxId: string,
+  userId: string,
+  metadata: Record<string, string>,
+): Promise<void> {
+  try {
+    await db.query(
+      `INSERT INTO browser.claims (sandbox_id, user_id, metadata)
+       VALUES ($1, $2, $3::jsonb)
+       ON CONFLICT (sandbox_id) DO UPDATE
+         SET user_id = EXCLUDED.user_id, metadata = EXCLUDED.metadata`,
+      [sandboxId, userId, JSON.stringify(metadata)],
+    )
+  } catch (e) {
+    console.error('[pool] persistClaim failed for', sandboxId, e)
+  }
+}
+
+function unpersistClaim(sandboxId: string): void {
+  db.query('DELETE FROM browser.claims WHERE sandbox_id = $1', [sandboxId]).catch((e) =>
+    console.error('[pool] unpersistClaim failed for', sandboxId, e),
+  )
+}
+
 function parseExpiry(iso: string): number {
   const t = new Date(iso).getTime()
   return Number.isNaN(t) ? Date.now() + WARM_TIMEOUT_SECONDS * 1000 : t
@@ -82,6 +118,7 @@ export function ownedClaims(
 
 export function releaseClaim(sandboxId: string): void {
   claims.delete(sandboxId)
+  unpersistClaim(sandboxId)
 }
 
 // Claim a ready warm instance for userId. The pick + reserve is synchronous (no
@@ -113,6 +150,9 @@ export async function claim(
   try {
     await sandbox.renewBrowser(picked, timeoutSeconds)
     const info = await sandbox.getBrowser(picked)
+    // Persist before returning so the claim survives a restart. Best-effort:
+    // a DB failure here only degrades to the pre-durability behaviour.
+    await persistClaim(picked, userId, metadata ?? {})
     console.log(`[pool] claim hit ${picked} for ${userId}`)
     void reconcile() // refill in the background
     return info as SandboxInfo
@@ -152,6 +192,7 @@ async function reconcile(): Promise<void> {
       try {
         if ((await sandbox.getBrowserOrNull(id)) === null) {
           claims.delete(id)
+          unpersistClaim(id)
           console.log(`[pool] released claim ${id} (instance gone)`)
         }
       } catch {
@@ -230,17 +271,49 @@ async function reconcile(): Promise<void> {
   }
 }
 
-// Kill every pre-existing warm instance. See the file header for why this is
-// required for correctness, not just cleanup.
-async function reapExisting(): Promise<void> {
+// Reconcile pre-existing warm instances against the durable claim table on
+// startup. Restores in-memory claims for instances a user still owns (kept
+// alive across the restart), and reaps only the genuinely unclaimed ones.
+//
+// Why reaping unclaimed warm is still correct: a warm instance with no claim row
+// was either never handed out, or its claim persist failed — in the latter case
+// we cannot tell who owns it, so we fail closed and reap it (the same guarantee
+// the old unconditional reap gave, now scoped to instances we have no record
+// for). A claimed instance never gets re-handed-out because reconcile() skips
+// anything in the `claims` map.
+async function reconcileExisting(): Promise<void> {
   try {
+    const { rows } = await db.query<{
+      sandbox_id: string
+      user_id: string
+      metadata: Record<string, string>
+    }>('SELECT sandbox_id, user_id, metadata FROM browser.claims')
+    const claimBy: Map<string, { userId: string; metadata: Record<string, string> }> = new Map(
+      rows.map((r) => [r.sandbox_id, { userId: r.user_id, metadata: r.metadata ?? {} }]),
+    )
+
     const { items } = await sandbox.listPool()
-    if (items.length) {
-      console.log(`[pool] reaping ${items.length} stale warm instance(s) on startup`)
+    const live = new Set(items.map((s) => s.id))
+
+    // Restore claims for instances that survived the restart; prune rows whose
+    // instance is already gone (expired / killed while we were down).
+    for (const [id, claim] of claimBy) {
+      if (live.has(id)) claims.set(id, claim)
+      else unpersistClaim(id)
     }
-    await Promise.all(items.map((s) => sandbox.deleteBrowser(s.id).catch(() => {})))
+
+    // Reap warm instances we have no claim record for (orphans / failed persist).
+    const orphans = items.filter((s) => !claims.has(s.id))
+    if (orphans.length) {
+      console.log(`[pool] reaping ${orphans.length} unclaimed warm instance(s) on startup`)
+    }
+    await Promise.all(orphans.map((s) => sandbox.deleteBrowser(s.id).catch(() => {})))
+
+    if (claims.size) {
+      console.log(`[pool] restored ${claims.size} claimed warm instance(s) across restart`)
+    }
   } catch (e) {
-    console.error('[pool] reap on startup failed', e)
+    console.error('[pool] reconcile on startup failed', e)
   }
 }
 
@@ -250,7 +323,7 @@ export async function startPool(): Promise<void> {
     return
   }
   console.log(`[pool] starting warm pool, target=${POOL_SIZE}`)
-  await reapExisting()
+  await reconcileExisting()
   await reconcile()
   setInterval(() => void reconcile(), RECONCILE_MS)
 }

--- a/self-host/manifests/browser-service.yaml
+++ b/self-host/manifests/browser-service.yaml
@@ -25,6 +25,13 @@ spec:
           env:
             - name: PORT
               value: "3005"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${APP_PREFIX}-pg-user
+                  key: password
+            - name: DATABASE_URL
+              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Problem

The warm pool keeps the claim map (claimed instance → owner) **only in memory**. Sandbox metadata is immutable, so a claimed warm instance keeps its `browser.pool=warm` tag forever and cannot be stamped with an owner. On restart the claim map is lost, and reconcile could hand a still-claimed instance to a different user.

To stay safe, the pool used to **reap every warm instance on startup** (`reapExisting`). Once the warm pool is enabled, that means **every deploy/restart kills all in-use pooled browser sessions** — and because a normal create claims from the pool first, those are the majority of active user browsers.

## Fix

Persist claims to Postgres and reconcile against them on startup:

- New `browser` schema + `browser.claims (sandbox_id, user_id, metadata, created_at)` (`migrations/001_init.sql`), `db.ts` mirrors the sandbox-service migration runner.
- `claim()` / `releaseClaim()` mirror the in-memory map to the table (best-effort — a DB error never fails a claim/delete).
- `reapExisting()` → **`reconcileExisting()`**: restore claims for instances that survived the restart and keep them alive; reap only warm instances with **no** claim record.
- `initDb()` runs **only when the pool is enabled**, so the DB stays optional for deployments with the warm pool off.
- self-host manifest wires `DATABASE_URL` from the existing `*-pg-user` secret.

## Correctness

- **No cross-user leak** (unchanged): a claimed instance is never re-handed-out (reconcile skips anything in the claim map); an instance with no claim row is reaped — **fail closed**.
- **Owned sessions survive a restart**, which they didn't before.
- Failure modes degrade to the old behaviour: if a claim's persist fails (or the DB is down), that instance simply has no row and gets reaped on the next restart.

## Rollout note

The first cutover from old → new still reaps once: when the new code first starts, `browser.claims` is empty (the old code never wrote it), so the then-current warm instances are treated as orphans. Durability only protects restarts **after** the new code is recording claims. Deploy during a low-traffic window. The companion deployment manifest must add `DATABASE_URL` in the same apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)