### PR TITLE
fix(web): chunk terminal input to avoid disconnect on large paste

### DIFF
--- a/web/src/components/workspace/WorkspaceTerminalPanel.tsx
+++ b/web/src/components/workspace/WorkspaceTerminalPanel.tsx
@@ -35,6 +35,37 @@ const CMD_RESIZE = 0x31 // '1'
 
 const textEncoder = new TextEncoder()
 
+// ttyd/libwebsockets fragments a single client→server frame once it grows past
+// its receive buffer (~2KB observed), then mis-parses the continuation frame's
+// first byte as a tty command and tears down the connection. So a large paste
+// sent as one frame silently kills the terminal. Split outgoing input into
+// sub-buffer-size chunks; xterm.js does no input-side chunking or flow control
+// itself (its flow-control guide covers the write/output path only).
+const TERMINAL_INPUT_CHUNK_SIZE = 1024
+// Pause feeding more chunks while the socket's send buffer is backed up, so a
+// huge paste can't balloon memory faster than the wire drains it.
+const WS_BACKPRESSURE_LIMIT = 1 << 20 // 1 MiB
+
+function sendInputFrame(ws: WebSocket, payload: Uint8Array) {
+  const msg = new Uint8Array(1 + payload.length)
+  msg[0] = CMD_INPUT
+  msg.set(payload, 1)
+  ws.send(msg)
+}
+
+function waitForDrain(ws: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    const check = () => {
+      if (ws.readyState !== WebSocket.OPEN || ws.bufferedAmount < WS_BACKPRESSURE_LIMIT) {
+        resolve()
+      } else {
+        setTimeout(check, 4)
+      }
+    }
+    check()
+  })
+}
+
 export function WorkspaceTerminalPanel({ workspaceId, instanceId }: WorkspaceTerminalPanelProps) {
   const { t } = useTranslation()
   const terminalTheme = useTerminalTheme()
@@ -274,14 +305,34 @@ export function WorkspaceTerminalPanel({ workspaceId, instanceId }: WorkspaceTer
       )
     }
 
+    // Serialize sends so a large paste's chunks stay in order ahead of any
+    // keystrokes typed while it's still streaming. Swallow rejections (e.g.
+    // socket closing mid-send) so one failure doesn't stall the chain.
+    let sendChain: Promise<void> = Promise.resolve()
+    const enqueueSend = (task: () => void | Promise<void>) => {
+      sendChain = sendChain.then(task).catch(() => {})
+    }
+
     const inputDisposable = term.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        const payload = textEncoder.encode(data)
-        const msg = new Uint8Array(1 + payload.length)
-        msg[0] = CMD_INPUT
-        msg.set(payload, 1)
-        ws.send(msg)
+      if (ws.readyState !== WebSocket.OPEN) return
+      const payload = textEncoder.encode(data)
+      // Fast path: typical keystrokes fit in one frame.
+      if (payload.length <= TERMINAL_INPUT_CHUNK_SIZE) {
+        enqueueSend(() => {
+          if (ws.readyState === WebSocket.OPEN) sendInputFrame(ws, payload)
+        })
+        return
       }
+      // Large input (paste): split into sub-buffer-size frames, pausing on
+      // backpressure. Splitting mid-UTF-8/mid-escape is safe — ttyd writes each
+      // payload to the pty in order, so the byte stream reassembles downstream.
+      enqueueSend(async () => {
+        for (let offset = 0; offset < payload.length; offset += TERMINAL_INPUT_CHUNK_SIZE) {
+          if (ws.readyState !== WebSocket.OPEN) return
+          if (ws.bufferedAmount >= WS_BACKPRESSURE_LIMIT) await waitForDrain(ws)
+          sendInputFrame(ws, payload.subarray(offset, offset + TERMINAL_INPUT_CHUNK_SIZE))
+        }
+      })
     })
 
     const resizeDisposable = term.onResize(({ cols, rows }) => {


### PR DESCRIPTION
## Problem

Pasting more than ~2KB of text into the web terminal closes the connection ("connection closed"). Empirically: 2000-byte paste OK, 3000-byte paste disconnects.

## Root cause

Terminal input was sent as a single WebSocket frame per `onData`. ttyd/libwebsockets fragments a client→server frame once it exceeds its receive buffer (~2KB observed) and parses the **continuation** frame's leading byte as a tty command — an invalid command tears down the agent↔ttyd connection. Both relay layers (control-plane and the agent server) faithfully propagate the backend close up to the browser, so the user just sees the terminal drop.

xterm.js does **no** input-side chunking or flow control of its own — its [flow-control guide](https://xtermjs.org/docs/guides/flowcontrol/) covers the write/output path only, and explicitly treats the outgoing websocket as an infinite sink. So input-side handling is the app's responsibility.

## Fix (frontend only)

In `WorkspaceTerminalPanel.tsx`:

- Split outgoing input into **1KB** frames — comfortably under the observed ~2KB fragmentation boundary.
- Pause feeding chunks while `ws.bufferedAmount` is backed up (1 MiB watermark), so a huge paste can't outrun the wire.
- Serialize sends so a large paste's chunks stay ordered ahead of keystrokes typed mid-stream.

Splitting mid-UTF-8 / mid-escape is safe: ttyd writes each payload to the pty in order, so the byte stream reassembles downstream. The relay layers and ttyd are untouched.

## Test plan

- Paste 3000 / 9000-byte single-line payloads (ASCII and CJK) at the bash prompt → no disconnect, full content arrives (`wc -c` matches).
- Normal typing and small pastes behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)