### PR TITLE
i18n(web): extract inline strings and fill missing locale keys

### DIFF
--- a/web/src/components/admin/InfraSection.tsx
+++ b/web/src/components/admin/InfraSection.tsx
@@ -302,14 +302,14 @@ function CapacityEstimate({ data }: { data: AdminCluster }) {
     <div className="grid gap-3 @3xl:grid-cols-2">
       {agentGroup && (
         <PoolCapacityCard
-          title="Agent Pool — Workspaces"
+          title={i18n.t('components.admin.infraSection.pools.agent')}
           group={agentGroup}
           tiers={workspaceTiers}
         />
       )}
       {sandboxGroup && (
         <PoolCapacityCard
-          title="Sandbox Pool — Sandboxes"
+          title={i18n.t('components.admin.infraSection.pools.sandbox')}
           group={sandboxGroup}
           tiers={sandboxTiers}
         />

--- a/web/src/components/home/ActivityApp.tsx
+++ b/web/src/components/home/ActivityApp.tsx
@@ -132,11 +132,13 @@ export function ActivityApp({ instanceId }: AppComponentProps) {
               label={t('components.shell.activityApp.interactionsToday')}
               value={stats.interactionsToday}
               sparkline={stats.interactionsSpark}
+              sparklineAriaLabel={t('components.shell.statCard.aria')}
             />
             <StatCard
               label={t('components.shell.activityApp.sessionsToday')}
               value={stats.sessionsToday}
               sparkline={stats.sessionsSpark}
+              sparklineAriaLabel={t('components.shell.statCard.aria')}
             />
             <div className="flex flex-col gap-2 rounded-lg border border-foreground/[0.06] bg-card/40 p-3">
               <div className="flex flex-col gap-0.5">
@@ -158,6 +160,7 @@ export function ActivityApp({ instanceId }: AppComponentProps) {
                     }),
                   hourSuffix: t('components.shell.activityApp.hourSuffix'),
                   dowShort: (dow) => t(`components.shell.activityApp.dow.${dow}`),
+                  ariaLabel: t('components.shell.punchCard.aria'),
                 }}
               />
             </div>

--- a/web/src/components/home/PunchCard.tsx
+++ b/web/src/components/home/PunchCard.tsx
@@ -12,6 +12,8 @@ interface PunchCardProps {
     /** Short weekday name for each day index 0..6 (Sun..Sat). Caller-supplied
      *  so it can match the rest of the app's locale (i18n keys vs. Intl). */
     dowShort: (dow: number) => string
+    /** Accessible label for the chart's `role="img"` SVG. */
+    ariaLabel: string
   }
   className?: string
 }
