### PR TITLE
fix(mcp-oauth): hold token through grace window on transient invalid_grant

### DIFF
--- a/control-plane/migrations/117_mcp_oauth_refresh_failure_grace.sql
+++ b/control-plane/migrations/117_mcp_oauth_refresh_failure_grace.sql
@@ -1,0 +1,11 @@
+-- Hold an MCP OAuth token through a grace window before dropping it on refresh
+-- failure. Upstream MCP brokers surface a *transient* failure to refresh the
+-- underlying provider token (e.g. a TLS UNEXPECTED_EOF to googleapis.com) as an
+-- `invalid_grant` 401, which cp previously treated as permanently dead and
+-- deleted on the first occurrence — forcing the user to re-OAuth for a network
+-- blip. These columns track consecutive refresh failures so we only delete +
+-- prompt re-auth once the failures persist past the grace window; a successful
+-- refresh resets both back to 0 / NULL.
+ALTER TABLE public.mcp_oauth_tokens
+  ADD COLUMN IF NOT EXISTS refresh_fail_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS refresh_fail_first_at timestamp with time zone;

--- a/control-plane/src/services/mcp-oauth.test.ts
+++ b/control-plane/src/services/mcp-oauth.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for the refresh-failure grace decision — the core of the fix that
+ * stops a transient upstream `invalid_grant` (a TLS blip while the MCP broker
+ * refreshes the provider token) from deleting the stored OAuth token on the
+ * first failure and forcing the user to re-authorize.
+ *
+ * Only the pure decision function is exercised here; the DB-backed counter
+ * (`recordRefreshFailure`) and reset (`upsertToken`) hit the global pool and
+ * are out of scope for a unit test.
+ */
+import { describe, expect, it } from 'vitest'
+import { shouldDropTokenOnRefreshFailure } from './mcp-oauth'
+
+const NOW = new Date('2026-06-10T12:00:00.000Z')
+const ago = (seconds: number) => new Date(NOW.getTime() - seconds * 1000)
+
+describe('shouldDropTokenOnRefreshFailure', () => {
+  it('never drops when there is no recorded failure streak', () => {
+    expect(shouldDropTokenOnRefreshFailure(0, null, NOW)).toBe(false)
+  })
+
+  it('holds the token on the first failure (a likely transient blip)', () => {
+    expect(shouldDropTokenOnRefreshFailure(1, NOW, NOW)).toBe(false)
+  })
+
+  it('holds the token while failures are still within the grace window', () => {
+    // Many failures, but they all started < 10min ago — still treat as transient.
+    expect(shouldDropTokenOnRefreshFailure(50, ago(120), NOW)).toBe(false)
+  })
+
+  it('holds the token past the window if the failure count is still low', () => {
+    // Old enough, but only one failure: not yet a persistent dead-token signal.
+    expect(shouldDropTokenOnRefreshFailure(1, ago(3600), NOW)).toBe(false)
+  })
+
+  it('drops the token once failures persist past the window and count threshold', () => {
+    expect(shouldDropTokenOnRefreshFailure(3, ago(601), NOW)).toBe(true)
+    expect(shouldDropTokenOnRefreshFailure(10, ago(7200), NOW)).toBe(true)
+  })
+
+  it('is exactly at the grace boundary (inclusive)', () => {
+    expect(shouldDropTokenOnRefreshFailure(3, ago(600), NOW)).toBe(true)
+    expect(shouldDropTokenOnRefreshFailure(3, ago(599), NOW)).toBe(false)
+  })
+})

--- a/control-plane/src/services/mcp-oauth.ts
+++ b/control-plane/src/services/mcp-oauth.ts
@@ -29,6 +29,8 @@ interface OAuthToken {
   scope: string | null
   expires_at: Date | null
   updated_at: Date
+  refresh_fail_count: number
+  refresh_fail_first_at: Date | null
 }
 
 // Fallback TTL when the OAuth provider doesn't return `expires_in` (e.g.
