### PR TITLE
self-host: pull AFS image from its own repo

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -80,6 +80,11 @@ export RUNTIME_PYTHON_IMAGE="${RUNTIME_PYTHON_IMAGE:-docker.io/library/python:3.
 export RUNTIME_GOLANG_IMAGE="${RUNTIME_GOLANG_IMAGE:-docker.io/library/golang:1.23}"
 export PAUSE_IMAGE="${PAUSE_IMAGE:-registry.k8s.io/pause:3.9}"
 
+# AFS (AgentFS) ships from its own repo (github.com/neutree-ai/afs) and versions
+# independently of the platform, so it lives outside ${REGISTRY}/${IMAGE_TAG}.
+# Default to its public image; an offline/mirrored install overrides this.
+export AFS_IMAGE="${AFS_IMAGE:-ghcr.io/neutree-ai/afs:latest}"
+
 # Resolve AGENT_IMAGE_PREFIX if it references REGISTRY
 AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}-agent}"
 export AGENT_IMAGE_PREFIX
@@ -248,6 +253,7 @@ render_manifests() {
   VARS+='${IMAGE_PULL_SECRET}'
   VARS+='${POSTGRES_IMAGE}${GOTENBERG_IMAGE}${COTURN_IMAGE}${NFS_SERVER_IMAGE}'
   VARS+='${RUNTIME_NODE_IMAGE}${RUNTIME_PYTHON_IMAGE}${RUNTIME_GOLANG_IMAGE}${PAUSE_IMAGE}'
+  VARS+='${AFS_IMAGE}'
   VARS+='${PG_USERNAME}${PG_PASSWORD}${PG_INSTANCES}${PG_STORAGE_SIZE}${PG_STORAGE_CLASS}'
   VARS+='${NFS_SERVER}${NFS_PATH}${NFS_STORAGE_CLASS}'
   VARS+='${JWT_SECRET}${CREDENTIAL_ENCRYPTION_KEY}'

--- a/self-host/manifests/afs.yaml
+++ b/self-host/manifests/afs.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: afs-controller
-          image: ${REGISTRY}/afs:${IMAGE_TAG}
+          image: ${AFS_IMAGE}
           command: ["afs-controller"]
           args: ["/etc/afs/controller.toml"]
           ports:

--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -118,7 +118,7 @@ spec:
             - name: AFS_ENABLED
               value: "true"
             - name: AFS_IMAGE
-              value: "${REGISTRY}/afs:${IMAGE_TAG}"
+              value: "${AFS_IMAGE}"
             - name: AFS_CONTROLLER_ADDR
               value: "afs-controller.${NAMESPACE}.svc:9100"
             - name: MEMORY_FUSE_IMAGE

--- a/self-host/values.env.example
+++ b/self-host/values.env.example
@@ -41,6 +41,11 @@ IMAGE_TAG=latest
 # RUNTIME_GOLANG_IMAGE=docker.io/library/golang:1.23
 # PAUSE_IMAGE=registry.k8s.io/pause:3.9
 
+# AFS (AgentFS) image. Ships from its own repo (github.com/neutree-ai/afs) and
+# versions independently, so it is not under ${REGISTRY}/${IMAGE_TAG}. Override
+# to pin a version or to pull from a mirror.
+# AFS_IMAGE=ghcr.io/neutree-ai/afs:latest
+
 # --- Cluster & Access -------------------------------------------------------
 NAMESPACE=nap
 KUBECONFIG=./kubeconfig.yaml


### PR DESCRIPTION
AFS (AgentFS) now ships from its own repo (github.com/neutree-ai/afs) and versions independently of the platform, so its image is no longer co-released under `${REGISTRY}/${IMAGE_TAG}`.

## Changes
- Add an `AFS_IMAGE` knob in `install.sh` (default `ghcr.io/neutree-ai/afs:latest`), added to the envsubst allowlist.
- `afs.yaml` + `control-plane.yaml` (`AFS_IMAGE` env) now reference `${AFS_IMAGE}` instead of `${REGISTRY}/afs:${IMAGE_TAG}`.
- Document the knob in `values.env.example`.

Verified with `./install.sh --render-only` — both manifests resolve to `ghcr.io/neutree-ai/afs:latest`, no unresolved vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)