### PR TITLE
fix(web): reconnect to live turn from authoritative chat_status

### DIFF
--- a/web/src/stores/agent-session-store.test.ts
+++ b/web/src/stores/agent-session-store.test.ts
@@ -140,10 +140,14 @@ describe('createAgentSessionStore', () => {
     })
 
     test('reconnects SSE when session is active (chat_status=agent)', async () => {
-      const deps = makeDeps()
+      const deps = makeDeps({
+        api: {
+          getSession: vi.fn().mockResolvedValue({ chat_status: 'agent', pending_message: null }),
+        },
+      })
       const { s } = make('ws-1', deps)
 
-      await s.switchSession('session-1', { sessionChatStatus: 'agent' })
+      await s.switchSession('session-1')
 
       expect(deps.sse.createCPReconnectStream).toHaveBeenCalledWith(
         'ws-1',
@@ -158,15 +162,36 @@ describe('createAgentSessionStore', () => {
       const deps = makeDeps()
       const { s } = make('ws-1', deps)
 
-      await s.switchSession('session-1', { sessionChatStatus: 'idle' })
+      await s.switchSession('session-1')
 
       expect(deps.sse.createCPReconnectStream).not.toHaveBeenCalled()
       expect(s.isLoading).toBe(false)
     })
 
+    test('reconnects from the authoritative getSession status, not a stale context snapshot', async () => {
+      // Regression: switch-back / reload would skip reconnect when the
+      // caller-supplied context snapshot was stale (taken before the turn
+      // went live), leaving a running turn un-reattached and the composer
+      // looking idle. The decision must follow the freshly fetched status.
+      const deps = makeDeps({
+        api: {
+          getSession: vi.fn().mockResolvedValue({ chat_status: 'agent', pending_message: null }),
+        },
+      })
+      const { s } = make('ws-1', deps)
+
+      await s.switchSession('session-1', { sessionChatStatus: 'idle' })
+
+      expect(deps.sse.createCPReconnectStream).toHaveBeenCalled()
+      expect(s.isLoading).toBe(true)
+    })
+
     test('aborts previous SSE stream when switching sessions', async () => {
       const abortSignals: AbortSignal[] = []
       const deps = makeDeps({
+        api: {
+          getSession: vi.fn().mockResolvedValue({ chat_status: 'agent', pending_message: null }),
+        },
         sse: {
           createCPReconnectStream: vi.fn((_wid, _h, signal) => {
             abortSignals.push(signal)
@@ -175,7 +200,7 @@ describe('createAgentSessionStore', () => {
       })
       const { s } = make('ws-1', deps)
 
-      await s.switchSession('session-1', { sessionChatStatus: 'agent' })
+      await s.switchSession('session-1')
       expect(abortSignals[0].aborted).toBe(false)
 
       await s.switchSession('session-2')

--- a/web/src/stores/agent-session-store.ts
+++ b/web/src/stores/agent-session-store.ts
@@ -694,7 +694,19 @@ export function createAgentSessionStore(
         loadedSessionId: sessionId,
       })
 
-      if (context?.sessionChatStatus === 'agent') {
+      // Decide whether to re-attach to a live turn from the authoritative
+      // chat_status we just fetched, not the caller-supplied `context`
+      // snapshot. That snapshot is stale on reload (no live status) and on
+      // switch-back (the sidebar cached it before the turn went live), which
+      // left running turns un-reattached and the composer looking idle — so
+      // the turn kept running in the background while the user saw a ready
+      // input box and had to manually type "continue". Fall back to the
+      // snapshot only if the fresh fetch failed.
+      const liveChatStatus =
+        sessionResult.status === 'fulfilled'
+          ? sessionResult.value.chat_status
+          : context?.sessionChatStatus
+      if (liveChatStatus === 'agent') {
         startReconnect()
       }
     },


### PR DESCRIPTION
## Problem

A running turn would show as stopped — the composer fell back to its idle "ready to send" state even though the turn was still streaming on the backend — in two situations:

1. **Page reload** (notably the "new version available, reload" prompt).
2. **Switching to another workspace and back** to the session (no reload, no deploy).

Users learned to type "continue" to force the view to resume. The turn was never actually interrupted: it kept running and persisting to the DB, which is why "continue" worked.

## Root cause

`switchSession` fetches the authoritative session row via `getSession` (it already reads `pending_message` from it), but gated the **reconnect** decision on the caller-supplied `context.sessionChatStatus` snapshot instead. That snapshot is stale:

- on reload, the initial context carries no live status;
- on switch-back, the sidebar cached it before the turn went live.

So `startReconnect()` never fired and the live turn was never re-attached. (The polling path in `followPendingTurn` already keys off the fresh `getSession` status — `switchSession` simply didn't.)

## Fix

Decide whether to reconnect from the freshly fetched `getSession` `chat_status`, falling back to the context snapshot only if the fetch failed.

## Tests

- Updated the two `switchSession` reconnect tests to drive the decision through `getSession` (the corrected contract).
- Added a regression test asserting reconnect follows the authoritative status even when the context snapshot is stale.
- Full `agent-session-store.test.ts` suite passes (50/50); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)