@@ -254,6 +256,34 @@ export async function exchangeCodeForToken(
 // transient and left for the next retry.
 const PERMANENT_OAUTH_ERRORS = new Set(['invalid_grant', 'invalid_client', 'unauthorized_client'])
 
+// A "permanent" OAuth code is not always permanent: upstream MCP brokers
+// surface a *transient* failure to refresh the underlying provider token (e.g.
+// a TLS UNEXPECTED_EOF to googleapis.com) as `invalid_grant`. Rather than drop
+// the token row on the first such error, we hold it through a grace window and
+// only drop + prompt re-auth once refresh has kept failing across multiple
+// requests spanning at least this long. A genuinely dead token keeps failing
+// and gets cleaned up; a transient one heals on a later request and resets the
+// counter via `upsertToken`.
+const REFRESH_FAIL_GRACE_SECONDS = 600
+const REFRESH_FAIL_MIN_COUNT = 3
+
+/**
+ * Decide whether persistent refresh failures warrant dropping the stored token
+ * and prompting the user to re-authorize. Requires both a minimum number of
+ * consecutive failures and that the first failure is older than the grace
+ * window, so a short-lived network blip (which resets the counter once it
+ * heals) never escalates to a re-auth prompt. Pure — unit-testable without a DB.
+ */
+export function shouldDropTokenOnRefreshFailure(
+  failCount: number,
+  firstFailAt: Date | null,
+  now: Date,
+): boolean {
+  if (firstFailAt === null) return false
+  const elapsedMs = now.getTime() - firstFailAt.getTime()
+  return failCount >= REFRESH_FAIL_MIN_COUNT && elapsedMs >= REFRESH_FAIL_GRACE_SECONDS * 1000
+}
+
 class McpRefreshError extends Error {
   constructor(
     message: string,
@@ -347,7 +377,8 @@ export async function upsertToken(
      VALUES ($1, $2, $3, $4, $5, $6, $7)
      ON CONFLICT (user_id, server_origin) DO UPDATE SET
        access_token = $3, refresh_token = COALESCE($4, mcp_oauth_tokens.refresh_token),
-       token_type = $5, scope = $6, expires_at = $7, updated_at = NOW()`,
+       token_type = $5, scope = $6, expires_at = $7, updated_at = NOW(),
+       refresh_fail_count = 0, refresh_fail_first_at = NULL`,
     [
       userId,
       serverOrigin,
@@ -366,6 +397,30 @@ export async function getToken(userId: string, serverOrigin: string): Promise<OA
     [userId, serverOrigin],
   )
   return rows[0] ?? null
+}
+
+/**
+ * Increment the consecutive refresh-failure counter for a token, stamping the
+ * time of the first failure in the current streak. Returns the running count
+ * and first-failure timestamp so the caller can decide whether the failures
+ * have persisted past the grace window. A successful refresh resets both via
+ * `upsertToken`.
+ */
+async function recordRefreshFailure(
+  userId: string,
+  serverOrigin: string,
+): Promise<{ failCount: number; firstFailAt: Date | null }> {
+  const { rows } = await pool.query(
+    `UPDATE mcp_oauth_tokens
+       SET refresh_fail_count = refresh_fail_count + 1,
+           refresh_fail_first_at = COALESCE(refresh_fail_first_at, NOW())
+     WHERE user_id = $1 AND server_origin = $2
+     RETURNING refresh_fail_count, refresh_fail_first_at`,
+    [userId, serverOrigin],
+  )
+  const row = rows[0]
+  if (!row) return { failCount: 0, firstFailAt: null }
+  return { failCount: row.refresh_fail_count, firstFailAt: row.refresh_fail_first_at }
 }
 
 export async function deleteToken(userId: string, serverOrigin: string): Promise<boolean> {
@@ -427,13 +482,28 @@ export async function getValidAccessToken(
     return refreshed.access_token
   } catch (e) {
     if (e instanceof McpRefreshError && e.permanent) {
-      // refresh_token / client is dead — drop the row so we stop hammering
-      // the broker on every request, and signal the caller to prompt re-auth.
-      await deleteToken(userId, serverOrigin)
+      // A "permanent" OAuth code may actually be an upstream transient (a TLS
+      // blip while the broker refreshes the provider token, reported back as
+      // `invalid_grant`). Don't drop the row on the first failure — hold it
+      // through a grace window so a network hiccup doesn't force the user to
+      // re-OAuth. Only once refresh keeps failing across multiple requests
+      // spanning the window do we drop the row (so we stop hammering the broker)
+      // and signal the caller to prompt re-auth.
+      const { failCount, firstFailAt } = await recordRefreshFailure(userId, serverOrigin)
+      if (shouldDropTokenOnRefreshFailure(failCount, firstFailAt, new Date())) {
+        await deleteToken(userId, serverOrigin)
+        console.warn(
+          `[mcp-oauth] dropped dead token for ${serverOrigin} after ${failCount} refresh failures over grace window (oauth_error=${e.oauthError ?? 'none'}, status=${e.status})`,
+        )
+        throw new McpOAuthReauthRequired(serverOrigin, e.oauthError)
+      }
+      // Within the grace window: keep the token and treat as transient so the
+      // next request retries the refresh. The agent sees a transient auth error
+      // but self-heals once the upstream blip clears.
       console.warn(
-        `[mcp-oauth] dropped dead token for ${serverOrigin} (oauth_error=${e.oauthError ?? 'none'}, status=${e.status})`,
+        `[mcp-oauth] holding token for ${serverOrigin} through grace window (refresh failure ${failCount}, oauth_error=${e.oauthError ?? 'none'}, status=${e.status}); treating as transient`,
       )
-      throw new McpOAuthReauthRequired(serverOrigin, e.oauthError)
+      return null
     }
     console.error(`[mcp-oauth] refresh failed (transient) for ${serverOrigin}:`, e)
     return null


### PR DESCRIPTION
## Problem

A user's Google Workspace MCP session intermittently got stuck on `Auth required` / `Authentication error occurred, please sign in via OAuth`, and did **not** recover on its own — the user had to manually reconnect (re-OAuth) the service.

The token wasn't actually expired. It was a transient fault escalated into a permanent one:

1. The upstream `google-workspace-mcp` pod hits TLS connection flaps to `googleapis.com` (`UNEXPECTED_EOF_WHILE_READING`) and intermittently fails to refresh the underlying Google token.
2. The broker reports that transient network failure back to cp's `/token` as an `invalid_grant` 401.
3. cp's `PERMANENT_OAUTH_ERRORS` treats `invalid_grant` as permanently dead and **deletes the `mcp_oauth_tokens` row on the first occurrence** (`control-plane/src/services/mcp-oauth.ts`).
4. Every later request has no token to inject → the agent is stuck on `Auth required` until the user re-authorizes.

## Fix

Don't drop the token row on the first "permanent" OAuth error. Hold it through a grace window and only delete + prompt re-auth once refresh keeps failing across multiple requests spanning the window:

- **Drop condition:** `refresh_fail_count >= 3` **and** the failure streak is older than `600s`.
- A **successful** refresh resets the counter → a transient blip self-heals and the token survives.
- A **genuinely revoked** token keeps failing and still gets cleaned up after the window (so we stop hammering the broker and the UI still gets its `needs_reauth` prompt).
- Within the grace window, `getValidAccessToken` returns `null` (the existing transient path) so the request is forwarded and the next request retries — the agent sees a transient auth error but recovers once the upstream blip clears.

## Changes

- **migration 117** — add `refresh_fail_count` / `refresh_fail_first_at` to `mcp_oauth_tokens`.
- `shouldDropTokenOnRefreshFailure()` — pure, unit-tested decision function.
- `recordRefreshFailure()` — increment the counter + stamp first-failure time.
- `upsertToken()` — reset the counter on any successful (re)fresh.
- `getValidAccessToken()` — hold-through-grace logic in the permanent-error branch.
- unit tests for the decision function (`VITEST_UNIT=1 vitest run src/services/mcp-oauth.test.ts`).

The grace knobs (`REFRESH_FAIL_GRACE_SECONDS = 600`, `REFRESH_FAIL_MIN_COUNT = 3`) — ~10 min of continuous failures before asking the user to reconnect — are easy to tune.

## Out of scope

The underlying egress TLS `UNEXPECTED_EOF` from the MCP pod to `googleapis.com` (suspected egress proxy / network issue) is infra, not addressed here. This PR only stops cp from amplifying that transient into a forced re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)