### PR TITLE
feat(workspaces): template-version drift, one-click rebuild, admin sweep + fixes

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -8,12 +8,18 @@ COPY .npmrc /root/.npmrc
 
 WORKDIR /app/web
 
-# Copy frontend package files (lockfile excluded — npm resolves platform-specific
-# optional deps like @rollup/rollup-linux-x64-gnu fresh on each build)
-COPY web/package.json ./
+# Copy frontend package files INCLUDING the lockfile. A lockfile-less install
+# resolves a fresh, non-reproducible tree that can duplicate singleton-context
+# packages (e.g. two @radix-ui/react-tooltip copies → "must be used within
+# TooltipProvider" at runtime). npm ci pins the exact deduped tree and still
+# installs the correct per-platform optional deps (@rollup/rollup-linux-x64-gnu)
+# from the lockfile's os/cpu metadata.
+COPY web/package.json web/package-lock.json ./
 
-# Install frontend dependencies
-RUN npm install
+# --legacy-peer-deps mirrors the local web/.npmrc: @base-ui/react (vendored
+# Extend UI viewers) declares a peerOptional date-fns@^4 while the app pins
+# date-fns@3 — an unused/harmless conflict that otherwise aborts with ERESOLVE.
+RUN npm ci --legacy-peer-deps
 
 # Copy frontend source
 COPY web/tsconfig.json web/vite.config.ts web/tailwind.config.js web/postcss.config.js web/index.html ./

