### PR TITLE
feat(agent-skills): persist unpublished skill drafts on the workspace volume

### DIFF
--- a/agents/claude-code/src/config.ts
+++ b/agents/claude-code/src/config.ts
@@ -1,9 +1,9 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { writePlatformPrompt } from '../../../internal/platform-prompt/src/index.js'
 import { SkillManager } from '../../../internal/agent-skills/src/index.js'
 import { nodeFetch, nodeFs, nodeShell } from '../../../internal/agent-skills/src/node.js'
 import { renderPlatformSkillFiles } from '../../../internal/agent-skills/src/platform.js'
+import { writePlatformPrompt } from '../../../internal/platform-prompt/src/index.js'
 
 export const CP_URL = process.env.CP_URL
 export const WORKSPACE_ID = process.env.WORKSPACE_ID
@@ -128,6 +128,9 @@ export async function loadSkills(): Promise<{ ok: boolean; failed: string[] }> {
     workspaceId: WORKSPACE_ID,
     skillsDir: join(WORKSPACE_DIR, '.claude', 'skills'),
     localBase: '/tmp',
+    // Drafts (unpublished edits) live here on the persistent workspace volume so
+    // they survive pod rebuilds; published skills stay on tmpfs (localBase).
+    draftBase: join(WORKSPACE_DIR, '.skills-draft'),
     useSymlink: true,
     fetch: nodeFetch,
     fs: nodeFs,

--- a/agents/codex/src/config.ts
+++ b/agents/codex/src/config.ts
@@ -9,10 +9,10 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import type { McpServer } from '@agentclientprotocol/sdk'
-import { writePlatformPrompt } from '../../../internal/platform-prompt/src/index.js'
 import { SkillManager } from '../../../internal/agent-skills/src/index.js'
 import { nodeFetch, nodeFs, nodeShell } from '../../../internal/agent-skills/src/node.js'
 import { renderPlatformSkillFiles } from '../../../internal/agent-skills/src/platform.js'
+import { writePlatformPrompt } from '../../../internal/platform-prompt/src/index.js'
 
 export const CP_URL = process.env.CP_URL
 export const WORKSPACE_ID = process.env.WORKSPACE_ID
@@ -235,6 +235,9 @@ export async function loadSkills(): Promise<{ ok: boolean; failed: string[] }> {
     workspaceId: WORKSPACE_ID,
     skillsDir: join(home, '.codex', 'skills'),
     localBase: '/tmp',
+    // Drafts (unpublished edits) live here on the persistent workspace volume so
+    // they survive pod rebuilds; published skills stay on tmpfs (localBase).
+    draftBase: join(WORKSPACE_DIR, '.skills-draft'),
     useSymlink: true,
     filesBrowsePath: '/.home/.codex/skills',
     fetch: nodeFetch,

--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -556,3 +556,131 @@ describe('SkillManager', () => {
     })
   })
 })
