### PR TITLE
feat(agents): persist input image attachments to workspace files

### DIFF
--- a/agents/claude-code/src/agent.ts
+++ b/agents/claude-code/src/agent.ts
@@ -7,6 +7,7 @@ import {
   type SDKUserMessage,
   query,
 } from '@anthropic-ai/claude-agent-sdk'
+import { formatAttachmentNote, writeInputAttachments } from '../../../internal/types/attachments.js'
 import type {
   AskUserRequest,
   ChatImageAttachment,
@@ -178,7 +179,10 @@ export async function chat(
         source: { type: 'base64', media_type: img.media_type, data: img.data },
       })
     }
-    contentBlocks.push({ type: 'text', text: userMessage })
+    // Also persist the images as files so the model can hand them to tools that
+    // need a real file or URL (vision content alone cannot be re-exported).
+    const written = writeInputAttachments(images, { workspaceDir: WORKSPACE_DIR, sessionId })
+    contentBlocks.push({ type: 'text', text: userMessage + formatAttachmentNote(written) })
     const userMsg = {
       type: 'user' as const,
       message: { role: 'user' as const, content: contentBlocks },

--- a/internal/acp-adapter/acp-bridge.ts
+++ b/internal/acp-adapter/acp-bridge.ts
@@ -12,22 +12,29 @@ import { type ChildProcess, spawn } from 'node:child_process'
 import { createInterface } from 'node:readline'
 import { Readable, Writable } from 'node:stream'
 import {
-  ClientSideConnection,
-  PROTOCOL_VERSION,
-  ndJsonStream,
   type Client,
+  ClientSideConnection,
   type ContentBlock,
   type McpServer,
+  PROTOCOL_VERSION,
   type PromptResponse,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
   type SessionUpdate,
+  ndJsonStream,
 } from '@agentclientprotocol/sdk'
+import { formatAttachmentNote, writeInputAttachments } from '../types/attachments.js'
 import type { ChatImageAttachment } from '../types/events.js'
 
 // Re-export SDK types that consumers need
-export type { McpServer, PromptResponse, RequestPermissionRequest, RequestPermissionResponse, SessionUpdate }
+export type {
+  McpServer,
+  PromptResponse,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionUpdate,
+}
 
 // ── Bridge options ──
 
@@ -42,9 +49,7 @@ export interface AcpBridgeOptions {
 
 export interface AcpSessionHandler {
   onUpdate(update: SessionUpdate): void
-  onPermissionRequest(
-    params: RequestPermissionRequest,
-  ): Promise<RequestPermissionResponse>
+  onPermissionRequest(params: RequestPermissionRequest): Promise<RequestPermissionResponse>
 }
 
 // ── Bridge ──
@@ -207,10 +212,13 @@ export class AcpBridge {
    * Load (restore) a previously persisted session. Returns the session ID.
    * Throws if the agent doesn't support loadSession or the session is not found.
    */
-  async loadSession(sessionId: string, opts?: {
-    cwd?: string
-    mcpServers?: McpServer[]
-  }): Promise<string> {
+  async loadSession(
+    sessionId: string,
+    opts?: {
+      cwd?: string
+      mcpServers?: McpServer[]
+    },
+  ): Promise<string> {
     if (!this.connection) throw new Error('ACP bridge not started')
     await this.connection.loadSession({
       sessionId,
@@ -240,25 +248,37 @@ export class AcpBridge {
    * Send a prompt to an existing session. Resolves when the turn completes.
    * During execution, session updates flow through the registered handler.
    */
-  async prompt(sessionId: string, text: string, images?: ChatImageAttachment[]): Promise<PromptResponse> {
+  async prompt(
+    sessionId: string,
+    text: string,
+    images?: ChatImageAttachment[],
+  ): Promise<PromptResponse> {
     if (!this.connection) throw new Error('ACP bridge not started')
     const contentBlocks: ContentBlock[] = []
+    let promptText = text
     if (images?.length) {
       for (const img of images) {
         contentBlocks.push({ type: 'image', data: img.data, mimeType: img.media_type })
       }
+      // Also persist the images as files so the model can hand them to tools
+      // that need a real file or URL — the ACP image block only feeds vision,
+      // it does not expose a path the model can pass downstream.
+      const written = writeInputAttachments(images, { workspaceDir: this.options.cwd, sessionId })
+      promptText += formatAttachmentNote(written)
     }
-    contentBlocks.push({ type: 'text', text })
+    contentBlocks.push({ type: 'text', text: promptText })
     // Race the protocol-level prompt against a child-died rejection so the
     // promise actually settles when codex-acp gets OOM-killed mid-turn.
     return new Promise<PromptResponse>((resolve, reject) => {
       this.pendingPromptRejects.set(sessionId, reject)
-      this.connection!.prompt({ sessionId, prompt: contentBlocks }).then(resolve, reject).finally(() => {
-        // Only clear our own entry — concurrent prompts on different
-        // sessions share this map.
-        const current = this.pendingPromptRejects.get(sessionId)
-        if (current === reject) this.pendingPromptRejects.delete(sessionId)
-      })
+      this.connection!.prompt({ sessionId, prompt: contentBlocks })
+        .then(resolve, reject)
+        .finally(() => {
+          // Only clear our own entry — concurrent prompts on different
+          // sessions share this map.
+          const current = this.pendingPromptRejects.get(sessionId)
+          if (current === reject) this.pendingPromptRejects.delete(sessionId)
+        })
     })
   }
 

--- a/internal/types/attachments.ts
+++ b/internal/types/attachments.ts
@@ -1,0 +1,77 @@
+/**
+ * Input image attachment handling shared by agent implementations.
+ *
+ * When a user pastes an image into chat, the control-plane forwards it to the
+ * agent pod as a base64 {@link ChatImageAttachment}. By default the image is
+ * only available as vision content — the model can "see" it but cannot hand it
+ * to a tool that needs a real file or URL (e.g. uploading to a GitLab issue via
+ * an MCP tool). These helpers decode the base64 and write the bytes into the
+ * agent workspace so the model can reference them as files; downstream tools can
+ * then read the path directly or mint a URL via the `export_file_url` tool.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { ChatImageAttachment } from './events.js'
+
+const MIME_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+}
+
+export interface WrittenAttachment {
+  /** Absolute path of the written file inside the agent workspace. */
+  path: string
+  media_type: string
+}
+
+/**
+ * Decode base64 input image attachments and write them under
+ * `<workspaceDir>/.attachments/<sessionId>/img_<index>.<ext>`.
+ *
+ * Naming is index-based and scoped per session: a later turn's images reuse the
+ * same `img_<index>` names and overwrite the previous turn's files. That is an
+ * accepted trade-off — there is no cleanup, and the model receives the freshly
+ * written paths within the same turn that wrote them.
+ *
+ * Never throws: a write failure is logged and that image is skipped, leaving the
+ * existing vision-only behaviour intact.
+ */
+export function writeInputAttachments(
+  images: ChatImageAttachment[] | undefined,
+  opts: { workspaceDir: string; sessionId: string | undefined },
+): WrittenAttachment[] {
+  if (!images?.length) return []
+  const dir = join(opts.workspaceDir, '.attachments', opts.sessionId || 'session')
+  try {
+    mkdirSync(dir, { recursive: true })
+  } catch (err) {
+    console.warn(`[attachments] mkdir failed for ${dir}: ${String(err)}`)
+    return []
+  }
+  const written: WrittenAttachment[] = []
+  images.forEach((img, i) => {
+    const ext = MIME_EXT[img.media_type] ?? 'bin'
+    const path = join(dir, `img_${i}.${ext}`)
+    try {
+      writeFileSync(path, Buffer.from(img.data, 'base64'))
+      written.push({ path, media_type: img.media_type })
+    } catch (err) {
+      console.warn(`[attachments] write failed for ${path}: ${String(err)}`)
+    }
+  })
+  return written
+}
+
+/**
+ * A text note listing the written attachment paths, to append to the user
+ * prompt so the model knows the images also exist as files. Returns '' when
+ * nothing was written.
+ */
+export function formatAttachmentNote(written: WrittenAttachment[]): string {
+  if (!written.length) return ''
+  const lines = written.map((w) => `- ${w.path} (${w.media_type})`)
+  return `\n\n[The image(s) in this message are also saved as files in the workspace. Read these paths or pass them to tools that need a file or URL (use export_file_url to obtain a shareable URL):]\n${lines.join('\n')}`
+}


### PR DESCRIPTION
## Problem

When a user pastes an image into chat, the image reaches the agent only as **vision content** — the model can "see" it but cannot hand it to a tool that needs a real file or URL (e.g. uploading the image to a GitLab issue comment via an MCP tool). Writing it to the filesystem from the original input attachment was not possible either.

## Change

Add a shared helper (`internal/types/attachments.ts`) that decodes the base64 input images and writes them to `<workspace>/.attachments/<sessionId>/img_<index>.<ext>`, then appends a text note listing the paths to the prompt.

- The original **vision blocks are kept** — the model both sees the image and knows the file path.
- Tools needing a URL can call the existing `export_file_url` tool on the written path. No new control-plane / DB / signing code.
- Wired symmetrically into both agents:
  - **claude-code**: `agents/claude-code/src/agent.ts`
  - **codex (and any ACP agent)**: `internal/acp-adapter/acp-bridge.ts`, using the bridge's `cwd` (= workspace dir).

### Naming / lifecycle
- Index-based naming, scoped per session. A later turn's images reuse the same `img_<index>` names and overwrite the previous turn's files — accepted trade-off; the model receives freshly written paths within the same turn.
- No cleanup job (intentional for now).
- `writeInputAttachments` never throws: a write failure is logged and that image is skipped, leaving vision-only behaviour intact.

## Notes
- The `acp-bridge.ts` diff includes some formatting churn from biome re-wrapping (import block / `prompt()` signature / `.finally`) — the functional change is only the few lines inside `prompt()`.
- A pre-existing biome control-character lint at `acp-bridge.ts:133` (the ANSI-strip regex) is unrelated to this change and left untouched.

## Testing
- `tsc --noEmit` passes for both `agents/claude-code` and `agents/codex`.
- Runtime fs-write not exercised (requires a live agent pod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)