### PR TITLE
feat(web): add copy-path button to file viewer breadcrumb

### DIFF
--- a/web/src/components/workspace/FileViewer.tsx
+++ b/web/src/components/workspace/FileViewer.tsx
@@ -95,6 +95,7 @@ export function FileViewer({
   const [isLoading, setIsLoading] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [pathCopied, setPathCopied] = useState(false)
 
   const url = fileUrl(workspaceId, filePath, drive)
   const previewUrl = filePreviewUrl(workspaceId, filePath, drive)
@@ -182,6 +183,14 @@ export function FileViewer({
       setTimeout(() => setCopied(false), 1500)
     })
   }, [isEditing, editedContent, fileContent])
+
+  const handleCopyPath = useCallback(() => {
+    const fullPath = `${drive === 'afs' ? '/mnt/afs' : '/workspace'}${filePath}`
+    navigator.clipboard.writeText(fullPath).then(() => {
+      setPathCopied(true)
+      setTimeout(() => setPathCopied(false), 1500)
+    })
+  }, [drive, filePath])
 
   // Download the raw file via the same bytes endpoint the directory list and
   // context menu use. Uses the cache-buster-free `url` so the download always
@@ -351,6 +360,16 @@ export function FileViewer({
             {drive === 'afs' ? '/mnt/afs' : '/workspace'}
             {filePath}
           </span>
+          <AppHeaderButton
+            icon={pathCopied ? ClipboardCheck : Copy}
+            title={
+              pathCopied
+                ? t('components.fileViewer.actions.copiedPath')
+                : t('components.fileViewer.actions.copyPath')
+            }
+            onClick={handleCopyPath}
+            className={pathCopied ? 'text-success hover:text-success' : ''}
+          />
           <div className="flex shrink-0 items-center gap-0.5">{actions}</div>
         </div>
       )}

--- a/web/src/components/workspace/WorkspaceFilesPanel.tsx
+++ b/web/src/components/workspace/WorkspaceFilesPanel.tsx
@@ -34,6 +34,8 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronUp,
+  ClipboardCheck,
+  Copy,
   Download,
   File,
   FilePlus,
@@ -162,6 +164,15 @@ export function WorkspaceFilesPanel({
   // Component-local — purely render-cycle state.
   const [afsRefreshToken, setAfsRefreshToken] = useState(0)
   const [fileRefreshToken, setFileRefreshToken] = useState(0)
+  const [pathCopied, setPathCopied] = useState(false)
+
+  const handleCopyPath = useCallback(() => {
+    const fullPath = `${drive === 'workspace' ? '/workspace' : '/mnt/afs'}${viewingPath}`
+    navigator.clipboard.writeText(fullPath).then(() => {
+      setPathCopied(true)
+      setTimeout(() => setPathCopied(false), 1500)
+    })
+  }, [drive, viewingPath])
 
   const isViewingFile = viewingPath !== '' && !viewingPath.endsWith('/')
   const currentPath = isViewingFile
@@ -1232,6 +1243,18 @@ export function WorkspaceFilesPanel({
                   )
                 })}
               </div>
+            )}
+            {isViewingFile && !isSearching && (
+              <AppHeaderButton
+                icon={pathCopied ? ClipboardCheck : Copy}
+                title={
+                  pathCopied
+                    ? t('components.workspaceFiles.actions.copiedPath')
+                    : t('components.workspaceFiles.actions.copyPath')
+                }
+                onClick={handleCopyPath}
+                className={pathCopied ? 'text-success hover:text-success' : ''}
+              />
             )}
           </>,
           headerSlot,

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1534,7 +1534,9 @@
         "newFolder": "New folder",
         "newFolderDisabled": "Create not allowed here",
         "managePublicLinks": "Manage public links",
-        "refresh": "Refresh"
+        "refresh": "Refresh",
+        "copyPath": "Copy path",
+        "copiedPath": "Path copied!"
       },
       "placeholders": {
         "search": "Search files..."
@@ -2447,6 +2449,8 @@
         "backToList": "Back to file list",
         "copied": "Copied!",
         "copyContent": "Copy file content",
+        "copyPath": "Copy path",
+        "copiedPath": "Path copied!",
         "download": "Download file",
         "edit": "Edit file",
         "save": "Save",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1559,7 +1559,9 @@
         "newFolder": "新建文件夹",
         "newFolderDisabled": "当前位置不可新建",
         "managePublicLinks": "管理公开链接",
-        "refresh": "刷新"
+        "refresh": "刷新",
+        "copyPath": "复制路径",
+        "copiedPath": "路径已复制"
       },
       "placeholders": {
         "search": "搜索文件..."
@@ -2471,6 +2473,8 @@
         "backToList": "返回文件列表",
         "copied": "已复制",
         "copyContent": "复制文件内容",
+        "copyPath": "复制路径",
+        "copiedPath": "路径已复制",
         "download": "下载文件",
         "edit": "编辑文件",
         "save": "保存",


### PR DESCRIPTION
## What

Adds a one-click **copy path** button next to the file path breadcrumb in the file viewer, so users can grab the full file path without retyping it.

Closes #67

## Changes

- **`WorkspaceFilesPanel.tsx`** — primary location. The visible breadcrumb (`/workspace › …`, chevron-separated) is rendered here into the AppWindow header. Added a `copy path` button shown only when viewing a file; copies `/<drive-root>` + path.
- **`FileViewer.tsx`** — same button in its inline-header fallback (used standalone / in the pop-out), next to the path span.
- Both reuse the existing copy affordance: copy icon flips to a green checkmark for 1.5s on success.
- **i18n** — added `copyPath` / `copiedPath` to `en-US.json` and `zh-CN.json` under both `workspaceFiles.actions` and `fileViewer.actions`.

## Verification

- `npx tsc --noEmit` passes
- Locale JSON validates
- Pre-commit (knip + biome) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)