### PR TITLE
fix(web): scan @neutree-ai/ui-sdk in Tailwind content

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -5,6 +5,11 @@ export default {
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',
     './node_modules/@tremor/**/*.{js,ts,jsx,tsx}',
+    // @neutree-ai/ui-sdk is aliased to source (see vite.config) and ships its
+    // own Tailwind-classed components (MessageBubble, etc.). Without this the
+    // ui-sdk-only utilities (e.g. the chat bubble's bg-primary/90, rounded-2xl)
+    // get purged and the components render unstyled.
+    '../internal/ui-sdk/src/**/*.{js,ts,jsx,tsx}',
   ],
   safelist: [
     // Tremor charts construct color classes at runtime (e.g. fill-blue-500)


### PR DESCRIPTION
Chat bubble (MessageBubble, moved to @neutree-ai/ui-sdk) rendered unstyled — ui-sdk-only utilities like `bg-primary/90` were purged because Tailwind only scanned `./src`. Result: user messages were white-on-white under the light theme. Adds the ui-sdk source glob to `content`. Verified: `bg-primary/90` + `rounded-tr-md` now emitted in the built CSS. Needs a cp rollout to deploy.