### PR TITLE
fix(docs-site): use neutral base images in Dockerfile

### DIFF
--- a/docs-site/Dockerfile
+++ b/docs-site/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.1ms.run/library/node:22-alpine AS build
+FROM node:22-alpine AS build
 COPY .npmrc /root/.npmrc
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -6,7 +6,7 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM docker.1ms.run/library/nginx:1.27-alpine
+FROM nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
The docs-site Dockerfile was migrated verbatim from the downstream repo and still carried a China-mirror registry prefix (`docker.1ms.run/library/...`) on both `FROM` lines. Switches them to the upstream images (`node:22-alpine`, `nginx:1.27-alpine`), consistent with the other services (which use bare `node:22-bookworm-slim`). Registry mirroring is handled by the build environment (daemon `registry-mirrors`), not baked into source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)