### PR TITLE
fix(sse): bump session last_active_at on agent-stream liveness

### DIFF
--- a/control-plane/src/lib/sse.ts
+++ b/control-plane/src/lib/sse.ts
@@ -460,9 +460,36 @@ export function createInterceptedSSEResponse(
   // Plugin order matters: persist runs first so its DB enqueues land on
   // the shared queue before broadcast's deferred emits, ensuring emits
   // observe a consistent DB state.
+  // Tap the raw agent stream: any byte from the agent — a real event OR the
+  // acp-adapter heartbeat comment — proves the session is alive, so bump
+  // last_active_at (throttled). Previously last_active_at only advanced when a
+  // message/tool_result was persisted, so a single long operation (a slow tool,
+  // a long inference with no streamed text) starved it and looked "stalled" to
+  // the orchestrator's stall detector even while the agent was working.
+  let lastActivityTouchAt = 0
+  const ACTIVITY_TOUCH_THROTTLE_MS = 10_000
+  const tapActivity = (resp: Response | null): Response | null => {
+    if (!resp?.body) return resp
+    const tap = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        const sid = state.sessionId
+        const now = Date.now()
+        if (sid && now - lastActivityTouchAt >= ACTIVITY_TOUCH_THROTTLE_MS) {
+          lastActivityTouchAt = now
+          void updateSessionActivity(sid).catch(() => {})
+        }
+        controller.enqueue(chunk)
+      },
+    })
+    return new Response(resp.body.pipeThrough(tap), {
+      status: resp.status,
+      headers: resp.headers,
+    })
+  }
+
   runTurn(
     {
-      stream: async () => response,
+      stream: async () => tapActivity(response) ?? response,
       reconnect: reconnectFactory
         ? async () => {
             // During shutdown this CP is already on its way out; firing a
@@ -476,7 +503,7 @@ export function createInterceptedSSEResponse(
             const sid = state.sessionId
             if (!sid) return null
             try {
-              return await reconnectFactory(sid)
+              return tapActivity(await reconnectFactory(sid))
             } catch (e) {
               console.error(`[SSE] reconnect factory threw ${tag} session=${sid}:`, e)
               return null


### PR DESCRIPTION
## Problem

`sessions.last_active_at` only advances when a message or tool_result is **persisted** (`addMessage`). A single long operation — a slow tool call, or a long inference that streams no text for minutes — persists nothing for its duration, so `last_active_at` goes stale even though the agent↔cp stream is alive and `chat_status` is still `agent`.

Downstream, an orchestrator's stall detector that watches `last_active_at` then **falsely kills a working run** once the operation exceeds its timeout.

## Fix

Tap the raw agent SSE stream and throttle-bump `last_active_at` (≤ once / 10s) on **any** frame received from the agent — a real event *or* the acp-adapter heartbeat comment. So `last_active_at` now means "the session is alive," not "an event was persisted." A long operation keeps the timestamp fresh via the heartbeat; only a genuinely silent/dead stream goes stale (and a broken stream already flips `chat_status` to `idle` anyway).

- Applies to both the initial turn stream and the reconnect stream.
- Throttled, fire-and-forget — no added write pressure or stream backpressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)