### PR TITLE
feat(workspaces): surface template drift + user-facing rebuild action

### DIFF
--- a/control-plane/src/routes/workspaces/lifecycle.ts
+++ b/control-plane/src/routes/workspaces/lifecycle.ts
@@ -3,7 +3,7 @@ import type { AppEnv } from '../../lib/types'
 import { resetAllSessionsIdle } from '../../services/db/sessions'
 import { getWorkspace, updateWorkspace } from '../../services/db/workspaces'
 import * as k8s from '../../services/k8s'
-import { startWorkspaceInstance } from '../../services/workspace-reconcile'
+import { reconcileWorkspacePod, startWorkspaceInstance } from '../../services/workspace-reconcile'
 import { canManage, interruptAllSessions } from './_shared'
 
 const lifecycle = new OpenAPIHono<AppEnv>()
@@ -16,6 +16,13 @@ const StartResponseSchema = z.object({
 })
 
 const SuccessSchema = z.object({ success: z.boolean() })
+
+const RebuildResponseSchema = z.object({
+  // false when the workspace was already in sync (no-op).
+  rebuilt: z.boolean(),
+  // Diagnostic drift summary when rebuilt; omitted otherwise. Not shown to users.
+  reason: z.string().optional(),
+})
 
 const WorkspaceIdParam = z.object({
   id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
@@ -108,6 +115,61 @@ lifecycle.openapi(stopRoute, async (c) => {
     return c.json({ success: true }, 200)
   } catch (e: any) {
     return c.json({ error: e.message }, 500)
+  }
+})
+
+// ── POST /:id/rebuild ──────────────────────────────────────────────────────
+const rebuildRoute = createRoute({
+  method: 'post',
+  path: '/{id}/rebuild',
+  tags: ['workspaces'],
+  summary: 'Rebuild a workspace to the current platform template',
+  description:
+    "Recreates the workspace's Deployment when it drifts from the current " +
+    'desired spec (template version, agent image, sidecars), picking up ' +
+    'platform updates. DISRUPTIVE: the pod is replaced, interrupting any ' +
+    'in-flight session and clearing ephemeral (tmpfs) state. No-op when ' +
+    'already in sync.',
+  security: [{ bearerAuth: [] }],
+  request: { params: WorkspaceIdParam },
+  responses: {
+    200: {
+      description: 'Rebuild evaluated (rebuilt=false when already in sync)',
+      content: { 'application/json': { schema: RebuildResponseSchema } },
+    },
+    404: {
+      description: 'Workspace not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+    500: {
+      description: 'Internal error',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+lifecycle.openapi(rebuildRoute, async (c) => {
+  const currentUser = c.get('user')
+  const { id } = c.req.valid('param')
+  const workspace = await getWorkspace(id)
+  if (!workspace || !canManage(workspace, currentUser)) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+
+  try {
+    const { rebuilt, reason } = await reconcileWorkspacePod(workspace.id)
+    if (rebuilt) {
+      console.log(`[Rebuild] workspace=${id} rebuilt: ${reason}`)
+      // The old pod is gone — clear stale chat status and reflect that the
+      // instance is coming back up so the UI shows it re-launching.
+      await resetAllSessionsIdle(id)
+      await updateWorkspace(id, { status: 'starting' })
+    }
+    return c.json({ rebuilt, reason }, 200)
+  } catch (e: any) {
+    console.error('[Rebuild] Failed:', e)
+    const msg = e?.body?.message || e?.message || 'Unknown error'
+    return c.json({ error: msg }, 500)
   }
 })
 

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -14,6 +14,7 @@ import { getTagAssignmentsForUser } from '../../services/db/tags'
 import type { SessionWithPreview } from '../../services/db/types'
 import { getWorkspace, getWorkspaceConfig, listWorkspaces } from '../../services/db/workspaces'
 import * as k8s from '../../services/k8s'
+import { computeWorkspaceDrift } from '../../services/workspace-reconcile'
 import { canManage, toApiWorkspace } from './_shared'
 
 function toApiSession(s: SessionWithPreview) {
@@ -266,7 +267,10 @@ read.openapi(getStatusRoute, async (c) => {
     return c.json({ error: 'Workspace not found' }, 404)
   }
   try {
-    const status = await k8s.getInstanceStatus(workspace.id)
+    const [status, drift] = await Promise.all([
+      k8s.getInstanceStatus(workspace.id),
+      computeWorkspaceDrift(workspace.id),
+    ])
     return c.json(
       {
         deployment: status.deployment.exists
@@ -280,6 +284,11 @@ read.openapi(getStatusRoute, async (c) => {
         pods: { total: status.pods.total, ready: status.pods.ready },
         warnings: status.warnings,
         conditions: status.conditions,
+        rebuild: {
+          current: drift.current,
+          latest: drift.latest,
+          available: drift.hasInstance && drift.reasons.length > 0,
+        },
       },
       200,
     )

--- a/control-plane/src/services/workspace-reconcile.ts
+++ b/control-plane/src/services/workspace-reconcile.ts
@@ -15,34 +15,46 @@ async function getDesiredSpec(workspaceId: string): Promise<DesiredSpec> {
   }
 }
 
+interface WorkspaceDrift {
+  /** Deployed template version (annotation), or null when no Deployment exists. */
+  current: number | null
+  /** Desired template version (CURRENT_TEMPLATE_VERSION). */
+  latest: number
+  /** Whether a Deployment exists for this workspace at all. */
+  hasInstance: boolean
+  /**
+   * Human/diagnostic descriptions of each drifted marker. Empty => in sync.
+   * Internal only — not surfaced to end users (they see a boolean).
+   */
+  reasons: string[]
+}
+
 /**
- * Bring the workspace's Deployment in line with the current desired spec:
- * template_version, agent image, and memory-fuse sidecar presence. Rebuilds
- * (delete + recreate Deployment) if any marker drifts. Returns `rebuilt: false`
- * when the workspace has no Deployment yet (caller should use createInstance).
+ * Read-only drift check: compare the workspace's Deployment against the
+ * current desired spec (template_version, agent image, memory-fuse sidecar)
+ * WITHOUT mutating anything. Shared source of truth for "is an update
+ * available" — consumed by the status endpoint (read), the user-facing
+ * rebuild action, and the admin batch sweep. {@link reconcileWorkspacePod}
+ * is the write path built on top of it.
  *
  * Drift sources:
  *   - template_version annotation < CURRENT_TEMPLATE_VERSION (structural bump)
  *   - agent image != getAgentImage(desired agent_type)
  *   - memory-fuse sidecar present != cluster provides MEMORY_FUSE_IMAGE
  *     (only surfaces on v3 pods built before sidecar became unconditional)
- *
- * The PVC and Service are preserved across rebuilds — only the Deployment is
- * replaced.
  */
-export async function reconcileWorkspacePod(
-  workspaceId: string,
-): Promise<{ rebuilt: boolean; reason?: string }> {
+export async function computeWorkspaceDrift(workspaceId: string): Promise<WorkspaceDrift> {
+  const latest = k8s.CURRENT_TEMPLATE_VERSION
   const markers = await k8s.getInstanceSpecMarkers(workspaceId)
-  if (!markers) return { rebuilt: false }
+  if (!markers) return { current: null, latest, hasInstance: false, reasons: [] }
 
   const desired = await getDesiredSpec(workspaceId)
   const desiredImage = k8s.getAgentImage(desired.agentType)
   const desiredSidecar = k8s.isMemoryFuseAvailable()
 
   const reasons: string[] = []
-  if ((markers.templateVersion ?? 0) < k8s.CURRENT_TEMPLATE_VERSION) {
-    reasons.push(`template_version ${markers.templateVersion} < ${k8s.CURRENT_TEMPLATE_VERSION}`)
+  if ((markers.templateVersion ?? 0) < latest) {
+    reasons.push(`template_version ${markers.templateVersion} < ${latest}`)
   }
   if (markers.agentImage !== desiredImage) {
     reasons.push(`image ${markers.agentImage} != ${desiredImage}`)
@@ -51,10 +63,25 @@ export async function reconcileWorkspacePod(
     reasons.push(`memory-fuse sidecar ${markers.hasMemoryFuseSidecar} != cluster ${desiredSidecar}`)
   }
 
-  if (reasons.length === 0) return { rebuilt: false }
+  return { current: markers.templateVersion, latest, hasInstance: true, reasons }
+}
 
+/**
+ * Bring the workspace's Deployment in line with the current desired spec by
+ * rebuilding (delete + recreate Deployment) when any marker drifts — see
+ * {@link computeWorkspaceDrift}. Returns `rebuilt: false` when the workspace
+ * has no Deployment yet (caller should use createInstance) or is already in
+ * sync. The PVC and Service are preserved — only the Deployment is replaced.
+ */
+export async function reconcileWorkspacePod(
+  workspaceId: string,
+): Promise<{ rebuilt: boolean; reason?: string }> {
+  const drift = await computeWorkspaceDrift(workspaceId)
+  if (!drift.hasInstance || drift.reasons.length === 0) return { rebuilt: false }
+
+  const desired = await getDesiredSpec(workspaceId)
   await k8s.rebuildInstance(workspaceId, desired.agentType, desired.resources)
-  return { rebuilt: true, reason: reasons.join('; ') }
+  return { rebuilt: true, reason: drift.reasons.join('; ') }
 }
 
 /**

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -273,6 +273,15 @@ export const ApiK8sStatusSchema = z.object({
   conditions: z.array(
     z.object({ type: z.string(), status: z.boolean(), message: z.string().optional() }),
   ),
+  // Whether the workspace's runtime is behind the current platform template
+  // and can be rebuilt to pick it up. `available` is the only field the UI
+  // needs; `current`/`latest` are exposed for diagnostics. The underlying
+  // drift reasons are intentionally NOT surfaced to end users.
+  rebuild: z.object({
+    current: z.number().int().nullable(),
+    latest: z.number().int(),
+    available: z.boolean(),
+  }),
 })
 
 export type ApiK8sStatus = z.infer<typeof ApiK8sStatusSchema>

--- a/web/src/components/workspace/WorkspaceSettingsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSettingsPanel.tsx
@@ -42,6 +42,7 @@ import { useSetWorkspaceTags, useTags } from '@/hooks/useTags'
 import { useWorkspaceConfig } from '@/hooks/useWorkspaceConfig'
 import {
   usePatchWorkspace,
+  useRebuildWorkspace,
   useRestartWorkspace,
   useStartWorkspace,
   useStopWorkspace,
@@ -489,15 +490,17 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
   const startMutation = useStartWorkspace()
   const stopMutation = useStopWorkspace()
   const restartMutation = useRestartWorkspace()
+  const rebuildMutation = useRebuildWorkspace()
+  const [rebuildConfirmOpen, setRebuildConfirmOpen] = useState(false)
   const isRunning = workspace?.status === 'running' || workspace?.status === 'starting'
   const lifecyclePending =
     startMutation.isPending || stopMutation.isPending || restartMutation.isPending
 
-  // Poll K8s status only while the workspace is mid-transition. Surfaces
-  // FailedScheduling / image pull / OOM reasons that otherwise leave the
-  // workspace stuck in 'starting' with no visible explanation.
+  // Poll K8s status while the workspace is mid-transition (to surface
+  // FailedScheduling / image pull / OOM reasons behind a stuck 'starting')
+  // and while running (to detect template drift → "update available").
   const { data: k8sStatus } = useWorkspaceStatus(workspaceId, {
-    enabled: workspace?.status === 'starting',
+    enabled: workspace?.status === 'starting' || workspace?.status === 'running',
   })
   const startupWarnings = k8sStatus?.warnings ?? []
   const startupFailedConditions = (k8sStatus?.conditions ?? []).filter(
@@ -506,6 +509,21 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
   const showStartupAlert =
     workspace?.status === 'starting' &&
     (startupWarnings.length > 0 || startupFailedConditions.length > 0)
+  // Runtime is behind the current platform template — offer a rebuild.
+  const updateAvailable = (k8sStatus?.rebuild?.available ?? false) && !lifecyclePending
+
+  async function handleRebuild() {
+    try {
+      const res = await rebuildMutation.mutateAsync(workspaceId)
+      toast.success(
+        res.rebuilt
+          ? t('components.settings.rebuild.toasts.started')
+          : t('components.settings.rebuild.toasts.upToDate'),
+      )
+    } finally {
+      setRebuildConfirmOpen(false)
+    }
+  }
 
   // Persisted: which settings nav page is showing — "where am I".
   const [activeSection, setActiveSection] = useInstancePersistentState<SectionKey>(
@@ -1079,6 +1097,53 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
         {/* Center content */}
         <ScrollArea className="min-w-0 flex-1">
           <div className="px-6 py-5">
+            {updateAvailable && (
+              <Alert className="mb-4">
+                <ArrowUpCircle className="h-4 w-4 text-primary" strokeWidth={2} />
+                <AlertTitle className="text-sm">
+                  {t('components.settings.rebuild.available.title')}
+                </AlertTitle>
+                <AlertDescription className="mt-1.5">
+                  <p className="text-xs text-muted-foreground">
+                    {t('components.settings.rebuild.available.description')}
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="mt-2 h-7 gap-1.5 px-3 text-xs"
+                    onClick={() => setRebuildConfirmOpen(true)}
+                  >
+                    <ArrowUpCircle className="h-3 w-3" strokeWidth={2} />
+                    {t('components.settings.rebuild.available.action')}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
+            <Dialog open={rebuildConfirmOpen} onOpenChange={setRebuildConfirmOpen}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{t('components.settings.rebuild.confirm.title')}</DialogTitle>
+                  <DialogDescription>
+                    {t('components.settings.rebuild.confirm.description')}
+                  </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setRebuildConfirmOpen(false)}
+                    disabled={rebuildMutation.isPending}
+                  >
+                    {t('components.settings.rebuild.confirm.cancel')}
+                  </Button>
+                  <Button size="sm" onClick={handleRebuild} disabled={rebuildMutation.isPending}>
+                    {rebuildMutation.isPending
+                      ? t('components.settings.rebuild.confirm.pending')
+                      : t('components.settings.rebuild.confirm.confirm')}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
             {showStartupAlert && (
               <Alert variant="destructive" className="mb-4">
                 <AlertTriangle className="h-4 w-4" />

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -86,6 +86,26 @@ export function useRestartWorkspace() {
 }
 
 /**
+ * Rebuilds the workspace's runtime when it drifts from the current platform
+ * template (relaxed probes, new sidecars, image). Disruptive — the pod is
+ * replaced. No-op server-side when already in sync.
+ */
+export function useRebuildWorkspace() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) => api.rebuildWorkspace(id),
+    onSuccess: (_res, id) => {
+      queryClient.invalidateQueries({ queryKey: ['workspaces'] })
+      queryClient.invalidateQueries({ queryKey: ['workspace-status', id] })
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    },
+  })
+}
+
+/**
  * Polls the K8s status endpoint while a workspace is in a transient state
  * (e.g. `starting`). Surfaces pod warnings like FailedScheduling so users
  * see *why* a start is hanging instead of an indefinite spinner.

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -281,6 +281,12 @@ class ApiClient {
     return this.request<K8sResourceStatus>(`/workspaces/${id}/status`)
   }
 
+  async rebuildWorkspace(id: string): Promise<{ rebuilt: boolean; reason?: string }> {
+    return this.request<{ rebuilt: boolean; reason?: string }>(`/workspaces/${id}/rebuild`, {
+      method: 'POST',
+    })
+  }
+
   async getWorkspaceMessages(id: string, sessionId?: string): Promise<ApiMessage[]> {
     const params = sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : ''
     return this.request<ApiMessage[]>(`/workspaces/${id}/messages${params}`)

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3349,6 +3349,24 @@
       "startupAlert": {
         "title": "Workspace is having trouble starting"
       },
+      "rebuild": {
+        "available": {
+          "title": "A new workspace version is available",
+          "description": "The platform runtime has been updated. Rebuild the workspace to pick up the latest version.",
+          "action": "Update workspace"
+        },
+        "confirm": {
+          "title": "Update workspace?",
+          "description": "Updating restarts the workspace pod: any in-progress session is interrupted, ephemeral files are cleared, and the runtime takes a few minutes to come back up.",
+          "cancel": "Cancel",
+          "confirm": "Update now",
+          "pending": "Updating…"
+        },
+        "toasts": {
+          "started": "Workspace update started",
+          "upToDate": "Workspace is already up to date"
+        }
+      },
       "resizeConfirm": {
         "title": "Restart workspace to apply new size?",
         "description": "Changing the compute size restarts the workspace pod. Any in-progress session will be interrupted. The new size takes effect after you click Save.",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3373,6 +3373,24 @@
       "startupAlert": {
         "title": "工作空间启动异常"
       },
+      "rebuild": {
+        "available": {
+          "title": "工作空间有新版本",
+          "description": "平台运行环境已更新，重建工作空间即可获取最新版本。",
+          "action": "更新工作空间"
+        },
+        "confirm": {
+          "title": "更新工作空间？",
+          "description": "更新会重启工作空间的 pod：正在进行的 session 会被中断，临时文件会清空，环境需要几分钟重新就绪。",
+          "cancel": "取消",
+          "confirm": "立即更新",
+          "pending": "更新中…"
+        },
+        "toasts": {
+          "started": "工作空间更新已开始",
+          "upToDate": "工作空间已是最新版本"
+        }
+      },
       "resizeConfirm": {
         "title": "重启工作空间以应用新规格？",
         "description": "切换计算规格会重启工作空间的 pod，正在进行的 session 会被中断。新规格在点击保存后才会生效。",


### PR DESCRIPTION
## What

Productizes workspace template-version drift as a first-class workspace capability — observe "update available" + one-click rebuild — rather than a rollout-only concern.

**Backend only** (web UI + admin batch sweep are follow-ups; this is the shared API foundation).

## Changes

- **Shared core**: extract `computeWorkspaceDrift(wsId)` — read-only source of truth for whether a workspace is behind the current desired spec (template_version / agent image / memory-fuse sidecar). `reconcileWorkspacePod()` is now the write path built on top of it.
- **Read**: `GET /:id/status` gains `rebuild: { current, latest, available }`. `available` is the only field the UI needs; raw drift reasons stay internal/diagnostic.
- **Write**: `POST /:id/rebuild` (owner-authorized) recreates the Deployment when it drifts. Disruptive (pod replaced, tmpfs cleared), no-op when in sync; clears stale session chat status and marks the instance `starting`.

## Why

Running workspaces don't self-heal to a new template (reconcile only fires on config-change / start, no periodic loop). This gives users an explicit "your workspace is behind, update it" affordance, and gives admin/rollout a clean per-workspace primitive to batch over.

## Follow-ups (separate PRs, this is the foundation)
- Web UI: status banner + rebuild button + confirm dialog (disruption consent)
- Admin batch sweep `POST /api/admin/cluster/rebuild-stale` + rollout rewiring

## Test plan
Merged only after a real rollout + manual verification (per agreed sequencing).