### PR TITLE
fix(ui-sdk): package into web build and stop clobbering host i18n

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -28,6 +28,9 @@ COPY internal/sse-consumer /app/internal/sse-consumer
 # @neutree-ai/theme is referenced via vite alias '@neutree-ai/theme' → ../internal/theme/src
 # and tsconfig path "../internal/theme/index.d.ts"
 COPY internal/theme /app/internal/theme
+# @neutree-ai/ui-sdk is referenced via vite alias '@neutree-ai/ui-sdk' → ../internal/ui-sdk/src
+# and tsconfig path "../internal/ui-sdk/src/index.ts"; deps resolve from web/node_modules.
+COPY internal/ui-sdk /app/internal/ui-sdk
 
 # Build-time environment for vite — these are baked into the bundle.
 # Each is optional; unset means the corresponding feature degrades gracefully
@@ -45,6 +48,15 @@ ENV VITE_BUILD_TIME=$BUILD_TIME
 # zod relative to /app/internal/types/, which has no node_modules of its
 # own, so install them here.
 RUN cd /app/internal/types && npm install --no-audit --no-fund
+
+# @neutree-ai/ui-sdk is consumed via its src (vite alias + tsconfig path). ui-sdk
+# lives OUTSIDE the vite root (/app/web), so vite's resolve.dedupe does NOT reach
+# the deps it imports — giving ui-sdk its own node_modules yields duplicate
+# react / react-i18next / @radix-ui/* instances, which break React/i18next/Radix
+# context across the boundary (raw i18n keys, "must be used within Provider").
+# Point ui-sdk at web's single node_modules instead so every shared lib resolves
+# to one identical module (web/package.json already carries all of ui-sdk's deps).
+RUN ln -sfn /app/web/node_modules /app/internal/ui-sdk/node_modules
 
 # Build frontend
 ENV NODE_OPTIONS=--max-old-space-size=4096

--- a/internal/ui-sdk/src/i18n.tsx
+++ b/internal/ui-sdk/src/i18n.tsx
@@ -8,12 +8,20 @@
 // components need no key rewrites; the bundle below is just that subtree.
 import i18next, { type i18n as I18nInstance } from 'i18next'
 import { type ReactNode, useEffect } from 'react'
-import { I18nextProvider, initReactI18next } from 'react-i18next'
+import { I18nextProvider, getI18n, initReactI18next, setI18n } from 'react-i18next'
 import enUS from './locales/en-US.json'
 import zhCN from './locales/zh-CN.json'
 
 export const transcriptI18n: I18nInstance = i18next.createInstance()
 
+// initReactI18next.init() has a side effect: setI18n(instance) makes the passed
+// instance react-i18next's GLOBAL default — the one bare useTranslation() falls
+// back to outside any <I18nextProvider>. Letting our private, chat-only instance
+// become the global clobbers the host app's i18n (every non-wrapped key renders
+// raw). Capture the host's global before init and restore it after: our own
+// components reach transcriptI18n through <TranscriptI18nProvider> (context),
+// which takes precedence over the global, so they are unaffected by the restore.
+const hostI18n = getI18n()
 void transcriptI18n.use(initReactI18next).init({
   resources: {
     'en-US': { translation: enUS },
@@ -25,6 +33,7 @@ void transcriptI18n.use(initReactI18next).init({
   load: 'currentOnly',
   interpolation: { escapeValue: false },
 })
+if (hostI18n) setI18n(hostI18n)
 
 // Normalize anything zh-ish to our zh-CN bundle, everything else to en-US.
 function normalizeLocale(locale: string | undefined): 'en-US' | 'zh-CN' {


### PR DESCRIPTION
## Problem

The `@neutree-ai/ui-sdk` extraction (#31) left two integration gaps that surface only when the SDK is consumed from source via the vite alias (as `web` does) and built outside the workspace-hoisted dev tree (as the `control-plane` Docker image does):

1. **Build failure** — `control-plane/Dockerfile`'s frontend builder never copied `internal/ui-sdk`, so `npm run build` failed with `Cannot find module '@neutree-ai/ui-sdk'`.
2. **Runtime breakage** — even once it builds, two further problems appear:
   - ui-sdk lives **outside the vite root** (`web/`), so `resolve.dedupe` does not reach the deps it imports. Giving ui-sdk its own `node_modules` produces duplicate `react` / `react-i18next` / `@radix-ui/*` instances, so React/Radix context breaks across the boundary — e.g. `` `Tooltip` must be used within `TooltipProvider` ``.
   - `ui-sdk/src/i18n.tsx` initializes its private, chat-only i18next instance with `initReactI18next`, whose `setI18n()` side effect makes that instance react-i18next's **global default**. When the lazily-loaded transcript mounts, it clobbers the host app's global i18n and every `useTranslation()` outside an explicit `<I18nextProvider>` renders **raw keys**.

## Fix

- **`control-plane/Dockerfile`**: `COPY internal/ui-sdk` into the frontend builder (mirroring `internal/theme`), and symlink its `node_modules` to `web`'s single store so every shared lib resolves to one identical module. `web/package.json` already carries all of ui-sdk's deps.
- **`internal/ui-sdk/src/i18n.tsx`**: capture the host's global react-i18next instance before init and restore it after. The SDK's own components reach the private instance through `<TranscriptI18nProvider>` (context takes precedence over the global), so they are unaffected.

## Verify

- `control-plane` web build succeeds.
- In a host app with its own i18n, open a workspace transcript: host UI keeps its translations (no raw keys) and the transcript renders correctly; no `TooltipProvider` context error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