--- a/control-plane/migrations/118_workspace_runtime_version.sql
+++ b/control-plane/migrations/118_workspace_runtime_version.sql
@@ -1,0 +1,7 @@
+-- Cache the deployed runtime template version on the workspace row so that
+-- "an update is available" becomes a pure DB comparison against
+-- CURRENT_TEMPLATE_VERSION, instead of a live k8s read on every status
+-- request. cp writes it when it creates/rebuilds the Deployment, and the
+-- reconcile loop syncs it from the Deployment's workspace-version annotation
+-- (which also backfills existing rows). NULL = unknown/legacy → no prompt.
+ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS runtime_version integer;

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -178,11 +178,14 @@ app.use('/*', async (c, next) => {
   const isApiRequest = path.startsWith('/api/')
   const isProxyRequest = path.startsWith('/_proxy/')
 
-  // CI/rollout bypass for plugin admin endpoints — the static
-  // PLUGIN_ADMIN_TOKEN env grants both auth and admin role for the route's
-  // own check below. No user system involvement.
+  // CI/rollout bypass for ops admin endpoints — the static PLUGIN_ADMIN_TOKEN
+  // env grants both auth and admin role for the route's own check below. No
+  // user system involvement. Covers the plugin admin API and the rollout's
+  // batch workspace rebuild sweep.
   if (
-    (path === '/api/plugins/admin' || path.startsWith('/api/plugins/admin/')) &&
+    (path === '/api/plugins/admin' ||
+      path.startsWith('/api/plugins/admin/') ||
+      path === '/api/admin/cluster/rebuild-stale') &&
     process.env.PLUGIN_ADMIN_TOKEN
   ) {
     const headerToken = c.req.header('x-plugin-admin-token')

--- a/control-plane/src/lib/reconcile.ts
+++ b/control-plane/src/lib/reconcile.ts
@@ -58,9 +58,20 @@ async function fullReconcile(): Promise<string> {
     t2 = Date.now()
 
     for (const ws of allWorkspaces) {
-      const resolved = k8s.resolveDeploymentStatus(deployments.get(ws.id))
+      const dep = deployments.get(ws.id)
+      const resolved = k8s.resolveDeploymentStatus(dep)
       if (resolved !== ws.status) {
         await applyStatusChange(ws.id, resolved, ws.status)
+        dbUpdates++
+      }
+      // Cache the deployed template version so "update available" is a pure DB
+      // comparison (no live k8s read per status request). Backfills legacy rows
+      // and catches annotations changed outside cp (e.g. manual patches). Only
+      // sync when the Deployment actually carries a version — don't clobber the
+      // last-known value when the Deployment is absent/stopped.
+      const ver = k8s.deploymentTemplateVersion(dep)
+      if (ver !== null && ver !== ws.runtime_version) {
+        await updateWorkspace(ws.id, { runtime_version: ver })
         dbUpdates++
       }
     }

--- a/control-plane/src/routes/admin/cluster.ts
+++ b/control-plane/src/routes/admin/cluster.ts
@@ -1,6 +1,9 @@
 import * as k8s from '@kubernetes/client-node'
 import { Hono } from 'hono'
 import type { AppEnv } from '../../lib/types'
+import { listStreamingWorkspaceIds } from '../../services/db/sessions'
+import * as k8sService from '../../services/k8s'
+import { computeWorkspaceDrift, reconcileWorkspacePod } from '../../services/workspace-reconcile'
 
 const cluster = new Hono<AppEnv>()
 
@@ -147,6 +150,97 @@ cluster.get('/', async (c) => {
     total_workspaces: deploymentsRes.body.items.length,
     total_sandboxes: totalSandboxes,
   })
+})
+
+/**
+ * Batch "rebuild stale" sweep — the fleet/ops counterpart of the per-workspace
+ * POST /workspaces/:id/rebuild action, built on the SAME drift core. For every
+ * agent workspace whose Deployment drifts from the current platform template,
+ * reconcile (rebuild) it; for ones already in sync, roll the pods so a moving
+ * `:latest` image is re-pulled. Workspaces with a live streaming turn are
+ * skipped so a rollout never kills an in-flight session.
+ *
+ * Admin-authorized; also callable headless by the rollout pipeline via the
+ * static x-plugin-admin-token bypass (see index.ts).
+ *
+ * Body (all optional): {
+ *   agentType?: string,   // only this agent type (by image); default all
+ *   activeWindow?: string,// PG interval for the streaming skip; default '10 minutes'
+ *   concurrency?: number, // parallel reconciles; default 16
+ *   dryRun?: boolean,     // report drift without mutating; default false
+ * }
+ */
+cluster.post('/rebuild-stale', async (c) => {
+  const body = await c.req.json().catch(() => ({}) as Record<string, unknown>)
+  const agentType = typeof body.agentType === 'string' ? body.agentType : undefined
+  const activeWindow = typeof body.activeWindow === 'string' ? body.activeWindow : '10 minutes'
+  const concurrency = Math.max(1, Math.min(32, Number(body.concurrency) || 16))
+  const dryRun = body.dryRun === true
+
+  const wantImage = agentType ? k8sService.getAgentImage(agentType) : null
+
+  const { deployments } = await k8sService.listWorkspaceDeployments()
+  const targets: string[] = []
+  for (const [wsId, dep] of deployments) {
+    if (wantImage) {
+      const image = dep.spec?.template?.spec?.containers?.find((x) => x.name === 'agent')?.image
+      if (image !== wantImage) continue
+    }
+    targets.push(wsId)
+  }
+
+  const streaming = new Set(await listStreamingWorkspaceIds(activeWindow))
+
+  const result = {
+    total: targets.length,
+    rebuilt: [] as string[],
+    restarted: [] as string[],
+    inSync: 0,
+    skipped: [] as string[],
+    failed: [] as { workspaceId: string; error: string }[],
+  }
+
+  let cursor = 0
+  async function worker() {
+    while (cursor < targets.length) {
+      const wsId = targets[cursor++]
+      if (streaming.has(wsId)) {
+        result.skipped.push(wsId)
+        continue
+      }
+      try {
+        const drift = await computeWorkspaceDrift(wsId)
+        if (!drift.hasInstance) continue
+        if (drift.reasons.length > 0) {
+          if (dryRun) {
+            result.rebuilt.push(wsId)
+          } else {
+            const { rebuilt } = await reconcileWorkspacePod(wsId)
+            if (rebuilt) result.rebuilt.push(wsId)
+            else result.inSync++
+          }
+        } else if (dryRun) {
+          result.inSync++
+        } else {
+          // In sync, but roll the pod so a moving :latest tag is re-pulled.
+          await k8sService.restartInstance(wsId)
+          result.restarted.push(wsId)
+        }
+      } catch (e: any) {
+        result.failed.push({ workspaceId: wsId, error: e?.message || String(e) })
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, targets.length) }, worker))
+
+  console.log(
+    `[rebuild-stale] agentType=${agentType ?? 'all'} dryRun=${dryRun} total=${result.total} ` +
+      `rebuilt=${result.rebuilt.length} restarted=${result.restarted.length} ` +
+      `inSync=${result.inSync} skipped=${result.skipped.length} failed=${result.failed.length}`,
+  )
+
+  return c.json(result, result.failed.length > 0 ? 207 : 200)
 })
 
 export default cluster

--- a/control-plane/src/routes/workspaces/_shared.ts
+++ b/control-plane/src/routes/workspaces/_shared.ts
@@ -2,6 +2,7 @@ import type { ApiWorkspace } from '../../../../internal/types/api'
 import { getWorkspaceAddress } from '../../lib/workspace-address'
 import { listActiveSessionIds } from '../../services/db/sessions'
 import type { Workspace } from '../../services/db/types'
+import { CURRENT_TEMPLATE_VERSION } from '../../services/k8s'
 
 /** Check if user can manage (edit/delete/start/stop) a workspace */
 export function canManage(workspace: Workspace, user: { sub: string; role: string }): boolean {
@@ -70,5 +71,8 @@ export function toApiWorkspace(
     active_agent_sessions: w.active_agent_sessions ?? 0,
     active_human_sessions: w.active_human_sessions ?? 0,
     active_sessions: w.active_sessions ?? [],
+    // A rebuild/update is available when the deployed runtime version is known
+    // and behind the current platform template. Pure DB comparison — no k8s.
+    rebuild_available: w.runtime_version != null && w.runtime_version < CURRENT_TEMPLATE_VERSION,
   }
 }

--- a/control-plane/src/routes/workspaces/lifecycle.ts
+++ b/control-plane/src/routes/workspaces/lifecycle.ts
@@ -3,7 +3,7 @@ import type { AppEnv } from '../../lib/types'
 import { resetAllSessionsIdle } from '../../services/db/sessions'
 import { getWorkspace, updateWorkspace } from '../../services/db/workspaces'
 import * as k8s from '../../services/k8s'
-import { startWorkspaceInstance } from '../../services/workspace-reconcile'
+import { reconcileWorkspacePod, startWorkspaceInstance } from '../../services/workspace-reconcile'
 import { canManage, interruptAllSessions } from './_shared'
 
 const lifecycle = new OpenAPIHono<AppEnv>()
@@ -16,6 +16,13 @@ const StartResponseSchema = z.object({
 })
 
 const SuccessSchema = z.object({ success: z.boolean() })
+
+const RebuildResponseSchema = z.object({
+  // false when the workspace was already in sync (no-op).
+  rebuilt: z.boolean(),
+  // Diagnostic drift summary when rebuilt; omitted otherwise. Not shown to users.
+  reason: z.string().optional(),
+})
 
 const WorkspaceIdParam = z.object({
   id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
@@ -108,6 +115,61 @@ lifecycle.openapi(stopRoute, async (c) => {
     return c.json({ success: true }, 200)
   } catch (e: any) {
     return c.json({ error: e.message }, 500)
+  }
+})
+
+// ── POST /:id/rebuild ──────────────────────────────────────────────────────
+const rebuildRoute = createRoute({
+  method: 'post',
+  path: '/{id}/rebuild',
+  tags: ['workspaces'],
+  summary: 'Rebuild a workspace to the current platform template',
+  description:
+    "Recreates the workspace's Deployment when it drifts from the current " +
+    'desired spec (template version, agent image, sidecars), picking up ' +
+    'platform updates. DISRUPTIVE: the pod is replaced, interrupting any ' +
+    'in-flight session and clearing ephemeral (tmpfs) state. No-op when ' +
+    'already in sync.',
+  security: [{ bearerAuth: [] }],
+  request: { params: WorkspaceIdParam },
+  responses: {
+    200: {
+      description: 'Rebuild evaluated (rebuilt=false when already in sync)',
+      content: { 'application/json': { schema: RebuildResponseSchema } },
+    },
+    404: {
+      description: 'Workspace not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+    500: {
+      description: 'Internal error',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+lifecycle.openapi(rebuildRoute, async (c) => {
+  const currentUser = c.get('user')
+  const { id } = c.req.valid('param')
+  const workspace = await getWorkspace(id)
+  if (!workspace || !canManage(workspace, currentUser)) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+
+  try {
+    const { rebuilt, reason } = await reconcileWorkspacePod(workspace.id)
+    if (rebuilt) {
+      console.log(`[Rebuild] workspace=${id} rebuilt: ${reason}`)
+      // The old pod is gone — clear stale chat status and reflect that the
+      // instance is coming back up so the UI shows it re-launching.
+      await resetAllSessionsIdle(id)
+      await updateWorkspace(id, { status: 'starting' })
+    }
+    return c.json({ rebuilt, reason }, 200)
+  } catch (e: any) {
+    console.error('[Rebuild] Failed:', e)
+    const msg = e?.body?.message || e?.message || 'Unknown error'
+    return c.json({ error: msg }, 500)
   }
 })
 

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -14,6 +14,7 @@ import { getTagAssignmentsForUser } from '../../services/db/tags'
 import type { SessionWithPreview } from '../../services/db/types'
 import { getWorkspace, getWorkspaceConfig, listWorkspaces } from '../../services/db/workspaces'
 import * as k8s from '../../services/k8s'
+import { computeWorkspaceDrift } from '../../services/workspace-reconcile'
 import { canManage, toApiWorkspace } from './_shared'
 
 function toApiSession(s: SessionWithPreview) {
@@ -266,7 +267,10 @@ read.openapi(getStatusRoute, async (c) => {
     return c.json({ error: 'Workspace not found' }, 404)
   }
   try {
-    const status = await k8s.getInstanceStatus(workspace.id)
+    const [status, drift] = await Promise.all([
+      k8s.getInstanceStatus(workspace.id),
+      computeWorkspaceDrift(workspace.id),
+    ])
     return c.json(
       {
         deployment: status.deployment.exists
@@ -280,6 +284,11 @@ read.openapi(getStatusRoute, async (c) => {
         pods: { total: status.pods.total, ready: status.pods.ready },
         warnings: status.warnings,
         conditions: status.conditions,
+        rebuild: {
+          current: drift.current,
+          latest: drift.latest,
+          available: drift.hasInstance && drift.reasons.length > 0,
+        },
       },
       200,
     )

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -14,7 +14,6 @@ import { getTagAssignmentsForUser } from '../../services/db/tags'
 import type { SessionWithPreview } from '../../services/db/types'
 import { getWorkspace, getWorkspaceConfig, listWorkspaces } from '../../services/db/workspaces'
 import * as k8s from '../../services/k8s'
-import { computeWorkspaceDrift } from '../../services/workspace-reconcile'
 import { canManage, toApiWorkspace } from './_shared'
 
 function toApiSession(s: SessionWithPreview) {
@@ -267,10 +266,7 @@ read.openapi(getStatusRoute, async (c) => {
     return c.json({ error: 'Workspace not found' }, 404)
   }
   try {
-    const [status, drift] = await Promise.all([
-      k8s.getInstanceStatus(workspace.id),
-      computeWorkspaceDrift(workspace.id),
-    ])
+    const status = await k8s.getInstanceStatus(workspace.id)
     return c.json(
       {
         deployment: status.deployment.exists
@@ -284,11 +280,6 @@ read.openapi(getStatusRoute, async (c) => {
         pods: { total: status.pods.total, ready: status.pods.ready },
         warnings: status.warnings,
         conditions: status.conditions,
-        rebuild: {
-          current: drift.current,
-          latest: drift.latest,
-          available: drift.hasInstance && drift.reasons.length > 0,
-        },
       },
       200,
     )

--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -233,6 +233,24 @@ export async function listActiveSessionIds(workspaceId: string): Promise<string[
   return rows.map((r: { id: string }) => r.id)
 }
 
+/**
+ * Workspace IDs with a session whose agent is mid-turn (chat_status='agent')
+ * and was active within the given interval. Used by the admin rebuild sweep
+ * to skip workspaces a user is actively streaming with, so a rollout doesn't
+ * kill a live turn. `withinInterval` is a Postgres interval literal
+ * (e.g. '10 minutes'), bound as a parameter.
+ */
+export async function listStreamingWorkspaceIds(withinInterval: string): Promise<string[]> {
+  const { rows } = await pool.query(
+    `SELECT DISTINCT workspace_id FROM sessions
+      WHERE status = 'active'
+        AND chat_status = 'agent'
+        AND last_active_at >= NOW() - $1::interval`,
+    [withinInterval],
+  )
+  return rows.map((r: { workspace_id: string }) => r.workspace_id)
+}
+
 interface RecentSessionItem {
   session_id: string
   workspace_id: string

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -22,6 +22,10 @@ export interface Workspace {
   is_system: boolean
   status: string
   created_at: string
+  // Deployed runtime template version (cached from the Deployment's
+  // workspace-version annotation). null = unknown/legacy. Compared against
+  // CURRENT_TEMPLATE_VERSION to decide whether a rebuild/update is available.
+  runtime_version: number | null
 }
 
 /**

--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -99,7 +99,7 @@ export async function listWorkspaces(
 
 export async function updateWorkspace(
   id: string,
-  updates: Partial<Pick<Workspace, 'name' | 'slug' | 'visibility' | 'status'>>,
+  updates: Partial<Pick<Workspace, 'name' | 'slug' | 'visibility' | 'status' | 'runtime_version'>>,
 ): Promise<boolean> {
   const sets: string[] = []
   const values: any[] = []
@@ -120,6 +120,10 @@ export async function updateWorkspace(
   if (updates.status !== undefined) {
     sets.push(`status = $${paramIndex++}`)
     values.push(updates.status)
+  }
+  if (updates.runtime_version !== undefined) {
+    sets.push(`runtime_version = $${paramIndex++}`)
+    values.push(updates.runtime_version)
   }
 
   if (sets.length === 0) return false

--- a/control-plane/src/services/k8s.ts
+++ b/control-plane/src/services/k8s.ts
@@ -818,6 +818,18 @@ export function resolveDeploymentStatus(dep: k8s.V1Deployment | undefined): Reco
 }
 
 /**
+ * Read the template version stamped on a Deployment (the workspace-version
+ * annotation), or null if absent/unparseable. The reconcile loop caches this
+ * onto the workspace row so drift checks don't need a live k8s read.
+ */
+export function deploymentTemplateVersion(dep: k8s.V1Deployment | undefined): number | null {
+  const raw = dep?.metadata?.annotations?.[TEMPLATE_VERSION_ANNOTATION]
+  if (raw === undefined) return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
  * Full list of all workspace deployments. Returns deployments indexed by
  * workspace-id plus the response resourceVersion for starting a watch.
  */

--- a/control-plane/src/services/k8s.ts
+++ b/control-plane/src/services/k8s.ts
@@ -462,6 +462,43 @@ export async function startInstance(workspaceId: string): Promise<boolean> {
   return scaleInstance(workspaceId, 1)
 }
 
+/**
+ * Roll the instance's pods without changing the Deployment spec — the
+ * equivalent of `kubectl rollout restart`. Stamps a template annotation so
+ * the Deployment controller recreates the pod (e.g. to re-pull a moving
+ * `:latest` tag). Returns false when the Deployment doesn't exist.
+ */
+export async function restartInstance(workspaceId: string): Promise<boolean> {
+  const name = getResourceName(workspaceId)
+  try {
+    await k8sAppsApi.patchNamespacedDeployment(
+      name,
+      NAMESPACE,
+      {
+        spec: {
+          template: {
+            metadata: {
+              annotations: {
+                'kubectl.kubernetes.io/restartedAt': new Date().toISOString(),
+              },
+            },
+          },
+        },
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+    )
+    return true
+  } catch (e: any) {
+    if (e.response?.statusCode === 404) return false
+    throw e
+  }
+}
+
 interface InstanceSpecMarkers {
   templateVersion: number | null
   agentImage: string | null

--- a/control-plane/src/services/skills-service.test.ts
+++ b/control-plane/src/services/skills-service.test.ts
@@ -80,6 +80,7 @@ function buildWorkspace(over: Partial<Workspace> & { id: string; user_id: string
     is_system: over.is_system ?? false,
     status: over.status ?? 'running',
     created_at: over.created_at ?? new Date().toISOString(),
+    runtime_version: over.runtime_version ?? null,
   }
 }
 

--- a/control-plane/src/services/workspace-reconcile.ts
+++ b/control-plane/src/services/workspace-reconcile.ts
@@ -81,6 +81,9 @@ export async function reconcileWorkspacePod(
 
   const desired = await getDesiredSpec(workspaceId)
   await k8s.rebuildInstance(workspaceId, desired.agentType, desired.resources)
+  // Cache the now-deployed version so the "update available" prompt clears
+  // immediately, without waiting for the reconcile loop's next annotation sync.
+  await updateWorkspace(workspaceId, { runtime_version: k8s.CURRENT_TEMPLATE_VERSION })
   return { rebuilt: true, reason: drift.reasons.join('; ') }
 }
 

--- a/control-plane/src/services/workspace-reconcile.ts
+++ b/control-plane/src/services/workspace-reconcile.ts
@@ -15,34 +15,46 @@ async function getDesiredSpec(workspaceId: string): Promise<DesiredSpec> {
   }
 }
 
+interface WorkspaceDrift {
+  /** Deployed template version (annotation), or null when no Deployment exists. */
+  current: number | null
+  /** Desired template version (CURRENT_TEMPLATE_VERSION). */
+  latest: number
+  /** Whether a Deployment exists for this workspace at all. */
+  hasInstance: boolean
+  /**
+   * Human/diagnostic descriptions of each drifted marker. Empty => in sync.
+   * Internal only — not surfaced to end users (they see a boolean).
+   */
+  reasons: string[]
+}
+
 /**
- * Bring the workspace's Deployment in line with the current desired spec:
- * template_version, agent image, and memory-fuse sidecar presence. Rebuilds
- * (delete + recreate Deployment) if any marker drifts. Returns `rebuilt: false`
- * when the workspace has no Deployment yet (caller should use createInstance).
+ * Read-only drift check: compare the workspace's Deployment against the
+ * current desired spec (template_version, agent image, memory-fuse sidecar)
+ * WITHOUT mutating anything. Shared source of truth for "is an update
+ * available" — consumed by the status endpoint (read), the user-facing
+ * rebuild action, and the admin batch sweep. {@link reconcileWorkspacePod}
+ * is the write path built on top of it.
  *
  * Drift sources:
  *   - template_version annotation < CURRENT_TEMPLATE_VERSION (structural bump)
  *   - agent image != getAgentImage(desired agent_type)
  *   - memory-fuse sidecar present != cluster provides MEMORY_FUSE_IMAGE
  *     (only surfaces on v3 pods built before sidecar became unconditional)
- *
- * The PVC and Service are preserved across rebuilds — only the Deployment is
- * replaced.
  */
-export async function reconcileWorkspacePod(
-  workspaceId: string,
-): Promise<{ rebuilt: boolean; reason?: string }> {
+export async function computeWorkspaceDrift(workspaceId: string): Promise<WorkspaceDrift> {
+  const latest = k8s.CURRENT_TEMPLATE_VERSION
   const markers = await k8s.getInstanceSpecMarkers(workspaceId)
-  if (!markers) return { rebuilt: false }
+  if (!markers) return { current: null, latest, hasInstance: false, reasons: [] }
 
   const desired = await getDesiredSpec(workspaceId)
   const desiredImage = k8s.getAgentImage(desired.agentType)
   const desiredSidecar = k8s.isMemoryFuseAvailable()
 
   const reasons: string[] = []
-  if ((markers.templateVersion ?? 0) < k8s.CURRENT_TEMPLATE_VERSION) {
-    reasons.push(`template_version ${markers.templateVersion} < ${k8s.CURRENT_TEMPLATE_VERSION}`)
+  if ((markers.templateVersion ?? 0) < latest) {
+    reasons.push(`template_version ${markers.templateVersion} < ${latest}`)
   }
   if (markers.agentImage !== desiredImage) {
     reasons.push(`image ${markers.agentImage} != ${desiredImage}`)
@@ -51,10 +63,25 @@ export async function reconcileWorkspacePod(
     reasons.push(`memory-fuse sidecar ${markers.hasMemoryFuseSidecar} != cluster ${desiredSidecar}`)
   }
 
-  if (reasons.length === 0) return { rebuilt: false }
+  return { current: markers.templateVersion, latest, hasInstance: true, reasons }
+}
 
+/**
+ * Bring the workspace's Deployment in line with the current desired spec by
+ * rebuilding (delete + recreate Deployment) when any marker drifts — see
+ * {@link computeWorkspaceDrift}. Returns `rebuilt: false` when the workspace
+ * has no Deployment yet (caller should use createInstance) or is already in
+ * sync. The PVC and Service are preserved — only the Deployment is replaced.
+ */
+export async function reconcileWorkspacePod(
+  workspaceId: string,
+): Promise<{ rebuilt: boolean; reason?: string }> {
+  const drift = await computeWorkspaceDrift(workspaceId)
+  if (!drift.hasInstance || drift.reasons.length === 0) return { rebuilt: false }
+
+  const desired = await getDesiredSpec(workspaceId)
   await k8s.rebuildInstance(workspaceId, desired.agentType, desired.resources)
-  return { rebuilt: true, reason: reasons.join('; ') }
+  return { rebuilt: true, reason: drift.reasons.join('; ') }
 }
 
 /**

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -33,6 +33,10 @@ export const ApiWorkspaceSchema = z.object({
       name: z.string().optional(),
     }),
   ),
+  // True when the deployed runtime is behind the current platform template
+  // and can be rebuilt to pick it up. Derived from the cached runtime_version,
+  // so it's free to read (no k8s call).
+  rebuild_available: z.boolean(),
 })
 
 export type ApiWorkspace = z.infer<typeof ApiWorkspaceSchema>
@@ -273,15 +277,6 @@ export const ApiK8sStatusSchema = z.object({
   conditions: z.array(
     z.object({ type: z.string(), status: z.boolean(), message: z.string().optional() }),
   ),
-  // Whether the workspace's runtime is behind the current platform template
-  // and can be rebuilt to pick it up. `available` is the only field the UI
-  // needs; `current`/`latest` are exposed for diagnostics. The underlying
-  // drift reasons are intentionally NOT surfaced to end users.
-  rebuild: z.object({
-    current: z.number().int().nullable(),
-    latest: z.number().int(),
-    available: z.boolean(),
-  }),
 })
 
 export type ApiK8sStatus = z.infer<typeof ApiK8sStatusSchema>

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -273,6 +273,15 @@ export const ApiK8sStatusSchema = z.object({
   conditions: z.array(
     z.object({ type: z.string(), status: z.boolean(), message: z.string().optional() }),
   ),
+  // Whether the workspace's runtime is behind the current platform template
+  // and can be rebuilt to pick it up. `available` is the only field the UI
+  // needs; `current`/`latest` are exposed for diagnostics. The underlying
+  // drift reasons are intentionally NOT surfaced to end users.
+  rebuild: z.object({
+    current: z.number().int().nullable(),
+    latest: z.number().int(),
+    available: z.boolean(),
+  }),
 })
 
 export type ApiK8sStatus = z.infer<typeof ApiK8sStatusSchema>

--- a/web/src/components/teamwork/TeamworkSection.tsx
+++ b/web/src/components/teamwork/TeamworkSection.tsx
@@ -1361,5 +1361,6 @@ function resolveMemberWorkspace(
     active_agent_sessions: 0,
     active_human_sessions: 0,
     active_sessions: [],
+    rebuild_available: false,
   }
 }

--- a/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -52,7 +52,7 @@ import { useAgentSessionActions, useAgentSessionStore } from '@/stores/AgentSess
 import type { ChatMessage as ChatMessageType } from '@/stores/agent-session-store'
 import { useComposerInsertRequests } from '@/stores/composer-store'
 import { useDraft } from '@/stores/draft-store'
-import { MessageBubble, TurnStatsBar } from '@neutree-ai/ui-sdk'
+import { MessageBubble, TranscriptI18nProvider, TurnStatsBar } from '@neutree-ai/ui-sdk'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   Bot,
@@ -76,7 +76,8 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useTranslation } from 'react-i18next'
+import { I18nextProvider, useTranslation } from 'react-i18next'
+import { i18n as appI18n } from '@/lib/i18n'
 
 const FONT_SIZE_MIN = 10
 const FONT_SIZE_MAX = 18
@@ -246,7 +247,7 @@ export function WorkspaceChatPanel({
   readonly = false,
   onMessages,
 }: WorkspaceChatPanelProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { mode: chatSendKeyMode } = useChatSendKey()
   const hints = useMemo(
     () => [
@@ -602,8 +603,16 @@ export function WorkspaceChatPanel({
 
   return (
     <TranscriptProviders agentType={agentType}>
-      {!readonly &&
-        headerSlot &&
+      {/* The panel chrome (header, composer, dialogs) is app UI keyed against
+          the host i18n bundle. TranscriptProviders' TranscriptI18nProvider
+          rebinds useTranslation to the SDK's chat-only instance, which would
+          make every self-translating app child (ShareSessionButton,
+          AskUserQuestionPanel, VoiceInputButton, …) render raw keys. Override
+          back to the app instance here; the few SDK components that genuinely
+          need the chat bundle (MessageBubble / TurnStatsBar) re-assert it. */}
+      <I18nextProvider i18n={appI18n}>
+        {!readonly &&
+          headerSlot &&
         createPortal(
           <>
             {!sessionsAppOpened && (
@@ -848,7 +857,9 @@ export function WorkspaceChatPanel({
                       }}
                     >
                       <div className="pb-3">
-                        <MessageBubble message={messages[vi.index]} />
+                        <TranscriptI18nProvider locale={i18n.language}>
+                          <MessageBubble message={messages[vi.index]} />
+                        </TranscriptI18nProvider>
                       </div>
                     </div>
                   ))}
@@ -856,7 +867,9 @@ export function WorkspaceChatPanel({
                 {/* Tail rendered in normal flow — see virtualCount above. */}
                 {messages.length > 0 && (
                   <div className="pb-3">
-                    <MessageBubble message={messages[messages.length - 1]} />
+                    <TranscriptI18nProvider locale={i18n.language}>
+                      <MessageBubble message={messages[messages.length - 1]} />
+                    </TranscriptI18nProvider>
                   </div>
                 )}
                 {error && (
@@ -868,7 +881,9 @@ export function WorkspaceChatPanel({
             ) : (
               <div className="p-3 space-y-3">
                 {messages.map((msg) => (
-                  <MessageBubble key={msg.id} message={msg} />
+                  <TranscriptI18nProvider key={msg.id} locale={i18n.language}>
+                    <MessageBubble message={msg} />
+                  </TranscriptI18nProvider>
                 ))}
                 {error && (
                   <Alert variant="destructive" className="p-3">
@@ -890,11 +905,13 @@ export function WorkspaceChatPanel({
         </div>
 
         {!isLoading && messages.length > 0 && (
-          <TurnStatsBar
-            turns={turnCount}
-            contextTokens={lastTurnStats?.contextTokens}
-            contextWindow={lastTurnStats?.contextWindow}
-          />
+          <TranscriptI18nProvider locale={i18n.language}>
+            <TurnStatsBar
+              turns={turnCount}
+              contextTokens={lastTurnStats?.contextTokens}
+              contextWindow={lastTurnStats?.contextWindow}
+            />
+          </TranscriptI18nProvider>
         )}
 
         {pendingQuestion && (
@@ -1182,6 +1199,7 @@ export function WorkspaceChatPanel({
           </form>
         </DialogContent>
       </Dialog>
+      </I18nextProvider>
     </TranscriptProviders>
   )
 }

--- a/web/src/components/workspace/WorkspaceSettingsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSettingsPanel.tsx
@@ -496,11 +496,11 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
   const lifecyclePending =
     startMutation.isPending || stopMutation.isPending || restartMutation.isPending
 
-  // Poll K8s status while the workspace is mid-transition (to surface
-  // FailedScheduling / image pull / OOM reasons behind a stuck 'starting')
-  // and while running (to detect template drift → "update available").
+  // Poll K8s status only while the workspace is mid-transition. Surfaces
+  // FailedScheduling / image pull / OOM reasons that otherwise leave the
+  // workspace stuck in 'starting' with no visible explanation.
   const { data: k8sStatus } = useWorkspaceStatus(workspaceId, {
-    enabled: workspace?.status === 'starting' || workspace?.status === 'running',
+    enabled: workspace?.status === 'starting',
   })
   const startupWarnings = k8sStatus?.warnings ?? []
   const startupFailedConditions = (k8sStatus?.conditions ?? []).filter(
@@ -509,8 +509,9 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
   const showStartupAlert =
     workspace?.status === 'starting' &&
     (startupWarnings.length > 0 || startupFailedConditions.length > 0)
-  // Runtime is behind the current platform template — offer a rebuild.
-  const updateAvailable = (k8sStatus?.rebuild?.available ?? false) && !lifecyclePending
+  // Runtime is behind the current platform template — offer a rebuild. Read
+  // straight off the workspace object (cached server-side), no status poll.
+  const updateAvailable = (workspace?.rebuild_available ?? false) && !lifecyclePending
 
   async function handleRebuild() {
     try {

--- a/web/src/components/workspace/WorkspaceSettingsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSettingsPanel.tsx
@@ -42,6 +42,7 @@ import { useSetWorkspaceTags, useTags } from '@/hooks/useTags'
 import { useWorkspaceConfig } from '@/hooks/useWorkspaceConfig'
 import {
   usePatchWorkspace,
+  useRebuildWorkspace,
   useRestartWorkspace,
   useStartWorkspace,
   useStopWorkspace,
@@ -489,15 +490,17 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
   const startMutation = useStartWorkspace()
   const stopMutation = useStopWorkspace()
   const restartMutation = useRestartWorkspace()
+  const rebuildMutation = useRebuildWorkspace()
+  const [rebuildConfirmOpen, setRebuildConfirmOpen] = useState(false)
   const isRunning = workspace?.status === 'running' || workspace?.status === 'starting'
   const lifecyclePending =
     startMutation.isPending || stopMutation.isPending || restartMutation.isPending
 
-  // Poll K8s status only while the workspace is mid-transition. Surfaces
-  // FailedScheduling / image pull / OOM reasons that otherwise leave the
-  // workspace stuck in 'starting' with no visible explanation.
+  // Poll K8s status while the workspace is mid-transition (to surface
+  // FailedScheduling / image pull / OOM reasons behind a stuck 'starting')
+  // and while running (to detect template drift → "update available").
   const { data: k8sStatus } = useWorkspaceStatus(workspaceId, {
-    enabled: workspace?.status === 'starting',
+    enabled: workspace?.status === 'starting' || workspace?.status === 'running',
   })
   const startupWarnings = k8sStatus?.warnings ?? []
   const startupFailedConditions = (k8sStatus?.conditions ?? []).filter(
@@ -506,6 +509,21 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
   const showStartupAlert =
     workspace?.status === 'starting' &&
     (startupWarnings.length > 0 || startupFailedConditions.length > 0)
+  // Runtime is behind the current platform template — offer a rebuild.
+  const updateAvailable = (k8sStatus?.rebuild?.available ?? false) && !lifecyclePending
+
+  async function handleRebuild() {
+    try {
+      const res = await rebuildMutation.mutateAsync(workspaceId)
+      toast.success(
+        res.rebuilt
+          ? t('components.settings.rebuild.toasts.started')
+          : t('components.settings.rebuild.toasts.upToDate'),
+      )
+    } finally {
+      setRebuildConfirmOpen(false)
+    }
+  }
 
   // Persisted: which settings nav page is showing — "where am I".
   const [activeSection, setActiveSection] = useInstancePersistentState<SectionKey>(
@@ -1079,6 +1097,53 @@ export function WorkspaceSettingsPanel({ workspaceId, instanceId }: WorkspaceSet
         {/* Center content */}
         <ScrollArea className="min-w-0 flex-1">
           <div className="px-6 py-5">
+            {updateAvailable && (
+              <Alert className="mb-4">
+                <ArrowUpCircle className="h-4 w-4 text-primary" strokeWidth={2} />
+                <AlertTitle className="text-sm">
+                  {t('components.settings.rebuild.available.title')}
+                </AlertTitle>
+                <AlertDescription className="mt-1.5">
+                  <p className="text-xs text-muted-foreground">
+                    {t('components.settings.rebuild.available.description')}
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="mt-2 h-7 gap-1.5 px-3 text-xs"
+                    onClick={() => setRebuildConfirmOpen(true)}
+                  >
+                    <ArrowUpCircle className="h-3 w-3" strokeWidth={2} />
+                    {t('components.settings.rebuild.available.action')}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
+            <Dialog open={rebuildConfirmOpen} onOpenChange={setRebuildConfirmOpen}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{t('components.settings.rebuild.confirm.title')}</DialogTitle>
+                  <DialogDescription>
+                    {t('components.settings.rebuild.confirm.description')}
+                  </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setRebuildConfirmOpen(false)}
+                    disabled={rebuildMutation.isPending}
+                  >
+                    {t('components.settings.rebuild.confirm.cancel')}
+                  </Button>
+                  <Button size="sm" onClick={handleRebuild} disabled={rebuildMutation.isPending}>
+                    {rebuildMutation.isPending
+                      ? t('components.settings.rebuild.confirm.pending')
+                      : t('components.settings.rebuild.confirm.confirm')}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
             {showStartupAlert && (
               <Alert variant="destructive" className="mb-4">
                 <AlertTriangle className="h-4 w-4" />

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -86,6 +86,26 @@ export function useRestartWorkspace() {
 }
 
 /**
+ * Rebuilds the workspace's runtime when it drifts from the current platform
+ * template (relaxed probes, new sidecars, image). Disruptive — the pod is
+ * replaced. No-op server-side when already in sync.
+ */
+export function useRebuildWorkspace() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) => api.rebuildWorkspace(id),
+    onSuccess: (_res, id) => {
+      queryClient.invalidateQueries({ queryKey: ['workspaces'] })
+      queryClient.invalidateQueries({ queryKey: ['workspace-status', id] })
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    },
+  })
+}
+
+/**
  * Polls the K8s status endpoint while a workspace is in a transient state
  * (e.g. `starting`). Surfaces pod warnings like FailedScheduling so users
  * see *why* a start is hanging instead of an indefinite spinner.

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -281,6 +281,12 @@ class ApiClient {
     return this.request<K8sResourceStatus>(`/workspaces/${id}/status`)
   }
 
+  async rebuildWorkspace(id: string): Promise<{ rebuilt: boolean; reason?: string }> {
+    return this.request<{ rebuilt: boolean; reason?: string }>(`/workspaces/${id}/rebuild`, {
+      method: 'POST',
+    })
+  }
+
   async getWorkspaceMessages(id: string, sessionId?: string): Promise<ApiMessage[]> {
     const params = sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : ''
     return this.request<ApiMessage[]>(`/workspaces/${id}/messages${params}`)

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3357,7 +3357,7 @@
         },
         "confirm": {
           "title": "Update workspace?",
-          "description": "Updating restarts the workspace pod: any in-progress session is interrupted, ephemeral files are cleared, and the runtime takes a few minutes to come back up.",
+          "description": "Updating restarts the workspace pod: any in-progress session is interrupted.",
           "cancel": "Cancel",
           "confirm": "Update now",
           "pending": "Updating…"

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3349,6 +3349,24 @@
       "startupAlert": {
         "title": "Workspace is having trouble starting"
       },
+      "rebuild": {
+        "available": {
+          "title": "A new workspace version is available",
+          "description": "The platform runtime has been updated. Rebuild the workspace to pick up the latest version.",
+          "action": "Update workspace"
+        },
+        "confirm": {
+          "title": "Update workspace?",
+          "description": "Updating restarts the workspace pod: any in-progress session is interrupted, ephemeral files are cleared, and the runtime takes a few minutes to come back up.",
+          "cancel": "Cancel",
+          "confirm": "Update now",
+          "pending": "Updating…"
+        },
+        "toasts": {
+          "started": "Workspace update started",
+          "upToDate": "Workspace is already up to date"
+        }
+      },
       "resizeConfirm": {
         "title": "Restart workspace to apply new size?",
         "description": "Changing the compute size restarts the workspace pod. Any in-progress session will be interrupted. The new size takes effect after you click Save.",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3381,7 +3381,7 @@
         },
         "confirm": {
           "title": "更新工作空间？",
-          "description": "更新会重启工作空间的 pod：正在进行的 session 会被中断，临时文件会清空，环境需要几分钟重新就绪。",
+          "description": "更新会重启工作空间的 pod：正在进行的 session 会被中断。",
           "cancel": "取消",
           "confirm": "立即更新",
           "pending": "更新中…"

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3373,6 +3373,24 @@
       "startupAlert": {
         "title": "工作空间启动异常"
       },
+      "rebuild": {
+        "available": {
+          "title": "工作空间有新版本",
+          "description": "平台运行环境已更新，重建工作空间即可获取最新版本。",
+          "action": "更新工作空间"
+        },
+        "confirm": {
+          "title": "更新工作空间？",
+          "description": "更新会重启工作空间的 pod：正在进行的 session 会被中断，临时文件会清空，环境需要几分钟重新就绪。",
+          "cancel": "取消",
+          "confirm": "立即更新",
+          "pending": "更新中…"
+        },
+        "toasts": {
+          "started": "工作空间更新已开始",
+          "upToDate": "工作空间已是最新版本"
+        }
+      },
       "resizeConfirm": {
         "title": "重启工作空间以应用新规格？",
         "description": "切换计算规格会重启工作空间的 pod，正在进行的 session 会被中断。新规格在点击保存后才会生效。",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -70,6 +70,10 @@ export default defineConfig(({ mode }) => {
   const target = env.VITE_BACKEND_URL || 'http://localhost:3000'
 
   return {
+    // @extend-ai/react-xlsx ships a Web Worker that code-splits; Rollup
+    // rejects the default iife worker format for code-splitting builds, so
+    // emit workers as ES modules.
+    worker: { format: 'es' },
     plugins: [
       {
         enforce: 'pre',
@@ -93,7 +97,23 @@ export default defineConfig(({ mode }) => {
         '@neutree-ai/theme': path.resolve(__dirname, '../internal/theme/src/index.ts'),
         '@neutree-ai/ui-sdk': path.resolve(__dirname, '../internal/ui-sdk/src/index.ts'),
       },
-      dedupe: ['react', 'react-dom', 'sonner', 'lucide-react', 'react-i18next', 'i18next'],
+      // @neutree-ai/ui-sdk (aliased to source) ships its own copies of these
+      // packages under internal/ui-sdk/node_modules. Radix primitives use
+      // module-scoped React contexts, so a second instance means a <Tooltip>
+      // from ui-sdk's MessageBubble can't see the app-root <TooltipProvider>
+      // (web's instance) → "Tooltip must be used within TooltipProvider".
+      // Dedupe forces a single instance across web + ui-sdk (same as React).
+      dedupe: [
+        'react',
+        'react-dom',
+        'sonner',
+        'lucide-react',
+        'react-i18next',
+        'i18next',
+        '@radix-ui/react-tooltip',
+        '@radix-ui/react-collapsible',
+        '@radix-ui/react-slot',
+      ],
     },
     server: {
       host: '0.0.0.0',


### PR DESCRIPTION
Stacked on #39 (workspace drift + rebuild). Review/merge #39 first.

## What

`POST /api/admin/cluster/rebuild-stale` — the ops/fleet counterpart of the per-workspace rebuild action, built on the **same** `computeWorkspaceDrift` core (no duplicated spec logic).

For each agent workspace:
- **template drift** → `reconcileWorkspacePod` (rebuild Deployment to current spec)
- **in sync** → `restartInstance` (roll pods to re-pull a moving `:latest`)
- **live streaming turn** (`chat_status=agent` within the active window) → **skipped** so a rollout never kills an in-flight session

Body (all optional): `agentType` (filter by image), `activeWindow` (PG interval, default `10 minutes`), `concurrency` (default 16), `dryRun`.

## Auth

Admin-authorized; also callable headless by the rollout via the existing static `x-plugin-admin-token` bypass (extended to this one path in `index.ts`) — same mechanism CI/rollout already uses for plugin admin. No new secret.

## Supporting changes
- `k8s.restartInstance()` — `kubectl rollout restart` equivalent (template annotation bump)
- `sessions.listStreamingWorkspaceIds()` — the active-skip set

## Pairs with (in-smtx, separate repo)
`rollout.sh` `rollout_agent` now POSTs this endpoint instead of running a local pg+kubectl script (which is retired). cp reuse = single source of truth for the desired spec; the old in-cluster-Job / new-auth ideas are no longer needed.

## Test plan
Real rollout + manual verification before merge (per agreed sequencing). `dryRun:true` first to inspect what would change.