### PR TITLE
feat(docs-site): migrate platform docs into OSS (English)

### DIFF
--- a/.github/workflows/build-chromium-headful.yml
+++ b/.github/workflows/build-chromium-headful.yml
@@ -1,0 +1,69 @@
+name: Build & push chromium-headful
+
+# The headful Chromium image used by browser-service is built from the upstream
+# project onkernel/kernel-images (Apache-2.0), pinned to a known-good commit,
+# and republished to GHCR so a self-host install pulls it from the same registry
+# path as the first-party images (${REGISTRY}/chromium-headful).
+#
+# We do not vendor or modify their sources — this workflow checks out the pinned
+# upstream commit and builds their Dockerfile as-is.
+#
+# Credit: https://github.com/onkernel/kernel-images (Apache-2.0). See NOTICE.
+#
+# Manual only (workflow_dispatch). Bump UPSTREAM_REF to take a newer upstream.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "onkernel/kernel-images ref to build (default: pinned commit)"
+        required: false
+        default: ""
+
+env:
+  IMAGE: ghcr.io/neutree-ai/agent-platform/chromium-headful
+  UPSTREAM_REPO: onkernel/kernel-images
+  UPSTREAM_REF: 4e9359cab045c95d4250aa378c583eaeb9dcc4d8
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout upstream kernel-images
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.UPSTREAM_REPO }}
+          ref: ${{ github.event.inputs.ref || env.UPSTREAM_REF }}
+
+      - name: Resolve tags
+        id: t
+        run: |
+          sha="$(git rev-parse --short HEAD)"
+          tags="$(printf '%s\n%s' "${IMAGE}:latest" "${IMAGE}:${sha}")"
+          { echo "tags<<EOF"; echo "$tags"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+          echo "building ${UPSTREAM_REPO}@${sha}"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build context is the upstream repo root — the Dockerfile's first stage
+      # COPYs server/ sources from there (see images/chromium-headful/build-docker.sh).
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: images/chromium-headful/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.t.outputs.tags }}
+          cache-from: type=gha,scope=chromium-headful
+          cache-to: type=gha,scope=chromium-headful,mode=max

--- a/NOTICE
+++ b/NOTICE
@@ -5,3 +5,15 @@ This product includes software developed at Arcfra.
 
 Licensed under the Apache License, Version 2.0. See the LICENSE file for the
 full license text.
+
+--------------------------------------------------------------------------------
+
+This product's Remote Browser capability uses a headful Chromium container image
+built from:
+
+  kernel-images — https://github.com/onkernel/kernel-images
+  Copyright onkernel, Inc.
+  Licensed under the Apache License, Version 2.0.
+
+The image is built from upstream sources as-is (pinned to a specific commit) and
+republished for distribution; the sources are not modified.

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -81,7 +81,10 @@ editing `values.env` and re-running `./install.sh` (it's idempotent).
 
 Lets agents drive a real browser that users watch live over WebRTC. NAP ships
 the browser service and a bundled TURN relay (coturn); enabling it is just
-configuration — no third-party component required.
+configuration. The headful Chromium itself runs from a published image
+(`${REGISTRY}/chromium-headful`) built from the upstream
+[onkernel/kernel-images](https://github.com/onkernel/kernel-images) project
+(Apache-2.0; see [NOTICE](../NOTICE)) — no extra setup on your side.
 
 1. In `values.env` set:
    ```bash


### PR DESCRIPTION
## What

Brings the documentation site into the platform repo as a top-level **`docs-site/`** (Astro + Starlight), translated to English and rebranded to **Neutree Agent Platform**. Previously this lived only in the downstream in-smtx repo, in Chinese, under TOS branding.

## Scope

**Translated zh-CN → en-US** (TOS → Neutree Agent Platform / NAP, SmartX removed):
- `concepts/*` (9), `guides/*` (7), `index.mdx`, `use-cases/translation.md`
- Component UI strings (TocWithActions, CodeBlock, SkillCard) and all source comments

**Self-host section — rewritten, not translated.** The old text documented a different *offline* install (`tos-cp`, namespace `tos`, image tarball, in-cluster registry). It is rewritten against this repo's `self-host/` *connected* installer:
- `nap-cp` / namespace `nap` / `nap-seed-oauth-clients` / `nap-installer`, public-registry image pulls
- Code Sandbox documented as the **third-party OpenSandbox** backend (the installer does *not* install it; the platform connects via `OPENSANDBOX_URL`)
- The interactive `values.env` generator's schema now matches `self-host/values.env.example` exactly (dropped `REGISTRY_SERVER/USERNAME/PASSWORD`, added `IMAGE_TAG` / `OPENSANDBOX_URL` / `SANDBOX_NODE_SELECTOR`, `nap` defaults)
- Frozen env-var names the installer keeps (`TOS_HOST`, `TOS_NODE_PORT`, …) preserved verbatim

**Dropped:** SmartX-internal use-cases (`infra-ops`, `sre-oncall`).

**Other:** docs domain → `nap.docs.neutree.ai`; favicon `TOS` → `NAP`; package name `@neutree-ai/docs-site` (the `tos-docs-site` registry image name stays, controlled by the downstream rollout script); `knip.json` gains a `docs-site` workspace for the Astro entry points.

## Verification
- `astro build` — 24 pages, no errors
- Zero CJK and zero `tos`/`smartx` branding left in source (frozen `TOS_*` env names excepted)
- Broken cross-page anchors (heading slugs changed by translation) fixed to the new English slugs
- pre-commit (knip + biome) passes

## Follow-up (after merge)
Downstream in-smtx will bump the submodule, point the docs-site build context at `$OSS_REPO_ROOT/docs-site`, and drop its local copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)