### PR TITLE
fix(chat): widen async session.started wait to 300s

### DIFF
--- a/control-plane/src/lib/sse-aggregate.ts
+++ b/control-plane/src/lib/sse-aggregate.ts
@@ -88,13 +88,16 @@ export async function aggregateChatStream(response: Response): Promise<Aggregate
  *
  * `knownSessionId` short-circuits the wait for resumed sessions, whose id is
  * already known before dispatch. For a new session we wait for the first
- * frame (`session.started` arrives well before the model finishes), bounded by
- * `timeoutMs` so a stuck agent can't hang the request.
+ * frame (`session.started`), bounded by `timeoutMs` so a stuck agent can't hang
+ * the request. The bound is generous because several sessions cold-starting in
+ * the same workspace at once (e.g. a fan-out of sub-agents) can delay
+ * `session.started` well past a tight timeout — and a premature timeout drops
+ * the id for a session that is in fact starting and will run to completion.
  */
 export async function awaitSessionId(
   response: Response,
   knownSessionId: string | null,
-  timeoutMs = 30_000,
+  timeoutMs = 300_000,
 ): Promise<{ sessionId: string | null; error: string | null }> {
   if (knownSessionId) {
     void response.body?.cancel().catch(() => {})


### PR DESCRIPTION
## Problem

Async chat waits for the agent's `session.started` frame to learn a **new** session's id before returning `202 { session_id }`, bounded by a 30s timeout (`awaitSessionId`).

When several sessions cold-start in the **same workspace at once** — e.g. a workflow fanning out to parallel sub-agents — `session.started` for the 2nd/3rd can arrive after 30s. The request then 502s with a null id **even though the session was created and the turn runs to completion server-side**. The caller sees a "dispatch failed" 502 and discards a session that is actually running, losing its result.

Observed: 3 sub-agents dispatched into one workspace; the 1st returned its id, the other 2 502'd at ~30s with `session.started not received before timeout` — yet both sessions existed and had produced full assistant answers.

## Fix

Widen the `awaitSessionId` bound from 30s to **300s**, so a real (if slow) concurrent cold-start reliably returns its id. A genuinely stuck agent is still bounded; the turn keeps running/persisting server-side regardless, so the only effect is the caller reliably learning the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)