### PR TITLE
fix(agent-skills): sweep leaked staging dirs on extract

### DIFF
--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -684,3 +684,48 @@ describe('SkillManager draft persistence (draftBase)', () => {
     expect(result.loaded).toEqual(['done'])
   })
 })
+
+describe('SkillManager staging cleanup', () => {
+  let fs: ReturnType<typeof createMemFs>
+  let shell: ReturnType<typeof createMemShell>
+
+  function createManager(fetchImpl: (url: string) => Promise<FetchResponse>) {
+    return new SkillManager({
+      cpUrl: 'http://cp:3000',
+      workspaceId: 'ws-1',
+      skillsDir: '/workspace/.claude/skills',
+      localBase: '/tmp',
+      useSymlink: true,
+      fetch: fetchImpl,
+      fs,
+      shell,
+    })
+  }
+
+  beforeEach(() => {
+    fs = createMemFs()
+    shell = createMemShell()
+  })
+
+  test('extract sweeps leaked .staging-* dirs for the same skill', async () => {
+    // Two leaked staging dirs from prior crashed/concurrent extracts.
+    fs.dirs.add('/tmp/skill-foo.staging-1-111')
+    fs.dirs.add('/tmp/skill-foo.staging-1-222')
+    // An unrelated skill's staging must NOT be touched.
+    fs.dirs.add('/tmp/skill-bar.staging-1-333')
+
+    const tarBuf = Buffer.from('fake-tar-gz')
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/workspaces/ws-1/skills')) return jsonResponse({ skills: ['foo'] })
+      if (url.includes('/_cp/skills/foo')) return binaryResponse(tarBuf)
+      if (url.includes('/_cp/skills')) return jsonResponse([{ name: 'foo' }])
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    await createManager(fetchImpl).load()
+
+    expect(fs.dirs.has('/tmp/skill-foo.staging-1-111')).toBe(false)
+    expect(fs.dirs.has('/tmp/skill-foo.staging-1-222')).toBe(false)
+    // Different skill untouched.
+    expect(fs.dirs.has('/tmp/skill-bar.staging-1-333')).toBe(true)
+  })
+})

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -525,8 +525,22 @@ export class SkillManager {
     const dest = this.destDir(name)
     const staging = `${local}.staging-${process.pid}-${Date.now()}`
 
-    // Extract into staging (clean any stale staging from a prior crash).
-    await this.fs.rm(staging)
+    // Sweep leaked staging dirs for this skill before extracting. Each staging
+    // dir carries a unique pid/timestamp suffix, so the old single rm of the
+    // current name never caught siblings left behind by a crashed or concurrent
+    // extract — they accumulated in localBase (hundreds were observed in prod).
+    // Clear them all, then stage fresh.
+    try {
+      const prefix = `skill-${name}.staging-`
+      const entries = await this.fs.readdir(this.localBase)
+      await Promise.all(
+        entries
+          .filter((e) => e.startsWith(prefix))
+          .map((e) => this.fs.rm(`${this.localBase}/${e}`)),
+      )
+    } catch {
+      // Best-effort
+    }
     await this.fs.mkdir(staging)
     const tmpFile = `${staging}/.skill.tar.gz`
     try {


### PR DESCRIPTION
## Problem

`extractAtomic` stages each download into `${localDir}.staging-<pid>-<timestamp>` then renames it into place. The comment claimed it cleaned "stale staging from a prior crash", but `rm(staging)` only removed the *current* uniquely-named dir — staging dirs left behind by a crashed or concurrent extract carried different suffixes and were never collected, so they piled up in `localBase`.

A read-only scan of live agent pods found **399 leaked `/tmp/skill-*.staging-*` dirs across 22 pods** (one pod had 100+).

## Fix

Before staging a fresh extract, sweep all `skill-<name>.staging-*` entries for that skill from `localBase`. Best-effort, and scoped to the skill being extracted (other skills' staging dirs untouched).

## Test

`internal/agent-skills`: **30 passed** (+1 new: leaked staging dirs for the skill are swept while a different skill's staging is left intact). Typecheck (claude-code) clean.

Note: this stops *new* leaks. Existing leftovers on running pods are cleared out-of-band separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
