### PR TITLE
docs(skills): add local→cloud agent handoff section to nap-api

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -38,15 +38,18 @@ CP_SPEC_URL=http://localhost:3000/api/docs/openapi.json npm run cp
 skills/
 ├── specs/               # snapshotted OpenAPI specs (regenerable)
 ├── templates/           # Eta template overrides applied during generation
-├── nap-api/             # generated skill (SKILL.md + references/)
+├── assets/              # hand-authored static files overlaid onto generated skills
+│   └── nap-api/         # → copied into nap-api/ after generation (e.g. scripts/handoff.sh)
+├── nap-api/             # generated skill (SKILL.md + references/ + overlaid assets)
 └── nap-design-system/   # hand-authored skill (SKILL.md + references/)
 ```
 
 ## Customizations (generated skills)
 
 - `templates/authentication.md.eta` — replaces the generic bearer-scheme blurb with steps to create a token in NAP Web (**Integration → Tokens**).
-- `templates/skill.md.eta` — scenario-based `description` for recall, a concrete Base URL (`$NAP_BASE_URL` convention), a Conventions block (URL-encode path-bearing query params), a "Common Intents → Operation" map, and an inline end-to-end async chat + poll example.
+- `templates/skill.md.eta` — scenario-based `description` for recall, a concrete Base URL (`$NAP_BASE_URL` convention), a Conventions block (URL-encode path-bearing query params), a "Common Intents → Operation" map, an end-to-end async chat + poll example, and a Handoff section pointing at the shipped `scripts/handoff.sh` driver.
 - `templates/resource.md.eta` — per-resource orientation preambles (disambiguates the look-alike agent-files / agent-afs-files / afs / shares resources).
+- `assets/nap-api/` — static files (e.g. `scripts/handoff.sh`) overlaid into the skill **after** generation via `openapi-to-skills --assets`. Regeneration wipes the skill dir, so hand-authored files that ship with the skill must live here, not in `nap-api/` directly. An asset overrides a generated file of the same path.
 
 The skill-specific blocks above are keyed by skill name (`nap-api`); other skills fall back to generic rendering.
 

--- a/skills/assets/nap-api/scripts/handoff.sh
+++ b/skills/assets/nap-api/scripts/handoff.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Hand a task to a NAP cloud agent (async chat) and print its reply.
+#
+# Usage:
+#   ./handoff.sh "implement what TASK.md describes"     # new session
+#   ./handoff.sh -s <session_id> "now add tests"        # continue a session
+#   echo "long task text..." | ./handoff.sh -           # task from stdin
+#
+# Env: NAP_TOKEN (required), NAP_BASE_URL (default https://nap.example.com),
+#      NAP_WS (required, target workspace id),
+#      POLL_INTERVAL (default 3s), POLL_MAX (default 200 polls).
+#
+# Keep this file ASCII-only: macOS bash 3.2 miscounts quotes when the *source*
+# holds multibyte chars. Task text is argv, not source, so it may be any language.
+set -euo pipefail
+
+BASE="${NAP_BASE_URL:-https://nap.example.com}"
+WS="${NAP_WS:?set NAP_WS to the target workspace id}"
+INTERVAL="${POLL_INTERVAL:-3}"
+MAX="${POLL_MAX:-200}"
+TOKEN="$(printenv NAP_TOKEN || true)"
+[ -n "$TOKEN" ] || { echo "error: NAP_TOKEN not set" >&2; exit 1; }
+
+SID=""
+if [ "${1:-}" = "-s" ]; then
+  SID="${2:-}"; shift 2
+  [ -n "$SID" ] || { echo "error: -s requires a session_id" >&2; exit 1; }
+fi
+MSG="${1:-}"; [ "$MSG" = "-" ] && MSG="$(cat)"
+[ -n "$MSG" ] || { echo "error: no task message provided" >&2; exit 1; }
+
+auth=(-H "Authorization: Bearer $TOKEN")
+
+# 1. Start (new) or continue (-s) the turn. async returns a session_id at once.
+#    Including session_id in the body continues that conversation.
+body=$(jq -n --arg m "$MSG" --arg s "$SID" \
+  '{message:$m, mode:"async", source:"api"} + (if $s=="" then {} else {session_id:$s} end)')
+SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" "${auth[@]}" \
+  -H "Content-Type: application/json" -d "$body" | jq -r '.session_id // empty')
+[ -n "$SID" ] || { echo "error: no session_id returned" >&2; exit 1; }
+echo "session_id: $SID" >&2
+
+# 2. Poll until the turn truly ends, then read the latest result.
+#    Any non-"agent" status means the turn handed back (idle, human, ...) -- we
+#    don't need to tell them apart. But a just-issued POST can briefly still read
+#    the PREVIOUS turn's status, so also require the last message to be this
+#    turn's assistant reply before treating the turn as done.
+i=0
+while :; do
+  i=$((i+1))
+  st=$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" "${auth[@]}" | jq -r '.chat_status // "unknown"')
+  msgs=$(curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" "${auth[@]}")
+  last_role=$(echo "$msgs" | jq -r 'last | .role // "none"')
+  printf '\r  polling... %s / last=%s (%d)   ' "$st" "$last_role" "$i" >&2
+  if [ "$st" != "agent" ] && [ "$last_role" = "assistant" ]; then
+    echo >&2
+    echo "$msgs" | jq -r '[.[] | select(.role=="assistant")] | last | (.content // "")
+      | if . == "" then "[no text reply; likely tool actions -- continue with -s to ask more]" else . end'
+    break
+  fi
+  [ "$i" -ge "$MAX" ] && { echo >&2; echo "error: timed out after $MAX polls (status=$st)" >&2; exit 2; }
+  sleep "$INTERVAL"
+done
+echo "continue with: $0 -s $SID \"...\"" >&2

--- a/skills/nap-api/SKILL.md
+++ b/skills/nap-api/SKILL.md
@@ -81,6 +81,52 @@ curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" \
 
 Continue the same conversation by POSTing again with this `session_id` in the body. For token-by-token output instead of polling, omit `mode` (or use `mode: "stream"`) and read the `text/event-stream` of UniversalEvent frames.
 
+## Handoff — local agent → NAP cloud agent
+
+A common use of async chat is **delegation**: a local agent (e.g. running on your laptop) hands a chunk of work to a NAP cloud agent that has its own persistent workspace, filesystem, and toolset, then collects the result.
+
+The cloud agent is a **fresh, isolated agent** — it shares none of your local context, conversation, or files. Everything it needs travels through the workspace and the prompt, so front-load it:
+
+- **Stage inputs** — write the files it needs into the workspace first (`PUT /api/workspaces/{id}/agent/files?path=…`, raw body), or tell it a repo to clone. Don't assume it can see your local tree.
+- **Write a self-contained, autonomous prompt** — the task, where the inputs live, the acceptance criteria, and how to behave unattended: proceed without asking for approval, reply tersely, and don't echo large files (you'll inspect artifacts directly). A clarifying round-trip is expensive, so decide up front. This prompt is also where you keep the agent from blocking on approval gates — instruct it to proceed rather than ask.
+
+Then dispatch async, poll until the turn ends, and collect. If the agent still hands back to you (`chat_status: "human"`), its question is the last message in the transcript — answer by POSTing the same `session_id`, which resumes the turn.
+
+```bash
+BASE="${NAP_BASE_URL:-https://nap.example.com}"
+WS="<workspace-id>"
+AUTH="Authorization: Bearer $NAP_TOKEN"
+
+# 1. Stage an input file (skip if the agent clones a repo itself). Body is the
+#    raw file; the path is a URL-encoded query param, not a JSON field.
+curl -s -X PUT "$BASE/api/workspaces/$WS/agent/files?path=TASK.md" \
+  -H "$AUTH" -H "Content-Type: application/octet-stream" \
+  --data-binary @./TASK.md
+
+# 2. Dispatch a self-contained, autonomous prompt.
+SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{"message":"Read TASK.md and implement it end to end. Work autonomously; do not ask for approval. Reply tersely; do not echo large files.","mode":"async","source":"api"}' \
+  | jq -r .session_id)
+
+# 3. Poll until the turn ends; if the agent hands back, answer and resume.
+while :; do
+  case "$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" -H "$AUTH" | jq -r .chat_status)" in
+    agent) sleep 3 ;;                  # still working
+    idle)  break ;;                    # turn finished
+    human)                             # agent asked — its question is the last message
+      curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[-1].content'
+      # decide an answer, then resume the same session by posting again
+      curl -s -X POST "$BASE/api/workspaces/$WS/chat" -H "$AUTH" -H "Content-Type: application/json" \
+        -d "$(jq -nc --arg sid "$SID" '{message:"<your answer>",session_id:$sid,mode:"async",source:"api"}')" >/dev/null ;;
+  esac
+done
+
+# 4. Collect: read the transcript, then pull artifacts back out of the workspace.
+curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[] | "\(.role): \(.content)"'
+curl -s "$BASE/api/workspaces/$WS/agent/files?path=out/result.json" -H "$AUTH"
+```
+
 ## Resources
 
 - **workspaces** → `references/resources/workspaces.md` (33 ops)

--- a/skills/nap-api/SKILL.md
+++ b/skills/nap-api/SKILL.md
@@ -90,42 +90,78 @@ The cloud agent is a **fresh, isolated agent** — it shares none of your local 
 - **Stage inputs** — write the files it needs into the workspace first (`PUT /api/workspaces/{id}/agent/files?path=…`, raw body), or tell it a repo to clone. Don't assume it can see your local tree.
 - **Write a self-contained, autonomous prompt** — the task, where the inputs live, the acceptance criteria, and how to behave unattended: proceed without asking for approval, reply tersely, and don't echo large files (you'll inspect artifacts directly). A clarifying round-trip is expensive, so decide up front. This prompt is also where you keep the agent from blocking on approval gates — instruct it to proceed rather than ask.
 
-Then dispatch async, poll until the turn ends, and collect. If the agent still hands back to you (`chat_status: "human"`), its question is the last message in the transcript — answer by POSTing the same `session_id`, which resumes the turn.
+### Driver script
+
+Save this as `handoff.sh` and call it directly, or adapt it. It dispatches a turn, polls until the turn truly ends, and prints the agent's reply. Pass `-s <session_id>` to **continue** an existing session instead of starting a new one — that's how you carry a conversation across calls.
 
 ```bash
