### PR TITLE
fix(control-plane): set explicit connection pool max to 35

### DIFF
--- a/control-plane/src/services/db/pool.ts
+++ b/control-plane/src/services/db/pool.ts
@@ -5,6 +5,7 @@ import { dbQueryDuration } from '../../lib/metrics'
 
 const _pool = new pg.Pool({
   connectionString: process.env.DATABASE_URL || 'postgresql://tos:tos@localhost:5432/tos',
+  max: 35,
 })
 
 // Wrap pool.query to observe DB query duration


### PR DESCRIPTION
## Summary

- Set `max: 35` on the `pg.Pool` instance in `control-plane/src/services/db/pool.ts`
- node-postgres default is 10; no explicit max was set previously, causing connection wait under peak load on the single-replica deployment
- 35 is the midpoint of the ops-recommended 30–40 range

## Test plan

- [ ] Deploy to staging, monitor `pg_stat_activity` connection count under load
- [ ] Confirm no `connection timeout` errors in cp logs post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)