### PR TITLE
ci: tag-trigger chromium-headful; scope build-images tag glob

### DIFF
--- a/.github/workflows/build-chromium-headful.yml
+++ b/.github/workflows/build-chromium-headful.yml
@@ -10,7 +10,9 @@ name: Build & push chromium-headful
 #
 # Credit: https://github.com/onkernel/kernel-images (Apache-2.0). See NOTICE.
 #
-# Manual only (workflow_dispatch). Bump UPSTREAM_REF to take a newer upstream.
+# Triggered by a `chromium-headful-v<x.y.z>` tag (publishes :latest, :<sha>,
+# :<x.y.z>) or manually via workflow_dispatch. Bump UPSTREAM_REF to take a newer
+# upstream.
 
 on:
   workflow_dispatch:
@@ -19,6 +21,9 @@ on:
         description: "onkernel/kernel-images ref to build (default: pinned commit)"
         required: false
         default: ""
+  push:
+    tags:
+      - "chromium-headful-v*"
 
 env:
   IMAGE: ghcr.io/neutree-ai/agent-platform/chromium-headful
@@ -43,6 +48,11 @@ jobs:
         run: |
           sha="$(git rev-parse --short HEAD)"
           tags="$(printf '%s\n%s' "${IMAGE}:latest" "${IMAGE}:${sha}")"
+          # On a `chromium-headful-v<x.y.z>` tag push, also publish :<x.y.z>.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            ver="v${GITHUB_REF_NAME##*-v}"
+            tags="$(printf '%s\n%s' "$tags" "${IMAGE}:${ver}")"
+          fi
           { echo "tags<<EOF"; echo "$tags"; echo "EOF"; } >> "$GITHUB_OUTPUT"
           echo "building ${UPSTREAM_REPO}@${sha}"
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,7 +19,7 @@ on:
         default: ""
   push:
     tags:
-      - "*-v*"
+      - "nap-*-v*"
 
 env:
   IMAGE_PREFIX: ghcr.io/neutree-ai/agent-platform


### PR DESCRIPTION
Follow-up to make image builds tag-driven (with `workflow_dispatch` kept as a manual fallback).

## Changes
- **build-chromium-headful.yml**: add a `chromium-headful-v<x.y.z>` tag trigger; the tag also publishes a `:<x.y.z>` image tag (alongside `:latest` and `:<sha>`).
- **build-images.yml**: narrow the tag glob `*-v*` → `nap-*-v*` so a `chromium-headful-v*` tag doesn't spin up (no-op) matrix jobs in this workflow.

Per-service version tags remain the model (e.g. `nap-cp-v1.2.0` builds only cp) — services version independently, no lockstep. afs (separate repo) already has `v*` + dispatch and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)