+#!/usr/bin/env bash
+# Hand a task to a NAP cloud agent (async chat) and print its reply.
+#
+# Usage:
+#   ./handoff.sh "implement what TASK.md describes"     # new session
+#   ./handoff.sh -s <session_id> "now add tests"        # continue a session
+#   echo "long task text..." | ./handoff.sh -           # task from stdin
+#
+# Env: NAP_TOKEN (required), NAP_BASE_URL (default https://nap.example.com),
+#      NAP_WS (required, target workspace id),
+#      POLL_INTERVAL (default 3s), POLL_MAX (default 200 polls).
+#
+# Keep this file ASCII-only: macOS bash 3.2 miscounts quotes when the *source*
+# holds multibyte chars. Task text is argv, not source, so it may be any language.
+set -euo pipefail
+
 BASE="${NAP_BASE_URL:-https://nap.example.com}"
-WS="<workspace-id>"
-AUTH="Authorization: Bearer $NAP_TOKEN"
+WS="${NAP_WS:?set NAP_WS to the target workspace id}"
+INTERVAL="${POLL_INTERVAL:-3}"
+MAX="${POLL_MAX:-200}"
+TOKEN="$(printenv NAP_TOKEN || true)"
+[ -n "$TOKEN" ] || { echo "error: NAP_TOKEN not set" >&2; exit 1; }
 
