### PR TITLE
chore(web): drop obsolete zh-CN ultimate-fallback in inline-help loader

### DIFF
--- a/web/src/docs/inline-help/_load.ts
+++ b/web/src/docs/inline-help/_load.ts
@@ -59,23 +59,7 @@ const docs = import.meta.glob('./*/*.md', {
 
 const FALLBACK = 'en-US'
 
-// TODO(2026-05-08): backfill missing en-US/*.md and remove ULTIMATE_FALLBACK.
-// Today most `agent-config-*.md` (and several others) only exist under
-// zh-CN/, so non-zh users get "" from loadDoc. In DocumentedDialog that
-// empty string flips `hasDocs` between false (1 empty section → empty
-// join) and true (≥2 empty sections → just the "\n\n---\n\n" separator),
-// which makes the dialog's column layout flicker — Safari fires a scroll
-// event on every resulting resize, the scroll-synced `visibleSections`
-// recomputes, hasDocs flips again, infinite loop. Falling back from en-US
-// to zh-CN keeps docs non-empty and stable until en-US files land.
-const ULTIMATE_FALLBACK = 'zh-CN'
-
 export function loadDoc(name: InlineDocName): string {
   const lang = i18n.language || FALLBACK
-  return (
-    docs[`./${lang}/${name}.md`] ??
-    docs[`./${FALLBACK}/${name}.md`] ??
-    docs[`./${ULTIMATE_FALLBACK}/${name}.md`] ??
-    ''
-  )
+  return docs[`./${lang}/${name}.md`] ?? docs[`./${FALLBACK}/${name}.md`] ?? ''
 }


### PR DESCRIPTION
## What

All en-US inline-help docs (`web/src/docs/inline-help/en-US/*.md`) have been backfilled — every name in the `InlineDocName` union now has both an en-US and a zh-CN file, with no Chinese leaks or staleness. That makes the `en-US → zh-CN` `ULTIMATE_FALLBACK` in `loadDoc` (and its `TODO(2026-05-08)`) dead code: the fallback branch can only fire when an en-US file is missing, which no longer happens.

Simplifies `loadDoc` to the standard `lang → en-US` fallback.

## Verification
- `npx tsc --noEmit` passes
- Confirmed 39/39 inline-help docs present in both locales (and 4/4 route-prompt-presets), no CJK in any en-US `.md`, no zh-CN file newer than its en-US counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)