### PR TITLE
fix(control-plane): use Hono routePath for HTTP metrics to fix label cardinality explosion

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -99,11 +99,9 @@ app.use('*', async (c, next) => {
   const start = Date.now()
   await next()
   httpActiveRequests.dec()
-  // Normalize path: replace workspace/session IDs with :id
-  const route = c.req.path
-    .replace(/\/[a-z0-9]{8,}(?=-)/g, '/:id') // workspace-prefixed paths
-    .replace(/\/[0-9a-f]{8}-[0-9a-f-]{27}/g, '/:id') // UUIDs
-    .replace(/\/019[0-9a-f]{5}-[0-9a-f-]{19}/g, '/:id') // UUIDv7 session IDs
+  // Use Hono's matched route pattern (e.g. /api/workspaces/:id/...) so dynamic
+  // IDs never become label values. Fall back to the raw path on unmatched routes.
+  const route = c.req.routePath ?? c.req.path
   httpRequestDuration.observe(
     { method: c.req.method, route, status: String(c.res.status) },
     (Date.now() - start) / 1000,


### PR DESCRIPTION
## Summary

- `tos_http_request_duration_seconds` histogram used `c.req.path` with a hand-rolled normalization regex
- The regex used `(?=-)` (lookahead for a hyphen) instead of `(?=/)`, so 8-char workspace/memory-store IDs followed by `/` were **never normalized**
- This produced ~9,800 unique `{method, route, status}` label combinations → 97k+ metric lines
- The `/metrics` endpoint took **13 seconds** to respond; vmagent default scrape timeout is 10s → periodic scrape failures → the intermittent gaps on the dashboard

## Fix

Replace the fragile regex with `c.req.routePath`, which Hono fills with the matched route pattern (e.g. `/api/workspaces/:id/memory-stores/:storeId/memories`) after `next()` resolves. IDs never reach label values.

## Expected result after rollout

- `tos_http_request_duration_seconds` cardinality drops from ~9,800 to ~100 (number of distinct routes)
- `/metrics` response time: <100ms instead of 13s
- vmagent scrapes succeed consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)