-# 1. Stage an input file (skip if the agent clones a repo itself). Body is the
-#    raw file; the path is a URL-encoded query param, not a JSON field.
-curl -s -X PUT "$BASE/api/workspaces/$WS/agent/files?path=TASK.md" \
-  -H "$AUTH" -H "Content-Type: application/octet-stream" \
-  --data-binary @./TASK.md
+SID=""
+if [ "${1:-}" = "-s" ]; then
+  SID="${2:-}"; shift 2
+  [ -n "$SID" ] || { echo "error: -s requires a session_id" >&2; exit 1; }
+fi
+MSG="${1:-}"; [ "$MSG" = "-" ] && MSG="$(cat)"
+[ -n "$MSG" ] || { echo "error: no task message provided" >&2; exit 1; }
 
-# 2. Dispatch a self-contained, autonomous prompt.
-SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" \
-  -H "$AUTH" -H "Content-Type: application/json" \
-  -d '{"message":"Read TASK.md and implement it end to end. Work autonomously; do not ask for approval. Reply tersely; do not echo large files.","mode":"async","source":"api"}' \
-  | jq -r .session_id)
+auth=(-H "Authorization: Bearer $TOKEN")
 
-# 3. Poll until the turn ends; if the agent hands back, answer and resume.
+# 1. Start (new) or continue (-s) the turn. async returns a session_id at once.
+#    Including session_id in the body continues that conversation.
+body=$(jq -n --arg m "$MSG" --arg s "$SID" \
+  '{message:$m, mode:"async", source:"api"} + (if $s=="" then {} else {session_id:$s} end)')
+SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" "${auth[@]}" \
+  -H "Content-Type: application/json" -d "$body" | jq -r '.session_id // empty')
+[ -n "$SID" ] || { echo "error: no session_id returned" >&2; exit 1; }
+echo "session_id: $SID" >&2
+
+# 2. Poll until the turn truly ends, then read the latest result.
+#    Any non-"agent" status means the turn handed back (idle, human, ...) -- we
+#    don't need to tell them apart. But a just-issued POST can briefly still read
+#    the PREVIOUS turn's status, so also require the last message to be this
+#    turn's assistant reply before treating the turn as done.
+i=0
 while :; do
