### PR TITLE
fix(sse): suppress error event when stream ends during graceful drain

### DIFF
--- a/control-plane/src/lib/sse.ts
+++ b/control-plane/src/lib/sse.ts
@@ -1147,17 +1147,30 @@ export function createBroadcastPlugin(ctx: BroadcastPluginCtx): TurnPlugin {
 
       if (!state.sessionEndedSeen) {
         const durationSec = ((Date.now() - streamStartedAt) / 1000).toFixed(1)
-        console.error(
-          `[SSE] ${result.reason === 'timeout' ? 'Timeout' : 'Error'} ${tag} session=${state.sessionId} duration=${durationSec}s: ${result.error?.message ?? 'unknown'}`,
-        )
-        const errorPayload = JSON.stringify({
-          type: 'error',
-          message:
-            result.reason === 'timeout'
-              ? 'Agent stream timed out (model inference took too long)'
-              : 'Agent stream ended unexpectedly',
-        })
-        emitSSE(activeStream, `data: ${errorPayload}\n\n`)
+        if (isDraining()) {
+          // This CP is shutting down (rolling deploy). The turn is still
+          // alive on the agent — the next pod's `recoverOrphanedSessions`
+          // will pick it up and the client's `runTurn` reconnects to the
+          // recovered stream transparently. Emitting an `error` here would
+          // misreport a successful handoff as a failure (the red "Agent
+          // stream ended unexpectedly" toast). Close cleanly instead and let
+          // reconnect/recovery own continuation.
+          console.log(
+            `[SSE] Handoff ${tag} session=${state.sessionId} duration=${durationSec}s — CP draining, skipping error emit, recovery will resume`,
+          )
+        } else {
+          console.error(
+            `[SSE] ${result.reason === 'timeout' ? 'Timeout' : 'Error'} ${tag} session=${state.sessionId} duration=${durationSec}s: ${result.error?.message ?? 'unknown'}`,
+          )
+          const errorPayload = JSON.stringify({
+            type: 'error',
+            message:
+              result.reason === 'timeout'
+                ? 'Agent stream timed out (model inference took too long)'
+                : 'Agent stream ended unexpectedly',
+          })
+          emitSSE(activeStream, `data: ${errorPayload}\n\n`)
+        }
       }
 
       // Mark done so the derived gauges stop counting this stream. Skipped


### PR DESCRIPTION
## Problem

During a rolling deploy, an in-flight turn is still alive on its agent and gets picked up by the next pod's `recoverOrphanedSessions`; the client's `runTurn` then reconnects to the recovered stream transparently — task and data are preserved.

But the broadcast plugin's `onEnd` emitted a `{type:'error', message:'Agent stream ended unexpectedly'}` event for **any** turn that ended without seeing `session.ended`. A graceful-shutdown handoff falls into that bucket, so a successful failover surfaced to users as a red error toast (often two per deploy when a workspace has concurrent sessions), even though the task completed fine after recovery.

This was reported by users: the red toast appears mid-deploy, but refreshing shows the task actually finished.

## Why reconnect didn't mask it

The error is an **in-band SSE `error` event**, not a stream break. The client consumer renders it as a terminal error immediately, so the existing `runTurn` reconnect path (which only triggers on a stream that ends *without* a terminal event) never gets a chance to recover silently.

## Fix

Gate the error emit in `createBroadcastPlugin`'s `onEnd` on `isDraining()`:

- **Draining (rolling deploy):** log the handoff and close the stream cleanly. The client sees a clean close without `session.ended` → `runTurn` reconnects → next pod's recovery has already re-registered the stream (the old pod's ~5s drain window covers recovery) → continuation is silent, no toast.
- **Not draining (genuine failure):** unchanged — the `error` event is emitted as before, so real failures stay visible.

`isDraining()` is an existing module-level signal in the same file; no new dependencies.

## Test plan

- [x] `tsc --noEmit` passes
- [x] biome / knip pre-commit pass
- [ ] Manual: trigger a rolling restart with an active turn, confirm no "Agent stream ended unexpectedly" toast and the turn resumes after recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)