### PR TITLE
feat(skills): name downloaded skill packages by skill

### DIFF
--- a/skills-content-service/src/db.ts
+++ b/skills-content-service/src/db.ts
@@ -128,9 +128,9 @@ export async function getSkillById(id: string): Promise<SkillMeta | null> {
  * version exists (transient state right after create) or skill missing. */
 export async function getActiveVersionPackage(
   skillId: string,
-): Promise<{ content_hash: string; package: Buffer } | null> {
-  const { rows } = await pool.query<{ content_hash: string; package: Buffer }>(
-    `SELECT v.content_hash, v.package
+): Promise<{ content_hash: string; package: Buffer; name: string } | null> {
+  const { rows } = await pool.query<{ content_hash: string; package: Buffer; name: string }>(
+    `SELECT v.content_hash, v.package, s.name
        FROM skills s
        JOIN skill_versions v ON v.id = s.active_version_id
       WHERE s.id = $1`,
@@ -155,9 +155,17 @@ export async function getActiveVersionHash(
 
 export async function getVersionPackage(
   versionId: string,
-): Promise<{ content_hash: string; package: Buffer; skill_id: string } | null> {
-  const { rows } = await pool.query<{ content_hash: string; package: Buffer; skill_id: string }>(
-    'SELECT content_hash, package, skill_id FROM skill_versions WHERE id = $1',
+): Promise<{ content_hash: string; package: Buffer; skill_id: string; name: string } | null> {
+  const { rows } = await pool.query<{
+    content_hash: string
+    package: Buffer
+    skill_id: string
+    name: string
+  }>(
+    `SELECT v.content_hash, v.package, v.skill_id, s.name
+       FROM skill_versions v
+       JOIN skills s ON s.id = v.skill_id
+      WHERE v.id = $1`,
     [versionId],
   )
   return rows[0] ?? null

--- a/skills-content-service/src/index.ts
+++ b/skills-content-service/src/index.ts
@@ -1296,6 +1296,16 @@ app.openapi(zipDirRoute, async (c) => {
   return new Response(resp.body, { status: resp.status, headers: out })
 })
 
+// Build an `attachment` Content-Disposition whose filename carries the skill
+// name so downloads are recognizable (the URL's last segment is the generic
+// "package"). RFC 5987 `filename*` preserves non-ASCII skill names; the ASCII
+// `filename` is a fallback for older clients.
+function packageDisposition(skillName: string, suffix = ''): string {
+  const base = `${skillName}${suffix}.tar.gz`
+  const ascii = base.replace(/[^\x20-\x7E]/g, '_').replace(/["\\/]/g, '_')
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(base)}`
+}
+
 // ── GET /skills/:id/package ───────────────────────────────────────────────
 //
 // Shortcut: stream the skill's currently-active version. The legacy
@@ -1338,6 +1348,7 @@ app.openapi(skillPackageRoute, async (c) => {
     headers: {
       'Content-Type': 'application/gzip',
       'Content-Length': String(row.package.byteLength),
+      'Content-Disposition': packageDisposition(row.name),
       ETag: etag,
     },
   })
@@ -1368,6 +1379,9 @@ app.openapi(versionPackageRoute, async (c) => {
     headers: {
       'Content-Type': 'application/gzip',
       'Content-Length': String(row.package.byteLength),
+      // Tag historical downloads with a short content hash so multiple
+      // versions of the same skill don't collide in the downloads folder.
+      'Content-Disposition': packageDisposition(row.name, `-${row.content_hash.slice(0, 8)}`),
     },
   })
 })


### PR DESCRIPTION
## What

Skill package downloads served the generic URL segment `package` as the filename, so saved files were unrecognizable (every skill download landed as `package`). This sets `Content-Disposition` on both package routes in `skills-content-service` so the browser names the file after the skill.

- Active version (`GET /skills/:id/package`) → `<name>.tar.gz`
- Specific version (`GET /skills/:id/versions/:vid/package`) → `<name>-<hash8>.tar.gz` — the short content hash keeps multiple downloaded versions of the same skill from colliding in the downloads folder.

Filenames use RFC 5987 `filename*=UTF-8''…` so non-ASCII skill names survive, with an ASCII `filename` fallback for older clients. The DB helpers (`getActiveVersionPackage` / `getVersionPackage`) now also return `skills.name`.

No changes needed downstream: the control-plane proxy already passes `Content-Disposition` through (it's in its `PASSTHROUGH` list), and the web download link (`<a download>`) is same-origin so it honors the header.

## Test

- `tsc --noEmit` clean.
- Manual: download a skill with a non-ASCII name, both current and a historical version — saved filenames are `<name>.tar.gz` and `<name>-xxxxxxxx.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)