-  case "$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" -H "$AUTH" | jq -r .chat_status)" in
-    agent) sleep 3 ;;                  # still working
-    idle)  break ;;                    # turn finished
-    human)                             # agent asked — its question is the last message
-      curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[-1].content'
-      # decide an answer, then resume the same session by posting again
-      curl -s -X POST "$BASE/api/workspaces/$WS/chat" -H "$AUTH" -H "Content-Type: application/json" \
-        -d "$(jq -nc --arg sid "$SID" '{message:"<your answer>",session_id:$sid,mode:"async",source:"api"}')" >/dev/null ;;
-  esac
+  i=$((i+1))
+  st=$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" "${auth[@]}" | jq -r '.chat_status // "unknown"')
+  msgs=$(curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" "${auth[@]}")
+  last_role=$(echo "$msgs" | jq -r 'last | .role // "none"')
+  printf '\r  polling... %s / last=%s (%d)   ' "$st" "$last_role" "$i" >&2
+  if [ "$st" != "agent" ] && [ "$last_role" = "assistant" ]; then
+    echo >&2
+    echo "$msgs" | jq -r '[.[] | select(.role=="assistant")] | last | (.content // "")
+      | if . == "" then "[no text reply; likely tool actions -- continue with -s to ask more]" else . end'
+    break
+  fi
+  [ "$i" -ge "$MAX" ] && { echo >&2; echo "error: timed out after $MAX polls (status=$st)" >&2; exit 2; }
+  sleep "$INTERVAL"
 done
-
-# 4. Collect: read the transcript, then pull artifacts back out of the workspace.
-curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[] | "\(.role): \(.content)"'
-curl -s "$BASE/api/workspaces/$WS/agent/files?path=out/result.json" -H "$AUTH"
+echo "continue with: $0 -s $SID \"...\"" >&2
 ```
+
+The script prints only the agent's final text; read the full turn (tool calls included) with `GET /api/workspaces/{id}/messages?session_id=$SID`, and pull any files the agent produced with `GET /api/workspaces/{id}/agent/files?path=…`.
 
 ## Resources
 

--- a/skills/nap-api/SKILL.md
+++ b/skills/nap-api/SKILL.md
@@ -92,76 +92,17 @@ The cloud agent is a **fresh, isolated agent** — it shares none of your local 
 
 ### Driver script
 
-Save this as `handoff.sh` and call it directly, or adapt it. It dispatches a turn, polls until the turn truly ends, and prints the agent's reply. Pass `-s <session_id>` to **continue** an existing session instead of starting a new one — that's how you carry a conversation across calls.
+A ready-to-run driver ships with this skill at **`scripts/handoff.sh`** — call it directly or adapt it. It dispatches a turn, polls until the turn truly ends, and prints the agent's reply. Pass `-s <session_id>` to **continue** an existing session instead of starting a new one — that's how you carry a conversation across calls.
 
 ```bash
-#!/usr/bin/env bash
-# Hand a task to a NAP cloud agent (async chat) and print its reply.
-#
-# Usage:
-#   ./handoff.sh "implement what TASK.md describes"     # new session
-#   ./handoff.sh -s <session_id> "now add tests"        # continue a session
-#   echo "long task text..." | ./handoff.sh -           # task from stdin
-#
-# Env: NAP_TOKEN (required), NAP_BASE_URL (default https://nap.example.com),
-#      NAP_WS (required, target workspace id),
-#      POLL_INTERVAL (default 3s), POLL_MAX (default 200 polls).
-#
-# Keep this file ASCII-only: macOS bash 3.2 miscounts quotes when the *source*
-# holds multibyte chars. Task text is argv, not source, so it may be any language.
-set -euo pipefail
+export NAP_TOKEN=<service-token> NAP_WS=<workspace-id>   # NAP_BASE_URL defaults to https://nap.example.com
 
-BASE="${NAP_BASE_URL:-https://nap.example.com}"
-WS="${NAP_WS:?set NAP_WS to the target workspace id}"
-INTERVAL="${POLL_INTERVAL:-3}"
-MAX="${POLL_MAX:-200}"
-TOKEN="$(printenv NAP_TOKEN || true)"
-[ -n "$TOKEN" ] || { echo "error: NAP_TOKEN not set" >&2; exit 1; }
-
-SID=""
-if [ "${1:-}" = "-s" ]; then
-  SID="${2:-}"; shift 2
-  [ -n "$SID" ] || { echo "error: -s requires a session_id" >&2; exit 1; }
-fi
-MSG="${1:-}"; [ "$MSG" = "-" ] && MSG="$(cat)"
-[ -n "$MSG" ] || { echo "error: no task message provided" >&2; exit 1; }
-
-auth=(-H "Authorization: Bearer $TOKEN")
-
-# 1. Start (new) or continue (-s) the turn. async returns a session_id at once.
-#    Including session_id in the body continues that conversation.
-body=$(jq -n --arg m "$MSG" --arg s "$SID" \
-  '{message:$m, mode:"async", source:"api"} + (if $s=="" then {} else {session_id:$s} end)')
-SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" "${auth[@]}" \
-  -H "Content-Type: application/json" -d "$body" | jq -r '.session_id // empty')
-[ -n "$SID" ] || { echo "error: no session_id returned" >&2; exit 1; }
-echo "session_id: $SID" >&2
-
-# 2. Poll until the turn truly ends, then read the latest result.
-#    Any non-"agent" status means the turn handed back (idle, human, ...) -- we
-#    don't need to tell them apart. But a just-issued POST can briefly still read
-#    the PREVIOUS turn's status, so also require the last message to be this
-#    turn's assistant reply before treating the turn as done.
-i=0
-while :; do
-  i=$((i+1))
-  st=$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" "${auth[@]}" | jq -r '.chat_status // "unknown"')
-  msgs=$(curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" "${auth[@]}")
-  last_role=$(echo "$msgs" | jq -r 'last | .role // "none"')
-  printf '\r  polling... %s / last=%s (%d)   ' "$st" "$last_role" "$i" >&2
-  if [ "$st" != "agent" ] && [ "$last_role" = "assistant" ]; then
-    echo >&2
-    echo "$msgs" | jq -r '[.[] | select(.role=="assistant")] | last | (.content // "")
-      | if . == "" then "[no text reply; likely tool actions -- continue with -s to ask more]" else . end'
-    break
-  fi
-  [ "$i" -ge "$MAX" ] && { echo >&2; echo "error: timed out after $MAX polls (status=$st)" >&2; exit 2; }
-  sleep "$INTERVAL"
-done
-echo "continue with: $0 -s $SID \"...\"" >&2
+scripts/handoff.sh "implement what TASK.md describes"    # new session -> prints session_id + reply
+scripts/handoff.sh -s <session_id> "now add tests"       # continue that session
+echo "long task text..." | scripts/handoff.sh -          # task from stdin
 ```
 
-The script prints only the agent's final text; read the full turn (tool calls included) with `GET /api/workspaces/{id}/messages?session_id=$SID`, and pull any files the agent produced with `GET /api/workspaces/{id}/agent/files?path=…`.
+The poll loop treats any non-`agent` `chat_status` as the turn handing back (idle, human, …) — but also requires the last message to be this turn's assistant reply, guarding against a just-issued POST briefly reading the previous turn's status. It prints only the agent's final text; read the full turn (tool calls included) with `GET /api/workspaces/{id}/messages?session_id=…`, and pull any files the agent produced with `GET /api/workspaces/{id}/agent/files?path=…`.
 
 ## Resources
 

--- a/skills/nap-api/scripts/handoff.sh
+++ b/skills/nap-api/scripts/handoff.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Hand a task to a NAP cloud agent (async chat) and print its reply.
+#
+# Usage:
+#   ./handoff.sh "implement what TASK.md describes"     # new session
+#   ./handoff.sh -s <session_id> "now add tests"        # continue a session
+#   echo "long task text..." | ./handoff.sh -           # task from stdin
+#
+# Env: NAP_TOKEN (required), NAP_BASE_URL (default https://nap.example.com),
+#      NAP_WS (required, target workspace id),
+#      POLL_INTERVAL (default 3s), POLL_MAX (default 200 polls).
+#
+# Keep this file ASCII-only: macOS bash 3.2 miscounts quotes when the *source*
+# holds multibyte chars. Task text is argv, not source, so it may be any language.
+set -euo pipefail
+
+BASE="${NAP_BASE_URL:-https://nap.example.com}"
+WS="${NAP_WS:?set NAP_WS to the target workspace id}"
+INTERVAL="${POLL_INTERVAL:-3}"
+MAX="${POLL_MAX:-200}"
+TOKEN="$(printenv NAP_TOKEN || true)"
+[ -n "$TOKEN" ] || { echo "error: NAP_TOKEN not set" >&2; exit 1; }
+
+SID=""
+if [ "${1:-}" = "-s" ]; then
+  SID="${2:-}"; shift 2
+  [ -n "$SID" ] || { echo "error: -s requires a session_id" >&2; exit 1; }
+fi
+MSG="${1:-}"; [ "$MSG" = "-" ] && MSG="$(cat)"
+[ -n "$MSG" ] || { echo "error: no task message provided" >&2; exit 1; }
+
+auth=(-H "Authorization: Bearer $TOKEN")
+
+# 1. Start (new) or continue (-s) the turn. async returns a session_id at once.
+#    Including session_id in the body continues that conversation.
+body=$(jq -n --arg m "$MSG" --arg s "$SID" \
+  '{message:$m, mode:"async", source:"api"} + (if $s=="" then {} else {session_id:$s} end)')
+SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" "${auth[@]}" \
+  -H "Content-Type: application/json" -d "$body" | jq -r '.session_id // empty')
+[ -n "$SID" ] || { echo "error: no session_id returned" >&2; exit 1; }
+echo "session_id: $SID" >&2
+
+# 2. Poll until the turn truly ends, then read the latest result.
+#    Any non-"agent" status means the turn handed back (idle, human, ...) -- we
+#    don't need to tell them apart. But a just-issued POST can briefly still read
+#    the PREVIOUS turn's status, so also require the last message to be this
+#    turn's assistant reply before treating the turn as done.
+i=0
+while :; do
+  i=$((i+1))
+  st=$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" "${auth[@]}" | jq -r '.chat_status // "unknown"')
+  msgs=$(curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" "${auth[@]}")
+  last_role=$(echo "$msgs" | jq -r 'last | .role // "none"')
+  printf '\r  polling... %s / last=%s (%d)   ' "$st" "$last_role" "$i" >&2
+  if [ "$st" != "agent" ] && [ "$last_role" = "assistant" ]; then
+    echo >&2
+    echo "$msgs" | jq -r '[.[] | select(.role=="assistant")] | last | (.content // "")
+      | if . == "" then "[no text reply; likely tool actions -- continue with -s to ask more]" else . end'
+    break
+  fi
+  [ "$i" -ge "$MAX" ] && { echo >&2; echo "error: timed out after $MAX polls (status=$st)" >&2; exit 2; }
+  sleep "$INTERVAL"
+done
+echo "continue with: $0 -s $SID \"...\"" >&2

--- a/skills/package.json
+++ b/skills/package.json
@@ -4,7 +4,7 @@
   "description": "NAP Agent Skills — generated REST-API skills plus hand-authored skills (e.g. the design system)",
   "scripts": {
     "fetch:cp": "curl -fsSL \"${CP_SPEC_URL:?set CP_SPEC_URL to a running control-plane, e.g. http://localhost:3000/api/docs/openapi.json}\" -o specs/control-plane.json",
-    "generate:cp": "npx -y openapi-to-skills@0.3.1 ./specs/control-plane.json -o . -n nap-api -f -t templates --excludeTags me,workspace-layouts,teamwork,invites --excludePaths '/api/workspaces/{id}/profile' --excludeDeprecated",
+    "generate:cp": "npx -y openapi-to-skills@0.3.2 ./specs/control-plane.json -o . -n nap-api -f -t templates --assets assets/nap-api --excludeTags me,workspace-layouts,teamwork,invites --excludePaths '/api/workspaces/{id}/profile' --excludeDeprecated",
     "cp": "npm run fetch:cp && npm run generate:cp"
   }
 }

--- a/skills/templates/skill.md.eta
+++ b/skills/templates/skill.md.eta
@@ -130,42 +130,78 @@ The cloud agent is a **fresh, isolated agent** — it shares none of your local 
 - **Stage inputs** — write the files it needs into the workspace first (`PUT /api/workspaces/{id}/agent/files?path=…`, raw body), or tell it a repo to clone. Don't assume it can see your local tree.
 - **Write a self-contained, autonomous prompt** — the task, where the inputs live, the acceptance criteria, and how to behave unattended: proceed without asking for approval, reply tersely, and don't echo large files (you'll inspect artifacts directly). A clarifying round-trip is expensive, so decide up front. This prompt is also where you keep the agent from blocking on approval gates — instruct it to proceed rather than ask.
 
-Then dispatch async, poll until the turn ends, and collect. If the agent still hands back to you (`chat_status: "human"`), its question is the last message in the transcript — answer by POSTing the same `session_id`, which resumes the turn.
+### Driver script
+
+Save this as `handoff.sh` and call it directly, or adapt it. It dispatches a turn, polls until the turn truly ends, and prints the agent's reply. Pass `-s <session_id>` to **continue** an existing session instead of starting a new one — that's how you carry a conversation across calls.
 
 ```bash
+#!/usr/bin/env bash
+# Hand a task to a NAP cloud agent (async chat) and print its reply.
+#
+# Usage:
+#   ./handoff.sh "implement what TASK.md describes"     # new session
+#   ./handoff.sh -s <session_id> "now add tests"        # continue a session
+#   echo "long task text..." | ./handoff.sh -           # task from stdin
+#
+# Env: NAP_TOKEN (required), NAP_BASE_URL (default https://nap.example.com),
+#      NAP_WS (required, target workspace id),
+#      POLL_INTERVAL (default 3s), POLL_MAX (default 200 polls).
+#
+# Keep this file ASCII-only: macOS bash 3.2 miscounts quotes when the *source*
+# holds multibyte chars. Task text is argv, not source, so it may be any language.
+set -euo pipefail
+
 BASE="${NAP_BASE_URL:-https://nap.example.com}"
-WS="<workspace-id>"
-AUTH="Authorization: Bearer $NAP_TOKEN"
+WS="${NAP_WS:?set NAP_WS to the target workspace id}"
+INTERVAL="${POLL_INTERVAL:-3}"
+MAX="${POLL_MAX:-200}"
+TOKEN="$(printenv NAP_TOKEN || true)"
+[ -n "$TOKEN" ] || { echo "error: NAP_TOKEN not set" >&2; exit 1; }
 
-# 1. Stage an input file (skip if the agent clones a repo itself). Body is the
-#    raw file; the path is a URL-encoded query param, not a JSON field.
-curl -s -X PUT "$BASE/api/workspaces/$WS/agent/files?path=TASK.md" \
-  -H "$AUTH" -H "Content-Type: application/octet-stream" \
-  --data-binary @./TASK.md
+SID=""
+if [ "${1:-}" = "-s" ]; then
+  SID="${2:-}"; shift 2
+  [ -n "$SID" ] || { echo "error: -s requires a session_id" >&2; exit 1; }
+fi
+MSG="${1:-}"; [ "$MSG" = "-" ] && MSG="$(cat)"
+[ -n "$MSG" ] || { echo "error: no task message provided" >&2; exit 1; }
 
-# 2. Dispatch a self-contained, autonomous prompt.
-SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" \
-  -H "$AUTH" -H "Content-Type: application/json" \
-  -d '{"message":"Read TASK.md and implement it end to end. Work autonomously; do not ask for approval. Reply tersely; do not echo large files.","mode":"async","source":"api"}' \
-  | jq -r .session_id)
+auth=(-H "Authorization: Bearer $TOKEN")
 
-# 3. Poll until the turn ends; if the agent hands back, answer and resume.
+# 1. Start (new) or continue (-s) the turn. async returns a session_id at once.
+#    Including session_id in the body continues that conversation.
+body=$(jq -n --arg m "$MSG" --arg s "$SID" \
+  '{message:$m, mode:"async", source:"api"} + (if $s=="" then {} else {session_id:$s} end)')
+SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" "${auth[@]}" \
+  -H "Content-Type: application/json" -d "$body" | jq -r '.session_id // empty')
+[ -n "$SID" ] || { echo "error: no session_id returned" >&2; exit 1; }
+echo "session_id: $SID" >&2
+
+# 2. Poll until the turn truly ends, then read the latest result.
+#    Any non-"agent" status means the turn handed back (idle, human, ...) -- we
+#    don't need to tell them apart. But a just-issued POST can briefly still read
+#    the PREVIOUS turn's status, so also require the last message to be this
+#    turn's assistant reply before treating the turn as done.
+i=0
 while :; do
-  case "$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" -H "$AUTH" | jq -r .chat_status)" in
-    agent) sleep 3 ;;                  # still working
-    idle)  break ;;                    # turn finished
-    human)                             # agent asked — its question is the last message
-      curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[-1].content'
-      # decide an answer, then resume the same session by posting again
-      curl -s -X POST "$BASE/api/workspaces/$WS/chat" -H "$AUTH" -H "Content-Type: application/json" \
-        -d "$(jq -nc --arg sid "$SID" '{message:"<your answer>",session_id:$sid,mode:"async",source:"api"}')" >/dev/null ;;
-  esac
+  i=$((i+1))
+  st=$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" "${auth[@]}" | jq -r '.chat_status // "unknown"')
+  msgs=$(curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" "${auth[@]}")
+  last_role=$(echo "$msgs" | jq -r 'last | .role // "none"')
+  printf '\r  polling... %s / last=%s (%d)   ' "$st" "$last_role" "$i" >&2
+  if [ "$st" != "agent" ] && [ "$last_role" = "assistant" ]; then
+    echo >&2
+    echo "$msgs" | jq -r '[.[] | select(.role=="assistant")] | last | (.content // "")
+      | if . == "" then "[no text reply; likely tool actions -- continue with -s to ask more]" else . end'
+    break
+  fi
+  [ "$i" -ge "$MAX" ] && { echo >&2; echo "error: timed out after $MAX polls (status=$st)" >&2; exit 2; }
+  sleep "$INTERVAL"
 done
-
-# 4. Collect: read the transcript, then pull artifacts back out of the workspace.
-curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[] | "\(.role): \(.content)"'
-curl -s "$BASE/api/workspaces/$WS/agent/files?path=out/result.json" -H "$AUTH"
+echo "continue with: $0 -s $SID \"...\"" >&2
 ```
+
+The script prints only the agent's final text; read the full turn (tool calls included) with `GET /api/workspaces/{id}/messages?session_id=$SID`, and pull any files the agent produced with `GET /api/workspaces/{id}/agent/files?path=…`.
 <% } %>
 ## Resources
 

--- a/skills/templates/skill.md.eta
+++ b/skills/templates/skill.md.eta
@@ -120,6 +120,52 @@ curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" \
 ```
 
 Continue the same conversation by POSTing again with this `session_id` in the body. For token-by-token output instead of polling, omit `mode` (or use `mode: "stream"`) and read the `text/event-stream` of UniversalEvent frames.
+
+## Handoff — local agent → NAP cloud agent
+
+A common use of async chat is **delegation**: a local agent (e.g. running on your laptop) hands a chunk of work to a NAP cloud agent that has its own persistent workspace, filesystem, and toolset, then collects the result.
+
+The cloud agent is a **fresh, isolated agent** — it shares none of your local context, conversation, or files. Everything it needs travels through the workspace and the prompt, so front-load it:
+
+- **Stage inputs** — write the files it needs into the workspace first (`PUT /api/workspaces/{id}/agent/files?path=…`, raw body), or tell it a repo to clone. Don't assume it can see your local tree.
+- **Write a self-contained, autonomous prompt** — the task, where the inputs live, the acceptance criteria, and how to behave unattended: proceed without asking for approval, reply tersely, and don't echo large files (you'll inspect artifacts directly). A clarifying round-trip is expensive, so decide up front. This prompt is also where you keep the agent from blocking on approval gates — instruct it to proceed rather than ask.
+
+Then dispatch async, poll until the turn ends, and collect. If the agent still hands back to you (`chat_status: "human"`), its question is the last message in the transcript — answer by POSTing the same `session_id`, which resumes the turn.
+
+```bash
+BASE="${NAP_BASE_URL:-https://nap.example.com}"
+WS="<workspace-id>"
+AUTH="Authorization: Bearer $NAP_TOKEN"
+
+# 1. Stage an input file (skip if the agent clones a repo itself). Body is the
+#    raw file; the path is a URL-encoded query param, not a JSON field.
+curl -s -X PUT "$BASE/api/workspaces/$WS/agent/files?path=TASK.md" \
+  -H "$AUTH" -H "Content-Type: application/octet-stream" \
+  --data-binary @./TASK.md
+
+# 2. Dispatch a self-contained, autonomous prompt.
+SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{"message":"Read TASK.md and implement it end to end. Work autonomously; do not ask for approval. Reply tersely; do not echo large files.","mode":"async","source":"api"}' \
+  | jq -r .session_id)
+
+# 3. Poll until the turn ends; if the agent hands back, answer and resume.
+while :; do
+  case "$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" -H "$AUTH" | jq -r .chat_status)" in
+    agent) sleep 3 ;;                  # still working
+    idle)  break ;;                    # turn finished
+    human)                             # agent asked — its question is the last message
+      curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[-1].content'
+      # decide an answer, then resume the same session by posting again
+      curl -s -X POST "$BASE/api/workspaces/$WS/chat" -H "$AUTH" -H "Content-Type: application/json" \
+        -d "$(jq -nc --arg sid "$SID" '{message:"<your answer>",session_id:$sid,mode:"async",source:"api"}')" >/dev/null ;;
+  esac
+done
+
+# 4. Collect: read the transcript, then pull artifacts back out of the workspace.
+curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" -H "$AUTH" | jq -r '.[] | "\(.role): \(.content)"'
+curl -s "$BASE/api/workspaces/$WS/agent/files?path=out/result.json" -H "$AUTH"
+```
 <% } %>
 ## Resources
 

