### PR TITLE
chore(k8s): bump workspace template version 5 -> 6 for relaxed probes

### DIFF
--- a/control-plane/src/services/k8s.ts
+++ b/control-plane/src/services/k8s.ts
@@ -66,7 +66,13 @@ const NAME_PREFIX = 'tos'
 //     reconcile no longer fires from attach/detach (count is always >= 1).
 // v5: afs-fuse sidecar gains AFS_BOOTSTRAP_URL env so it can self-heal
 //     mounts on pod replacement without relying on cp's push path.
-export const CURRENT_TEMPLATE_VERSION = 5
+// v6: agent probes relaxed — added a startupProbe (up to 600s boot grace)
+//     and widened liveness/readiness timeouts so skill-heavy boots and
+//     event-loop saturation no longer trip a SIGKILL. The probe spec
+//     changed in buildDeploymentSpec without a version bump, so existing
+//     v5 Deployments kept the old 1s-timeout / no-startupProbe config and
+//     CrashLoopBackOff'd; bumping forces reconcile to rebuild them.
+export const CURRENT_TEMPLATE_VERSION = 6
 const TEMPLATE_VERSION_ANNOTATION = 'agent-platform/workspace-version'
 const MEMORY_FUSE_CONTAINER_NAME = 'memory-fuse'
 


### PR DESCRIPTION
## What

Bump `CURRENT_TEMPLATE_VERSION` 5 → 6.

## Why

The agent probe relaxation (added `startupProbe` with up to 600s boot grace, widened liveness/readiness timeouts to 5s/3s) landed in `buildDeploymentSpec` **without** bumping the template version.

`reconcileWorkspacePod` only rebuilds a Deployment when its `agent-platform/workspace-version` annotation is behind `CURRENT_TEMPLATE_VERSION`. So workspaces already stamped v5 were considered in-sync and kept the old probe spec (`timeoutSeconds: 1`, no startupProbe). Under skill-heavy boots or single-event-loop saturation those `/health` GETs miss the 1s window → liveness SIGKILLs the agent container → CrashLoopBackOff.

Observed in prod: 18 agent pods stuck at `2/3` Ready, `exitCode 137`, 0 OOMKilled — pure probe kills. Two of them already annotated v5, so reconcile would never have healed them.

Bumping to v6 marks all ≤5 Deployments stale so reconcile regenerates them with the relaxed probes.

## Note

Reconcile is only triggered on workspace config change (no periodic loop), so existing Deployments rebuild lazily on their next config update / start. A one-shot reconcile sweep to force-heal the current CrashLooping set is tracked separately.