### PR TITLE
feat(file-preview): preview video files inline with a <video> element

### DIFF
--- a/web/src/components/workspace/file-preview/FilePreview.tsx
+++ b/web/src/components/workspace/file-preview/FilePreview.tsx
@@ -5,7 +5,7 @@ import { useMarkdownPreferencesStore } from '@/stores/markdown-preferences-store
 import { Code, Eye, FileText, Table, WrapText } from 'lucide-react'
 import { Suspense, lazy, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { isImageFile } from './file-types'
+import { isImageFile, isVideoFile } from './file-types'
 
 const MarkdownPreview = lazy(() =>
   import('./MarkdownPreview').then((m) => ({ default: m.MarkdownPreview })),
@@ -21,11 +21,22 @@ const OfficePreview = lazy(() =>
 )
 const XlsxPreview = lazy(() => import('./XlsxPreview').then((m) => ({ default: m.XlsxPreview })))
 const HtmlPreview = lazy(() => import('./HtmlPreview').then((m) => ({ default: m.HtmlPreview })))
+const VideoPreview = lazy(() => import('./VideoPreview').then((m) => ({ default: m.VideoPreview })))
 
-type PreviewType = 'markdown' | 'image' | 'csv' | 'excalidraw' | 'office' | 'xlsx' | 'html' | 'code'
+type PreviewType =
+  | 'markdown'
+  | 'image'
+  | 'video'
+  | 'csv'
+  | 'excalidraw'
+  | 'office'
+  | 'xlsx'
+  | 'html'
+  | 'code'
 
 function getPreviewType(filename: string): PreviewType {
   if (isImageFile(filename)) return 'image'
+  if (isVideoFile(filename)) return 'video'
   const ext = filename.split('.').pop()?.toLowerCase()
   switch (ext) {
     case 'md':
@@ -121,6 +132,7 @@ export function FilePreview({
   const isCanvasEditor = previewType === 'excalidraw'
   const useRendered =
     previewType === 'image' ||
+    previewType === 'video' ||
     previewType === 'office' ||
     previewType === 'xlsx' ||
     (showRendered && (isCanvasEditor || !isEditing))
@@ -209,6 +221,8 @@ export function FilePreview({
             onPrev={onPrevImage ?? null}
             onNext={onNextImage ?? null}
           />
+        ) : useRendered && previewType === 'video' && fileUrl ? (
+          <VideoPreview src={fileUrl} filename={filename} />
         ) : useRendered && previewType === 'csv' ? (
           <CsvPreview content={content} filename={filename} />
         ) : useRendered && previewType === 'excalidraw' ? (

--- a/web/src/components/workspace/file-preview/VideoPreview.tsx
+++ b/web/src/components/workspace/file-preview/VideoPreview.tsx
@@ -1,0 +1,22 @@
+interface VideoPreviewProps {
+  /** URL streaming the raw video bytes. */
+  src: string
+  filename: string
+}
+
+export function VideoPreview({ src, filename }: VideoPreviewProps) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center bg-muted/40 p-4">
+      {/* biome-ignore lint/a11y/useMediaCaption: user-uploaded media has no caption track */}
+      <video
+        key={src}
+        src={src}
+        controls
+        controlsList="nodownload"
+        preload="metadata"
+        aria-label={filename}
+        className="max-h-full max-w-full rounded"
+      />
+    </div>
+  )
+}

--- a/web/src/components/workspace/file-preview/file-types.ts
+++ b/web/src/components/workspace/file-preview/file-types.ts
@@ -4,3 +4,13 @@ export function isImageFile(name: string): boolean {
   const ext = name.split('.').pop()?.toLowerCase()
   return ext ? IMAGE_EXTS.has(ext) : false
 }
+
+// Containers/codecs a browser `<video>` element can generally play inline.
+// Kept in sync with the binary-fetch gate in `@/lib/api/agent-files` so these
+// files are streamed by URL, not fetched as text.
+const VIDEO_EXTS = new Set(['mp4', 'webm', 'ogg', 'ogv', 'm4v', 'mov'])
+
+export function isVideoFile(name: string): boolean {
+  const ext = name.split('.').pop()?.toLowerCase()
+  return ext ? VIDEO_EXTS.has(ext) : false
+}

--- a/web/src/lib/api/agent-files.ts
+++ b/web/src/lib/api/agent-files.ts
@@ -50,7 +50,25 @@ export function filePreviewUrl(
   return `/api/workspaces/${workspaceId}/${ep.files}/preview?path=${encodeURIComponent(stripLeading(path))}`
 }
 
-const BINARY_PREVIEW_EXTS = new Set(['pptx', 'ppt', 'docx', 'doc', 'pdf', 'xlsx', 'xls'])
+// Files fetched as raw bytes (streamed by URL) rather than as text. Office docs
+// render via the PDF preview endpoint; video plays inline through a `<video>`
+// element. Keep the video set in sync with `isVideoFile` in the file-preview
+// helpers.
+const BINARY_PREVIEW_EXTS = new Set([
+  'pptx',
+  'ppt',
+  'docx',
+  'doc',
+  'pdf',
+  'xlsx',
+  'xls',
+  'mp4',
+  'webm',
+  'ogg',
+  'ogv',
+  'm4v',
+  'mov',
+])
 
 export function isBinaryPreviewFile(filename: string): boolean {
   const ext = filename.split('.').pop()?.toLowerCase() ?? ''


### PR DESCRIPTION
## What

The file app now previews video files inline instead of falling through to the code view. Common containers — `mp4`, `webm`, `ogg`/`ogv`, `m4v`, `mov` — render in a native HTML `<video>` element with controls.

## How

- **`VideoPreview.tsx`** (new) — native `<video>` with `controls`, `preload="metadata"`, `controlsList="nodownload"`, streaming from the file's `fileUrl`. `key={src}` forces a fresh element when switching files; backdrop uses the `muted` token.
- **`file-types.ts`** — `isVideoFile` + `VIDEO_EXTS`, mirroring `isImageFile`.
- **`FilePreview.tsx`** — new `'video'` preview type, lazy-loaded; routed like image/office (always rendered, no source/wrap toggle), using `fileUrl`.
- **`lib/api/agent-files.ts`** — video extensions added to the binary-fetch gate so videos stream by URL instead of being fetched as a text blob.

No new i18n keys (only an `aria-label` from the filename); `FileViewer` dispatches by extension automatically.

## Notes

- Codec support is the browser's: `mp4` (H.264) and `webm` play everywhere; `mov`/`m4v` depend on the contained codec. Unplayable codecs fall back to the native "can't play" state — Download still works.
- `.ogg` (often audio) is included; it renders fine through `<video>` (controls only).

`tsc --noEmit` and biome both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)