--- a/skills/templates/skill.md.eta
+++ b/skills/templates/skill.md.eta
@@ -132,76 +132,17 @@ The cloud agent is a **fresh, isolated agent** — it shares none of your local 
 
 ### Driver script
 
-Save this as `handoff.sh` and call it directly, or adapt it. It dispatches a turn, polls until the turn truly ends, and prints the agent's reply. Pass `-s <session_id>` to **continue** an existing session instead of starting a new one — that's how you carry a conversation across calls.
+A ready-to-run driver ships with this skill at **`scripts/handoff.sh`** — call it directly or adapt it. It dispatches a turn, polls until the turn truly ends, and prints the agent's reply. Pass `-s <session_id>` to **continue** an existing session instead of starting a new one — that's how you carry a conversation across calls.
 
 ```bash
-#!/usr/bin/env bash
-# Hand a task to a NAP cloud agent (async chat) and print its reply.
-#
-# Usage:
-#   ./handoff.sh "implement what TASK.md describes"     # new session
-#   ./handoff.sh -s <session_id> "now add tests"        # continue a session
-#   echo "long task text..." | ./handoff.sh -           # task from stdin
-#
-# Env: NAP_TOKEN (required), NAP_BASE_URL (default https://nap.example.com),
-#      NAP_WS (required, target workspace id),
-#      POLL_INTERVAL (default 3s), POLL_MAX (default 200 polls).
-#
-# Keep this file ASCII-only: macOS bash 3.2 miscounts quotes when the *source*
-# holds multibyte chars. Task text is argv, not source, so it may be any language.
-set -euo pipefail
+export NAP_TOKEN=<service-token> NAP_WS=<workspace-id>   # NAP_BASE_URL defaults to https://nap.example.com
 
-BASE="${NAP_BASE_URL:-https://nap.example.com}"
-WS="${NAP_WS:?set NAP_WS to the target workspace id}"
-INTERVAL="${POLL_INTERVAL:-3}"
-MAX="${POLL_MAX:-200}"
-TOKEN="$(printenv NAP_TOKEN || true)"
-[ -n "$TOKEN" ] || { echo "error: NAP_TOKEN not set" >&2; exit 1; }
-
-SID=""
-if [ "${1:-}" = "-s" ]; then
-  SID="${2:-}"; shift 2
-  [ -n "$SID" ] || { echo "error: -s requires a session_id" >&2; exit 1; }
-fi
-MSG="${1:-}"; [ "$MSG" = "-" ] && MSG="$(cat)"
-[ -n "$MSG" ] || { echo "error: no task message provided" >&2; exit 1; }
-
-auth=(-H "Authorization: Bearer $TOKEN")
-
-# 1. Start (new) or continue (-s) the turn. async returns a session_id at once.
-#    Including session_id in the body continues that conversation.
-body=$(jq -n --arg m "$MSG" --arg s "$SID" \
-  '{message:$m, mode:"async", source:"api"} + (if $s=="" then {} else {session_id:$s} end)')
-SID=$(curl -s -X POST "$BASE/api/workspaces/$WS/chat" "${auth[@]}" \
-  -H "Content-Type: application/json" -d "$body" | jq -r '.session_id // empty')
-[ -n "$SID" ] || { echo "error: no session_id returned" >&2; exit 1; }
-echo "session_id: $SID" >&2
-
-# 2. Poll until the turn truly ends, then read the latest result.
-#    Any non-"agent" status means the turn handed back (idle, human, ...) -- we
-#    don't need to tell them apart. But a just-issued POST can briefly still read
-#    the PREVIOUS turn's status, so also require the last message to be this
-#    turn's assistant reply before treating the turn as done.
-i=0
-while :; do
-  i=$((i+1))
-  st=$(curl -s "$BASE/api/workspaces/$WS/sessions/$SID" "${auth[@]}" | jq -r '.chat_status // "unknown"')
-  msgs=$(curl -s "$BASE/api/workspaces/$WS/messages?session_id=$SID" "${auth[@]}")
-  last_role=$(echo "$msgs" | jq -r 'last | .role // "none"')
-  printf '\r  polling... %s / last=%s (%d)   ' "$st" "$last_role" "$i" >&2
-  if [ "$st" != "agent" ] && [ "$last_role" = "assistant" ]; then
-    echo >&2
-    echo "$msgs" | jq -r '[.[] | select(.role=="assistant")] | last | (.content // "")
-      | if . == "" then "[no text reply; likely tool actions -- continue with -s to ask more]" else . end'
-    break
-  fi
-  [ "$i" -ge "$MAX" ] && { echo >&2; echo "error: timed out after $MAX polls (status=$st)" >&2; exit 2; }
-  sleep "$INTERVAL"
-done
-echo "continue with: $0 -s $SID \"...\"" >&2
+scripts/handoff.sh "implement what TASK.md describes"    # new session -> prints session_id + reply
+scripts/handoff.sh -s <session_id> "now add tests"       # continue that session
+echo "long task text..." | scripts/handoff.sh -          # task from stdin
 ```
 