+
+describe('SkillManager draft persistence (draftBase)', () => {
+  let fs: ReturnType<typeof createMemFs>
+  let shell: ReturnType<typeof createMemShell>
+  const SKILLS_DIR = '/workspace/.claude/skills'
+  const LOCAL_BASE = '/tmp'
+  const DRAFT_BASE = '/workspace/.skills-draft'
+
+  function createManager(fetchImpl: (url: string) => Promise<FetchResponse>) {
+    return new SkillManager({
+      cpUrl: 'http://cp:3000',
+      workspaceId: 'ws-1',
+      skillsDir: SKILLS_DIR,
+      localBase: LOCAL_BASE,
+      draftBase: DRAFT_BASE,
+      useSymlink: true,
+      fetch: fetchImpl,
+      fs,
+      shell,
+    })
+  }
+
+  beforeEach(() => {
+    fs = createMemFs()
+    shell = createMemShell()
+  })
+
+  test('createDraft places content + lock on the persistent draftBase, not tmpfs', async () => {
+    const mgr = createManager(async () => {
+      throw new Error('createDraft should not fetch')
+    })
+    await mgr.createDraft('my-draft')
+
+    // Content and the .editing lock live under draftBase → survive a pod rebuild.
+    expect(fs.dirs.has('/workspace/.skills-draft/skill-my-draft')).toBe(true)
+    expect(fs.files.has('/workspace/.skills-draft/skill-my-draft/SKILL.md')).toBe(true)
+    expect(fs.files.has('/workspace/.skills-draft/skill-my-draft/.editing')).toBe(true)
+    // Nothing was written to tmpfs.
+    expect(fs.dirs.has('/tmp/skill-my-draft')).toBe(false)
+    // Symlink points at the persistent draft dir.
+    expect(shell.calls).toContainEqual({
+      cmd: 'ln',
+      args: ['-s', '/workspace/.skills-draft/skill-my-draft', '/workspace/.claude/skills/my-draft'],
+    })
+  })
+
+  test('load preserves an unpublished draft after a rebuild (tmpfs wiped, draftBase intact)', async () => {
+    // A draft on persistent NFS, not enabled in CP (never published).
+    fs.dirs.add('/workspace/.skills-draft/skill-wip')
+    fs.files.set('/workspace/.skills-draft/skill-wip/SKILL.md', 'draft body')
+    fs.dirs.add('/workspace/.claude/skills/wip') // symlink dest, still materialized
+
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/workspaces/ws-1/skills')) return jsonResponse({ skills: [] })
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    const result = await createManager(fetchImpl).load()
+
+    // Draft content untouched; not swept as an orphan.
+    expect(fs.dirs.has('/workspace/.skills-draft/skill-wip')).toBe(true)
+    expect(fs.files.get('/workspace/.skills-draft/skill-wip/SKILL.md')).toBe('draft body')
+    expect(result.loaded).toEqual([])
+  })
+
+  test('load recognises a still-editing draft via the NFS lock after a rebuild', async () => {
+    fs.dirs.add('/workspace/.skills-draft/skill-wip')
+    fs.files.set('/workspace/.skills-draft/skill-wip/.editing', '')
+    fs.dirs.add('/workspace/.claude/skills/wip')
+
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/workspaces/ws-1/skills'))
+        return jsonResponse({ skills: [{ name: 'wip', id: 'sk-wip' }] })
+      if (url.includes('/_cp/skills')) return jsonResponse([{ name: 'wip' }])
+      throw new Error(`Should not download a skill being edited: ${url}`)
+    }
+    const result = await createManager(fetchImpl).load()
+
+    expect(result.editing).toEqual(['wip'])
+    expect(shell.calls.find((c) => c.cmd === 'tar')).toBeUndefined()
+  })
+
+  test('startEditing promotes a published skill (tmpfs) into a persistent draft', async () => {
+    // Published skill content present on tmpfs (as after a normal load).
+    fs.dirs.add('/tmp/skill-pub')
+    fs.files.set('/tmp/skill-pub/SKILL.md', 'published body')
+
+    const mgr = createManager(async () => {
+      throw new Error('startEditing should not fetch')
+    })
+    await mgr.startEditing('pub')
+
+    // Copied to draftBase via `cp -a` (preserves +x), re-symlinked, lock on NFS.
+    expect(shell.calls).toContainEqual({
+      cmd: 'cp',
+      args: ['-a', '/tmp/skill-pub/.', '/workspace/.skills-draft/skill-pub'],
+    })
+    expect(shell.calls).toContainEqual({
+      cmd: 'ln',
+      args: ['-s', '/workspace/.skills-draft/skill-pub', '/workspace/.claude/skills/pub'],
+    })
+    expect(fs.files.has('/workspace/.skills-draft/skill-pub/.editing')).toBe(true)
+    // The tmpfs copy is dropped; the draft is now authoritative.
+    expect(fs.dirs.has('/tmp/skill-pub')).toBe(false)
+  })
+
+  test('load reclaims a stale draft once the skill is published (enabled + not editing)', async () => {
+    // Draft dir lingers on NFS with no lock, and CP now lists it as enabled.
+    fs.dirs.add('/workspace/.skills-draft/skill-done')
+    fs.files.set('/workspace/.skills-draft/skill-done/SKILL.md', 'old draft')
+    fs.dirs.add('/workspace/.claude/skills/done')
+
+    const tarBuf = Buffer.from('fake-tar-gz')
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/workspaces/ws-1/skills'))
+        return jsonResponse({ skills: [{ name: 'done', id: 'sk-done' }] })
+      if (url.includes('/_cp/skills/sk-done/package')) return binaryResponse(tarBuf)
+      if (url.includes('/_cp/skills')) return jsonResponse([{ name: 'done' }])
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    const result = await createManager(fetchImpl).load()
+
+    // Stale NFS draft cleared; re-extracted onto tmpfs (staging dir under /tmp).
+    expect(fs.dirs.has('/workspace/.skills-draft/skill-done')).toBe(false)
+    const tarCall = shell.calls.find((c) => c.cmd === 'tar' && c.args[0] === 'xzf')
+    expect(tarCall!.args[1]).toMatch(/^\/tmp\/skill-done\.staging-/)
+    expect(result.loaded).toEqual(['done'])
+  })
+})

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -60,6 +60,14 @@ export interface SkillManagerOptions {
    */
   localBase?: string
   /**
+   * Persistent (NFS-backed) base directory for *draft* skills — unpublished
+   * edits that must survive pod rebuilds. When set, a draft's content lives at
+   * `draftBase/skill-{name}` (not tmpfs), so it is not lost when /tmp is wiped.
+   * Must be distinct from `localBase` and outside the dufs-served skills tree.
+   * When unset, drafts fall back to tmpfs (legacy behaviour: lost on rebuild).
+   */
+  draftBase?: string
+  /**
    * Whether to symlink skillsDir/{name} → localBase/skill-{name}.
    * true for claude-code & codex (NFS workspace), false if skillsDir is already local.
    */
@@ -123,6 +131,7 @@ export class SkillManager {
   private workspaceId: string
   private skillsDir: string
   private localBase: string
+  private draftBase: string | null
   private useSymlink: boolean
   private fetch: Fetcher
   private fs: Fs
@@ -146,6 +155,7 @@ export class SkillManager {
     this.workspaceId = opts.workspaceId
     this.skillsDir = opts.skillsDir
     this.localBase = opts.localBase ?? '/tmp'
+    this.draftBase = opts.draftBase ?? null
     this.useSymlink = opts.useSymlink ?? true
     this._filesBrowsePath = opts.filesBrowsePath ?? '/.claude/skills'
     this.fetch = opts.fetch
@@ -153,9 +163,30 @@ export class SkillManager {
     this.shell = opts.shell
   }
 
-  /** Local extraction directory for a skill. */
+  /**
+   * Content directory for a skill. Drafts (unpublished edits) live on the
+   * persistent draftBase so they survive pod rebuilds; published skills live on
+   * tmpfs (localBase) and are re-downloaded from CP after a wipe. The draftBase
+   * probe is a stat on an NFS path that outlives the pod, so this stays correct
+   * across rebuilds without any in-memory state to reconstruct.
+   */
   private localDir(name: string): string {
+    const db = this.draftBase
+    if (db && this.fs.exists(`${db}/skill-${name}`)) {
+      return `${db}/skill-${name}`
+    }
     return `${this.localBase}/skill-${name}`
+  }
+
+  /** A skill is a (persistent) draft iff its content dir exists under draftBase. */
+  private isDraft(name: string): boolean {
+    const db = this.draftBase
+    return db != null && this.fs.exists(`${db}/skill-${name}`)
+  }
+
+  /** Persistent draft content dir for a skill (caller must ensure draftBase is set). */
+  private draftDir(name: string): string {
+    return `${this.draftBase}/skill-${name}`
   }
 
   /** Lock file path for a skill. */
@@ -324,6 +355,14 @@ export class SkillManager {
         if (this.isEditing(name)) {
           editing.push(name)
           return
+        }
+
+        // Enabled + not editing, yet a persistent draft dir lingers → it was
+        // published (or replaced) elsewhere. Reclaim it so we re-materialise the
+        // active version on tmpfs instead of serving the stale draft off NFS.
+        if (this.draftBase && this.isDraft(name)) {
+          await this.fs.rm(this.draftDir(name))
+          await this.fs.rm(this.destDir(name))
         }
 
         const res = await this.downloadWithRetry(name)
@@ -540,9 +579,24 @@ export class SkillManager {
     if (!this.isEditable(name)) {
       throw new Error(`Not allowed to edit skill: ${name}`)
     }
-    const local = this.localDir(name)
-    if (!this.fs.exists(local)) {
+    const cur = this.localDir(name)
+    if (!this.fs.exists(cur)) {
       throw new Error(`Skill not found locally: ${name}`)
+    }
+    // Promote a published skill (content on tmpfs) into a persistent draft so
+    // the edit isn't lost on pod rebuild. `cp -a` preserves mode bits, so
+    // executable scripts in the skill keep their +x. No-op if it's already a
+    // draft or draftBase isn't configured.
+    if (this.draftBase && !this.isDraft(name)) {
+      const draft = this.draftDir(name)
+      await this.fs.rm(draft)
+      await this.fs.mkdir(draft)
+      await this.shell.exec('cp', ['-a', `${cur}/.`, draft])
+      if (this.useSymlink) {
+        await this.fs.rm(this.destDir(name))
+        await this.shell.exec('ln', ['-s', draft, this.destDir(name)])
+      }
+      await this.fs.rm(cur)
     }
     await this.fs.writeFile(this.lockPath(name), '')
   }
@@ -561,7 +615,11 @@ export class SkillManager {
   /** Create a new empty skill with a template SKILL.md. */
   async createDraft(name: string): Promise<void> {
     assertNotReserved(name)
-    const local = this.localDir(name)
+    // A brand-new skill is a draft from birth: place its content on the
+    // persistent draftBase (when configured) so it survives a pod rebuild
+    // before it is ever published. localDir() can't be used here because it
+    // probes for an existing draft dir that we are about to create.
+    const local = this.draftBase ? this.draftDir(name) : this.localDir(name)
     const dest = this.destDir(name)
 
     await this.fs.rm(local)
@@ -589,7 +647,8 @@ export class SkillManager {
   async remove(name: string): Promise<void> {
     assertNotReserved(name)
     await this.fs.rm(this.destDir(name))
-    await this.fs.rm(this.localDir(name))
+    await this.fs.rm(`${this.localBase}/skill-${name}`)
+    if (this.draftBase) await this.fs.rm(this.draftDir(name))
     await this.fs.rm(this.etagPath(name))
     await this.fs.rm(this.managedPath(name))
     this.editableSkills.delete(name)


### PR DESCRIPTION
## Problem

Unpublished skill edits lived only in the pod's tmpfs (`/tmp/skill-<name>`, symlinked into `.claude/skills`). The database is the source of truth only for *published* skills, so a pod rebuild (upgrade / restart / OOM) wiped any draft that had not been published — users lost in-progress skill edits.

## Change

Drafts now live on the persistent workspace volume at `/workspace/.skills-draft/skill-<name>` (content + `.editing` lock). Published skills stay on tmpfs and are re-downloaded from the control plane after a wipe. `isDraft` is a probe for the draft directory on the persistent volume, which outlives the pod — no in-memory state to reconstruct after a rebuild.

### Lifecycle

| State | Content | `.claude/skills/<name>` | After pod rebuild |
|---|---|---|---|
| Published (not editing) | tmpfs | symlink → tmpfs | re-downloaded from CP |
| Draft (editing / idle) | persistent volume | symlink → volume | **preserved, no-op** |

- `createDraft` — new skills are born on the persistent volume
- `startEditing` — promotes a published skill (`cp -a`, preserves +x) into a draft
- `load` — preserves drafts across rebuilds (pre-sweep / orphan-sweep already key off content-dir presence + the `.managed` marker); reclaims a stale draft once its skill is published (enabled + not editing → re-extract to tmpfs)
- `remove` — clears the persistent draft too

Both in-workspace edit paths (the agent CLI and the workspace skill app via dufs) write through the `.claude/skills/<name>` symlink, so this takes effect with **no frontend or control-plane changes**. Gated behind the new optional `draftBase`; without it the legacy tmpfs behaviour is unchanged.

## Notes / trade-offs

- Promoting a many-file published skill into a draft is a one-time synchronous `cp -a` (kept simple; can be made async later).
- Post-publish reclaim happens on the next `load()` (reload), not via a new callback endpoint.

## Test

`internal/agent-skills` unit tests: **29 passed** (24 existing + 5 new: create-on-volume, draft survives rebuild, editing recognised via lock, published→draft promotion, post-publish reclaim). Typecheck (claude-code + codex) and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
