### PR TITLE
fix(web): remove session id display from session list, dropdown, and header

### DIFF
--- a/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -652,12 +652,7 @@ export function WorkspaceChatPanel({
                     <SelectContent>
                       {sessions.map((session) => (
                         <SelectItem key={session.id} value={session.id} className="text-xs">
-                          <span className="flex min-w-0 flex-col">
-                            <span className="truncate">{formatSessionLabel(session, t)}</span>
-                            <span className="font-mono text-[10px] text-muted-foreground/50">
-                              {session.id}
-                            </span>
-                          </span>
+                          <span className="truncate">{formatSessionLabel(session, t)}</span>
                         </SelectItem>
                       ))}
                       {hasNextPage && <LoadMoreSentinel onVisible={fetchNextPage} />}
@@ -669,11 +664,6 @@ export function WorkspaceChatPanel({
                     </SelectContent>
                   </Select>
                 </div>
-              )}
-              {!sessionsAppOpened && activeSessionId && (
-                <span className="shrink-0 font-mono text-[10px] text-muted-foreground/40">
-                  {activeSessionId}
-                </span>
               )}
               {sessionSource &&
                 (sessionSource.url ? (

--- a/web/src/components/workspace/WorkspaceSessionsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSessionsPanel.tsx
@@ -145,7 +145,6 @@ function SessionRow({
       >
         {session.name || previewTitle || t('components.sessions.untitled')}
       </div>
-      <div className="truncate font-mono text-[10px] text-muted-foreground/40">{session.id}</div>
     </div>
   )
 


### PR DESCRIPTION
Removes the session UUID surfaces that were added previously. The session id was visual noise in three places on the main site:

- session history list rows
- session selector dropdown items
- chat header bar

Typecheck passes; `sessionsAppOpened` / `appI18n` remain in use, no dead code left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)