-The script prints only the agent's final text; read the full turn (tool calls included) with `GET /api/workspaces/{id}/messages?session_id=$SID`, and pull any files the agent produced with `GET /api/workspaces/{id}/agent/files?path=…`.
+The poll loop treats any non-`agent` `chat_status` as the turn handing back (idle, human, …) — but also requires the last message to be this turn's assistant reply, guarding against a just-issued POST briefly reading the previous turn's status. It prints only the agent's final text; read the full turn (tool calls included) with `GET /api/workspaces/{id}/messages?session_id=…`, and pull any files the agent produced with `GET /api/workspaces/{id}/agent/files?path=…`.
 <% } %>
 ## Resources
 


### PR DESCRIPTION
## What

Adds a **Handoff — local agent → NAP cloud agent** section to the `nap-api` skill, documenting the common async-chat delegation flow as an end-to-end runnable example.

The cloud agent is a fresh, isolated agent, so the section emphasizes front-loading everything through the workspace + prompt:

1. **Stage inputs** — `PUT /agent/files?path=…` (raw body) or have the agent clone a repo.
2. **Dispatch** a self-contained, autonomous prompt (`mode: async`). Approval-gate behavior is driven from the prompt (tell it to proceed, don't ask) rather than via config.
3. **Poll** `chat_status`; on `human` hand-back, the agent's question is the last transcript message — answer by POSTing the same `session_id`, which resumes the turn.
4. **Collect** transcript + pull artifacts back out of the workspace.

## How

- Authored in `templates/skill.md.eta` (the `nap-api`-keyed block, next to the existing async-chat example) — the only hand-editable surface for this generated skill.
- Regenerated `nap-api/SKILL.md` via `generate:cp` (the other 158 operation files are byte-identical).

## Verified against cp source

- `human` status is triggered by `question.requested`; the question lives in the messages transcript (not `pending_message`, which is a *queued follow-up draft*).
- `agent/files` write takes `path` as a URL-encoded query param with a raw `application/octet-stream` body — not JSON.
- `GET /messages?session_id=` returns a chronological array of `{role, content, …}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)