@@ -82,7 +84,7 @@ export function PunchCard({ data, i18n, className }: PunchCardProps) {
             viewBox={`0 0 ${totalW} ${totalH}`}
             preserveAspectRatio="none"
             role="img"
-            aria-label="hour-of-day activity"
+            aria-label={i18n.ariaLabel}
             className="block w-full"
             style={{ aspectRatio: `${cols} / ${rows}` }}
           >

--- a/web/src/components/home/StatCard.tsx
+++ b/web/src/components/home/StatCard.tsx
@@ -16,6 +16,8 @@ interface StatCardProps {
   sparkline?: SparklinePoint[]
   /** Optional leading icon next to the label. */
   icon?: LucideIcon
+  /** Accessible label for the sparkline SVG (caller-supplied for i18n). */
+  sparklineAriaLabel?: string
   className?: string
 }
 
@@ -25,7 +27,14 @@ interface StatCardProps {
  * sparkline. Future stat surfaces (cost, success rate, cluster) compose
  * visually without re-design.
  */
-export function StatCard({ label, value, sparkline, icon: Icon, className }: StatCardProps) {
+export function StatCard({
+  label,
+  value,
+  sparkline,
+  icon: Icon,
+  sparklineAriaLabel,
+  className,
+}: StatCardProps) {
   return (
     <div
       className={cn(
@@ -43,7 +52,7 @@ export function StatCard({ label, value, sparkline, icon: Icon, className }: Sta
         </span>
         {sparkline && sparkline.length > 1 && (
           <div className="min-w-0 flex-1">
-            <Sparkline data={sparkline} />
+            <Sparkline data={sparkline} ariaLabel={sparklineAriaLabel} />
           </div>
         )}
       </div>
@@ -51,7 +60,7 @@ export function StatCard({ label, value, sparkline, icon: Icon, className }: Sta
   )
 }
 
-export function Sparkline({ data }: { data: SparklinePoint[] }) {
+export function Sparkline({ data, ariaLabel }: { data: SparklinePoint[]; ariaLabel?: string }) {
   const N = data.length
   const cellUnit = 4
   const gap = 1
@@ -79,7 +88,7 @@ export function Sparkline({ data }: { data: SparklinePoint[] }) {
         className="block w-full text-primary/50"
         style={{ height: totalH }}
         role="img"
-        aria-label="sparkline"
+        aria-label={ariaLabel ?? 'sparkline'}
       >
         {data.map((d, i) => {
           const barH = Math.max(1, (d.value / max) * (totalH - 2))

--- a/web/src/components/home/WorkspacesApp.tsx
+++ b/web/src/components/home/WorkspacesApp.tsx
@@ -189,7 +189,7 @@ function WorkspaceCard({
           {needsReply && (
             <span
               className="ml-auto inline-flex h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-warning"
-              aria-label="Needs reply"
+              aria-label={t('components.shell.workspacesApp.needsReply')}
             />
           )}
         </span>

--- a/web/src/components/memory/MemoryStoresPanel.tsx
+++ b/web/src/components/memory/MemoryStoresPanel.tsx
@@ -1089,7 +1089,7 @@ function MemoryViewer({ storeId, path, locale, onDeleted, onSaved }: MemoryViewe
           }}
         >
           <SelectTrigger className="h-6 w-auto gap-1 border-0 bg-foreground/[0.06] px-2 text-tiny shadow-none focus:ring-0">
-            <SelectValue placeholder="v?" />
+            <SelectValue placeholder={t('components.memoryStores.placeholders.version')} />
           </SelectTrigger>
           <SelectContent>
             {versionsQuery.isLoading ? (

--- a/web/src/components/shell/Dock.tsx
+++ b/web/src/components/shell/Dock.tsx
@@ -641,10 +641,11 @@ function DockShell({
   footerRef?: React.Ref<HTMLElement>
   maxWidth?: number
 }) {
+  const { t } = useTranslation()
   return (
     <footer ref={footerRef} className="flex shrink-0 justify-center px-4 pb-3 pt-1">
       <nav
-        aria-label="dock"
+        aria-label={t('components.shell.dock.label')}
         style={{ minWidth: MIN_DOCK_WIDTH, maxWidth: maxWidth || undefined }}
         className={cn(
           'group relative flex items-center justify-center',

--- a/web/src/components/shell/PopoutLayer.tsx
+++ b/web/src/components/shell/PopoutLayer.tsx
@@ -272,7 +272,7 @@ export function PopoutLayer() {
         onPointerDown={onPointerDownResize}
       >
         <svg className="h-4 w-4 text-muted-foreground/40" viewBox="0 0 16 16" fill="currentColor">
-          <title>Resize</title>
+          <title>{t('components.popout.actions.resize')}</title>
           <circle cx="12" cy="12" r="1.5" />
           <circle cx="7" cy="12" r="1.5" />
           <circle cx="12" cy="7" r="1.5" />

--- a/web/src/components/shell/master-sidebar/MasterSidebar.tsx
+++ b/web/src/components/shell/master-sidebar/MasterSidebar.tsx
@@ -81,7 +81,7 @@ function MasterSidebarSearch({ value, onChange, placeholder, action }: SearchPro
           <button
             type="button"
             onClick={() => onChange('')}
-            aria-label="clear"
+            aria-label={t('common.clear')}
             className="absolute right-1.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground"
           >
             <X className="h-3 w-3" />

--- a/web/src/components/shell/windows/AppHeaderSearch.tsx
+++ b/web/src/components/shell/windows/AppHeaderSearch.tsx
@@ -50,7 +50,7 @@ export function AppHeaderSearch({
         <button
           type="button"
           onClick={() => onChange('')}
-          aria-label="clear"
+          aria-label={t('common.clear')}
           className="absolute right-1.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground"
         >
           <X className="h-3 w-3" />

--- a/web/src/components/workspace/WorkspaceBrowserPanel.tsx
+++ b/web/src/components/workspace/WorkspaceBrowserPanel.tsx
@@ -86,7 +86,7 @@ function LiveViewEmbed({ url }: { url: string }) {
 
   return (
     <iframe
-      title="Browser session"
+      title={t('components.workspaceBrowser.sessionTitle')}
       src={url}
       className="w-full h-full border-0"
       allow="clipboard-read; clipboard-write"

--- a/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -943,7 +943,7 @@ export function WorkspaceChatPanel({
                     <div key={i} className="relative group">
                       <img
                         src={`data:${img.media_type};base64,${img.data}`}
-                        alt="attachment"
+                        alt={t('components.workspaceChat.attachmentAlt')}
                         className="h-14 w-14 rounded border border-foreground/[0.08] object-cover"
                       />
                       <button

--- a/web/src/components/workspace/WorkspaceFilesPanel.tsx
+++ b/web/src/components/workspace/WorkspaceFilesPanel.tsx
@@ -1361,7 +1361,7 @@ export function WorkspaceFilesPanel({
                 <Checkbox
                   checked={allSelected ? true : someSelected ? 'indeterminate' : false}
                   onCheckedChange={toggleAll}
-                  aria-label="Toggle select all"
+                  aria-label={t('components.workspaceFiles.selection.toggleAll')}
                 />
                 <span className="min-w-0 flex-1 truncate font-medium text-foreground">
                   {t('components.workspaceFiles.selection.count', { count: selected.size })}

--- a/web/src/components/workspace/file-preview/ImagePreview.tsx
+++ b/web/src/components/workspace/file-preview/ImagePreview.tsx
@@ -1,5 +1,6 @@
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 
@@ -13,6 +14,7 @@ interface ImagePreviewProps {
 }
 
 export function ImagePreview({ src, filename, onPrev, onNext }: ImagePreviewProps) {
+  const { t } = useTranslation()
   return (
     <ScrollArea className="flex-1">
       <div className="relative flex items-center justify-center p-4">
@@ -27,7 +29,7 @@ export function ImagePreview({ src, filename, onPrev, onNext }: ImagePreviewProp
           <button
             type="button"
             onClick={onPrev}
-            aria-label="Previous image"
+            aria-label={t('components.filePreview.image.prev')}
             className="absolute left-3 top-1/2 -translate-y-1/2 flex h-9 w-9 items-center justify-center rounded-full bg-background/70 text-foreground/80 backdrop-blur transition hover:bg-background/90 hover:text-foreground shadow-sm"
           >
             <ChevronLeft className="h-5 w-5" />
@@ -37,7 +39,7 @@ export function ImagePreview({ src, filename, onPrev, onNext }: ImagePreviewProp
           <button
             type="button"
             onClick={onNext}
-            aria-label="Next image"
+            aria-label={t('components.filePreview.image.next')}
             className="absolute right-3 top-1/2 -translate-y-1/2 flex h-9 w-9 items-center justify-center rounded-full bg-background/70 text-foreground/80 backdrop-blur transition hover:bg-background/90 hover:text-foreground shadow-sm"
           >
             <ChevronRight className="h-5 w-5" />

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -33,7 +33,8 @@
       "sidebarProviderRequired": "useSidebar must be used within a SidebarProvider",
       "themeProviderRequired": "useTheme must be used within ThemeProvider",
       "unknown": "Unknown error"
-    }
+    },
+    "edit": "Edit"
   },
   "session": {
     "status": {
@@ -1031,10 +1032,17 @@
         "appsCount": "{{count}} apps",
         "labels": {
           "custom": "Custom",
-          "resourcesSummary": "CPU: {{cpuRequest}} / {{cpuLimit}} · Memory: {{memoryRequest}} / {{memoryLimit}} · Storage: {{storage}}"
+          "resourcesSummary": "CPU: {{cpuRequest}} / {{cpuLimit}} · Memory: {{memoryRequest}} / {{memoryLimit}} · Storage: {{storage}}",
+          "preset": "Preset",
+          "cpu": "CPU",
+          "memory": "Memory",
+          "storage": "Storage"
         },
         "empty": {
           "value": "-"
+        },
+        "actions": {
+          "openInLibrary": "Open in library"
         }
       },
       "templates": {
@@ -1235,7 +1243,8 @@
     "popout": {
       "actions": {
         "closeAll": "Close all",
-        "closeTab": "Close tab"
+        "closeTab": "Close tab",
+        "resize": "Resize"
       }
     },
     "scheduleConsent": {
@@ -1345,7 +1354,8 @@
       "empty": {
         "title": "No active browser",
         "description": "Launch a browser instance or let the agent create one via MCP"
-      }
+      },
+      "sessionTitle": "Browser session"
     },
     "workspaceChat": {
       "actions": {
@@ -1404,7 +1414,8 @@
         "queueHint": "Agent is busy — will be queued",
         "unsavedChanges": "Unsaved changes",
         "composerHint": "Agent is busy — send to queue"
-      }
+      },
+      "attachmentAlt": "attachment"
     },
     "workspaceSandbox": {
       "empty": {
@@ -1553,7 +1564,8 @@
         "clear": "Clear",
         "dragBadge_one": "Moving 1 item",
         "dragBadge_other": "Moving {{count}} items",
-        "deleteConfirm": "Click again to delete {{count}}"
+        "deleteConfirm": "Click again to delete {{count}}",
+        "toggleAll": "Toggle select all"
       },
       "errors": {
         "listFailed": "Failed to list directory: {{status}}",
@@ -1604,7 +1616,8 @@
         "noAttachments": "not attached"
       },
       "placeholders": {
-        "content": "Memory content (Markdown recommended)"
+        "content": "Memory content (Markdown recommended)",
+        "version": "v?"
       },
       "dialog": {
         "createTitle": "New memory store",
@@ -2159,6 +2172,9 @@
         "providerRequired": "Provider is required",
         "modelRequired": "Model is required",
         "createFailed": "Failed to create template"
+      },
+      "toasts": {
+        "created": "Template created"
       }
     },
     "teamworkSection": {
@@ -2335,7 +2351,8 @@
       },
       "actions": {
         "new": "New",
-        "delete": "Delete credential"
+        "delete": "Delete credential",
+        "edit": "Edit credential"
       },
       "dialogs": {
         "editTitle": "Edit Credential"
@@ -2508,6 +2525,10 @@
       "toc": {
         "label": "On this page",
         "empty": "No headings in this document."
+      },
+      "image": {
+        "prev": "Previous image",
+        "next": "Next image"
       }
     },
     "officePreview": {
@@ -2782,7 +2803,8 @@
         "library": "Library",
         "integration": "Integration",
         "management": "Management",
-        "admin": "Admin"
+        "admin": "Admin",
+        "label": "Dock"
       },
       "slot": {
         "openApp": "Open app",
@@ -2840,7 +2862,8 @@
         "empty": "No workspaces yet — create one to get started.",
         "noResults": "No workspaces match.",
         "sessionCount_one": "{{count}} active",
-        "sessionCount_other": "{{count}} active"
+        "sessionCount_other": "{{count}} active",
+        "needsReply": "Needs reply"
       },
       "activityApp": {
         "appLabel": "Stats",
@@ -2877,6 +2900,12 @@
           "cacheRead": "Cache read",
           "cacheCreation": "Cache write"
         }
+      },
+      "punchCard": {
+        "aria": "hour-of-day activity"
+      },
+      "statCard": {
+        "aria": "sparkline"
       }
     },
     "admin": {
@@ -3015,6 +3044,10 @@
         },
         "errors": {
           "loadFailed": "Failed to load cluster data"
+        },
+        "pools": {
+          "agent": "Agent Pool — Workspaces",
+          "sandbox": "Sandbox Pool — Sandboxes"
         }
       },
       "systemSettingsSection": {
@@ -3490,7 +3523,8 @@
       "lastRun": "Last run: {{value}}",
       "actions": {
         "new": "New",
-        "delete": "Delete"
+        "delete": "Delete",
+        "edit": "Edit"
       },
       "states": {
         "saving": "Saving...",
@@ -3548,6 +3582,65 @@
       "ownTitle": "Your workspaces using this skill",
       "otherCount": "Plus {{count}} workspace(s) owned by other users.",
       "templateCount": "{{count}} template version(s) reference this skill."
+    },
+    "chat": {
+      "toolRenderers": {
+        "labels": {
+          "unknown": "Unknown"
+        },
+        "agentRequest": {
+          "loadFailed": "Failed to load request",
+          "loading": "Loading…",
+          "approve": "Approve",
+          "reject": "Reject",
+          "reasonPlaceholder": "Reason (optional)",
+          "confirmReject": "Confirm reject",
+          "cancel": "Cancel",
+          "reason": "Reason",
+          "appliedAt": "Applied at",
+          "invalidPayload": "Invalid payload",
+          "cleared": "Cleared",
+          "fields": {
+            "name": "Name",
+            "cron": "Cron",
+            "runAt": "Run at",
+            "prompt": "Prompt",
+            "type": "Type",
+            "timezone": "Timezone",
+            "enabled": "Enabled",
+            "slug": "Slug",
+            "visibility": "Visibility",
+            "agentType": "Agent type",
+            "provider": "Provider",
+            "model": "Model",
+            "smallModel": "Small model",
+            "systemPrompt": "System prompt",
+            "content": "Content",
+            "id": "ID",
+            "attach": "Enable skills",
+            "detach": "Disable skills"
+          },
+          "status": {
+            "pending": "Pending",
+            "approved": "Approved",
+            "rejected": "Rejected",
+            "applied": "Applied"
+          },
+          "commandTypes": {
+            "plain": "Plain",
+            "struct": "Structured"
+          },
+          "visibilityValues": {
+            "private": "Private",
+            "user": "User",
+            "public": "Public"
+          },
+          "enabledStates": {
+            "on": "On",
+            "off": "Off"
+          }
+        }
+      }
     }
   }
 }

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -33,7 +33,8 @@
       "themeProviderRequired": "useTheme 必须在 ThemeProvider 内使用",
       "unknown": "未知错误",
       "fileOverlayProviderRequired": "useFileOverlay 必须在 FileOverlayProvider 内使用"
-    }
+    },
+    "edit": "编辑"
   },
   "session": {
     "status": {
@@ -1056,10 +1057,17 @@
         "appsCount": "{{count}} 个应用",
         "labels": {
           "custom": "自定义",
-          "resourcesSummary": "CPU：{{cpuRequest}} / {{cpuLimit}} · 内存：{{memoryRequest}} / {{memoryLimit}} · 存储：{{storage}}"
+          "resourcesSummary": "CPU：{{cpuRequest}} / {{cpuLimit}} · 内存：{{memoryRequest}} / {{memoryLimit}} · 存储：{{storage}}",
+          "preset": "预设",
+          "cpu": "CPU",
+          "memory": "内存",
+          "storage": "存储"
         },
         "empty": {
           "value": "-"
+        },
+        "actions": {
+          "openInLibrary": "在资源库中打开"
         }
       },
       "templates": {
@@ -1260,7 +1268,8 @@
     "popout": {
       "actions": {
         "closeAll": "全部关闭",
-        "closeTab": "关闭标签"
+        "closeTab": "关闭标签",
+        "resize": "调整大小"
       }
     },
     "scheduleConsent": {
@@ -1370,7 +1379,8 @@
       "empty": {
         "title": "当前没有活跃浏览器",
         "description": "您可以手动启动浏览器实例，或让 Agent 通过 MCP 创建。"
-      }
+      },
+      "sessionTitle": "浏览器会话"
     },
     "workspaceChat": {
       "actions": {
@@ -1429,7 +1439,8 @@
         "queueHint": "Agent 忙碌中，将加入待发",
         "unsavedChanges": "有改动",
         "composerHint": "Agent 忙碌中，发送即加入待发"
-      }
+      },
+      "attachmentAlt": "附件"
     },
     "workspaceSandbox": {
       "empty": {
@@ -1578,7 +1589,8 @@
         "clear": "清除",
         "dragBadge_one": "正在移动 1 项",
         "dragBadge_other": "正在移动 {{count}} 项",
-        "deleteConfirm": "再次点击确认删除 {{count}} 项"
+        "deleteConfirm": "再次点击确认删除 {{count}} 项",
+        "toggleAll": "全选/取消全选"
       },
       "errors": {
         "listFailed": "列出目录失败：{{status}}",
@@ -1629,7 +1641,8 @@
         "noAttachments": "未挂载"
       },
       "placeholders": {
-        "content": "记忆内容，推荐使用 Markdown 格式"
+        "content": "记忆内容，推荐使用 Markdown 格式",
+        "version": "v?"
       },
       "dialog": {
         "createTitle": "新建记忆库",
@@ -2183,6 +2196,9 @@
         "providerRequired": "API 供应商不能为空",
         "modelRequired": "模型不能为空",
         "createFailed": "创建模板失败"
+      },
+      "toasts": {
+        "created": "模板已创建"
       }
     },
     "teamworkSection": {
@@ -2359,7 +2375,8 @@
       },
       "actions": {
         "new": "新建",
-        "delete": "删除凭证"
+        "delete": "删除凭证",
+        "edit": "编辑凭证"
       },
       "dialogs": {
         "editTitle": "编辑凭证"
@@ -2532,6 +2549,10 @@
       "toc": {
         "label": "本页目录",
         "empty": "当前文档没有标题。"
+      },
+      "image": {
+        "prev": "上一张",
+        "next": "下一张"
       }
     },
     "officePreview": {
@@ -2806,7 +2827,8 @@
         "library": "资源库",
         "integration": "集成",
         "management": "管理",
-        "admin": "管理后台"
+        "admin": "管理后台",
+        "label": "程序坞"
       },
       "slot": {
         "openApp": "打开应用",
@@ -2864,7 +2886,8 @@
         "empty": "还没有工作空间 —— 创建一个开始使用",
         "noResults": "没有匹配的工作空间。",
         "sessionCount_one": "{{count}} 个会话",
-        "sessionCount_other": "{{count}} 个会话"
+        "sessionCount_other": "{{count}} 个会话",
+        "needsReply": "待回复"
       },
       "activityApp": {
         "appLabel": "统计信息",
@@ -2901,6 +2924,12 @@
           "cacheRead": "缓存读",
           "cacheCreation": "缓存写"
         }
+      },
+      "punchCard": {
+        "aria": "按小时活跃度"
+      },
+      "statCard": {
+        "aria": "迷你趋势图"
       }
     },
     "admin": {
@@ -3039,6 +3068,10 @@
         },
         "errors": {
           "loadFailed": "加载集群数据失败"
+        },
+        "pools": {
+          "agent": "Agent 池 — 工作区",
+          "sandbox": "Sandbox 池 — Sandbox"
         }
       },
       "systemSettingsSection": {
@@ -3514,7 +3547,8 @@
       "lastRun": "最近运行：{{value}}",
       "actions": {
         "new": "新建",
-        "delete": "删除"
+        "delete": "删除",
+        "edit": "编辑"
       },
       "states": {
         "saving": "保存中...",
@@ -3572,6 +3606,65 @@
       "ownTitle": "你的 workspace 正在使用此 Skill",
       "otherCount": "另有 {{count}} 个其他用户的 workspace 在使用。",
       "templateCount": "{{count}} 个模板版本引用了此 Skill。"
+    },
+    "chat": {
+      "toolRenderers": {
+        "labels": {
+          "unknown": "未知"
+        },
+        "agentRequest": {
+          "loadFailed": "加载请求失败",
+          "loading": "加载中…",
+          "approve": "批准",
+          "reject": "拒绝",
+          "reasonPlaceholder": "原因（可选）",
+          "confirmReject": "确认拒绝",
+          "cancel": "取消",
+          "reason": "原因",
+          "appliedAt": "应用时间",
+          "invalidPayload": "无效的请求内容",
+          "cleared": "已清除",
+          "fields": {
+            "name": "名称",
+            "cron": "Cron",
+            "runAt": "执行时间",
+            "prompt": "Prompt",
+            "type": "类型",
+            "timezone": "时区",
+            "enabled": "启用",
+            "slug": "Slug",
+            "visibility": "可见性",
+            "agentType": "Agent 类型",
+            "provider": "API 供应商",
+            "model": "模型",
+            "smallModel": "小模型",
+            "systemPrompt": "系统 Prompt",
+            "content": "内容",
+            "id": "ID",
+            "attach": "启用技能",
+            "detach": "禁用技能"
+          },
+          "status": {
+            "pending": "待处理",
+            "approved": "已批准",
+            "rejected": "已拒绝",
+            "applied": "已应用"
+          },
+          "commandTypes": {
+            "plain": "普通",
+            "struct": "结构化"
+          },
+          "visibilityValues": {
+            "private": "私有",
+            "user": "用户",
+            "public": "公开"
+          },
+          "enabledStates": {
+            "on": "开启",
+            "off": "关闭"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Sweep `web/src` for inline (un-i18n'd) user-facing text and fix it in two parts.

### 1. Fill 57 missing i18n keys (runtime bugs)
These `t()` calls referenced keys absent from the locale files, so users saw raw key strings:
- The entire `components.chat.toolRenderers` namespace was missing — the Agent Request / Builder Mode approval cards shipped `t()` calls (including dynamic keys for fields, status, command types, visibility, enabled states) without ever adding the locale subtree. Rebuilt the full `agentRequest` subtree + `labels.unknown`.
- Scattered gaps in `TemplateConfigView`, `CreateTemplateDialog`, `CredentialsSection`, `WorkspaceAutomationPanel`, plus `common.edit`.

### 2. Extract & translate 15 remaining inline strings
Visible titles, accessibility labels (`aria-label` / iframe `title` / SVG `<title>`), placeholders, and img `alt` across `InfraSection`, `ImagePreview`, `WorkspaceBrowserPanel`/`ChatPanel`/`FilesPanel`, `MemoryStoresPanel`, `PopoutLayer`, `Dock`, `WorkspacesApp`, `MasterSidebar`, `AppHeaderSearch`.

`PunchCard` / `StatCard` are intentionally decoupled from `react-i18next` (caller supplies localized strings), so their aria labels are injected via props from `ActivityApp` rather than wiring `useTranslation` into them.

All keys added to both `en-US.json` and `zh-CN.json`, terminology aligned to existing conventions.

## Deliberately left untouched
- **`file-preview/extend/`** — vendored Extend UI (MIT); left as-is to avoid diverging from upstream.
- **`CONNECTOR_TYPES`** in `IntegrationPage` — the English const strings are inert source-of-truth, overridden at render by dynamic `typeConfigs.*` keys (already present in both locales).
- Proper nouns (product/OS/crypto-algorithm names), technical spec values, and format-example placeholders.

## Known pre-existing issue (not introduced here)
With the 57 missing keys fixed, `i18n:check-keys` no longer early-exits and now surfaces ~32 pre-existing key-set mismatches. These are false positives from the naive checker:
- `*_one` suffix keys exist only in `en-US` — correct i18next plural behavior (zh has only `_other`).
- `appKeywords.*` exist only in `zh-CN` — English aliases live in the `APP_KEYWORDS_EN` constant by design; `localizedKeywords` skips locales missing the key.

No redundant keys were added to satisfy the linter. Making the checker plural/alias-aware is a separate change.

## Verification
- `npx tsc --noEmit` passes
- `i18n:check-keys` missing keys = 0
- Custom detectors (CJK / `.ts` / `.tsx` JSX attrs / object-literal labels / multiline JSX text) report no remaining inline strings outside vendored code

🤖 Generated with [Claude Code](https://claude.com/claude-code)