### PR TITLE
fix(ui-sdk): add missing components.markdown.systemMessage i18n keys

### DIFF
--- a/internal/ui-sdk/src/locales/en-US.json
+++ b/internal/ui-sdk/src/locales/en-US.json
@@ -214,6 +214,9 @@
         "contextWarning": "consider /compact or starting a new session",
         "turnWarning": "High turn count - consider starting a new session or compacting"
       }
+    },
+    "markdown": {
+      "systemMessage": "System message"
     }
   }
 }

--- a/internal/ui-sdk/src/locales/zh-CN.json
+++ b/internal/ui-sdk/src/locales/zh-CN.json
@@ -214,6 +214,9 @@
         "contextWarning": "建议执行 /compact 或开启新会话",
         "turnWarning": "轮次较高，建议开启新会话或压缩会话"
       }
+    },
+    "markdown": {
+      "systemMessage": "系统消息"
     }
   }
 }


### PR DESCRIPTION
## Summary

- `AgentSysBlock` in `web/src/components/ui/markdown.tsx` calls `useTranslation()` to render the collapsible "System message" label
- Inside the chat transcript, the component is wrapped by `TranscriptI18nProvider`, which swaps in the ui-sdk's **private** i18n instance
- That instance only bundled `components.chat.*` keys — `components.markdown.systemMessage` was missing, so the raw key literal was displayed instead of the translated string
- Add the missing key to both `en-US` and `zh-CN` locale bundles in `internal/ui-sdk/src/locales/`

## Test plan

- [ ] Open a chat session and send a message that triggers an `<agent-sys>…</agent-sys>` block (e.g. a workspace tool agent)
- [ ] Confirm the collapsible header shows "System message" (en) / "系统消息" (zh) instead of the raw key `components.markdown.systemMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)