### PR TITLE
fix(control-plane): add messages workspace index + drop data col from share list queries

### DIFF
--- a/control-plane/migrations/119_messages_workspace_created_idx.sql
+++ b/control-plane/migrations/119_messages_workspace_created_idx.sql
@@ -1,0 +1,8 @@
+-- Speed up listIdleRunningWorkspaces: the idle-GC query runs
+-- `SELECT MAX(m.created_at) FROM messages m WHERE m.workspace_id = w.id`
+-- for every running workspace. Without this index it scans all 100k+ rows
+-- and filters by workspace_id, averaging ~5s per GC call.
+-- With (workspace_id, created_at DESC) Postgres uses an index-only scan
+-- returning the single latest row per workspace.
+CREATE INDEX IF NOT EXISTS idx_messages_workspace_created
+  ON messages(workspace_id, created_at DESC);

--- a/control-plane/src/services/db/shares.ts
+++ b/control-plane/src/services/db/shares.ts
@@ -1,5 +1,5 @@
 import { generateId, pool } from './pool'
-import type { ServiceToken, Share } from './types'
+import type { ServiceToken, Share, ShareSummary } from './types'
 
 export async function createShare(
   userId: string,
@@ -40,23 +40,25 @@ export async function getShareWithOwner(
   return (rows[0] as Share & { owner_name: string }) ?? null
 }
 
+const SHARE_SUMMARY_COLS = 'id, user_id, workspace_id, session_id, title, created_at'
+
 export async function listSharesBySession(
   workspaceId: string,
   sessionId: string,
-): Promise<Share[]> {
+): Promise<ShareSummary[]> {
   const { rows } = await pool.query(
-    'SELECT * FROM shares WHERE workspace_id = $1 AND session_id = $2 ORDER BY created_at DESC',
+    `SELECT ${SHARE_SUMMARY_COLS} FROM shares WHERE workspace_id = $1 AND session_id = $2 ORDER BY created_at DESC`,
     [workspaceId, sessionId],
   )
-  return rows as Share[]
+  return rows as ShareSummary[]
 }
 
-export async function listSharesByWorkspace(workspaceId: string): Promise<Share[]> {
+export async function listSharesByWorkspace(workspaceId: string): Promise<ShareSummary[]> {
   const { rows } = await pool.query(
-    'SELECT * FROM shares WHERE workspace_id = $1 ORDER BY created_at DESC',
+    `SELECT ${SHARE_SUMMARY_COLS} FROM shares WHERE workspace_id = $1 ORDER BY created_at DESC`,
     [workspaceId],
   )
-  return rows as Share[]
+  return rows as ShareSummary[]
 }
 
 export async function updateShareTitle(

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -274,6 +274,9 @@ export interface Share {
   created_at: string
 }
 
+/** List projection of Share — omits the heavy `data` column. */
+export type ShareSummary = Omit<Share, 'data'>
+
 export interface ServiceToken {
   id: string
   name: string


### PR DESCRIPTION
## Summary

Two DB performance fixes identified via pg_stat_statements analysis.

### P0 — Add `messages(workspace_id, created_at DESC)` index

`listIdleRunningWorkspaces` runs a correlated subquery for every running workspace:
```sql
SELECT MAX(m.created_at) FROM messages m WHERE m.workspace_id = w.id
```
Without a composite index, Postgres scans all 100k+ rows using `idx_messages_created_at` and filters by `workspace_id` — **avg 5300ms per GC call, 569 calls = ~3000s total** in pg_stat_statements.

The new index `idx_messages_workspace_created ON messages(workspace_id, created_at DESC)` turns this into a single-row index scan per workspace.

### P1 — Omit `data` column from share list queries

`listSharesByWorkspace` / `listSharesBySession` used `SELECT *`, pulling the full share snapshot (avg 1.1MB, max 50MB) for every list request. The list endpoint only maps `id / title / created_at / session_id` — `data` is never used. **10,179 calls × 71ms avg = 725s total** wasted on unnecessary data transfer.

Replace with an explicit column list via a new `ShareSummary = Omit<Share, 'data'>` type. Single-row `getShare` / `getShareWithOwner` paths keep `SELECT *` since they need `data`.

## Test plan

- [ ] `listIdleRunningWorkspaces` query uses `Index Scan` on `idx_messages_workspace_created` after rollout (`EXPLAIN ANALYZE` to verify)
- [ ] Share list API returns same shape (no `data` field was ever sent to clients — confirmed from route handler mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)