### PR TITLE
provider test: require explicit model, drop hardcoded defaults

### DIFF
--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -347,7 +347,13 @@ providers.openapi(testRoute, async (c) => {
   if (!provider) return c.json({ error: 'Provider not found' }, 404)
 
   const body = c.req.valid('json')
-  const model = body.model || ''
+  const model = body.model?.trim() || ''
+
+  // A model is mandatory: the probe issues a real completion request, so there
+  // is no safe provider-agnostic default to fall back to.
+  if (!model) {
+    return c.json({ ok: false, detail: 'Select a model to test this provider.' }, 200)
+  }
 
   // Merge optional draft config over the stored provider so the Edit Provider
   // dialog can probe unsaved values. A blank api_key keeps the stored key.
@@ -370,7 +376,7 @@ providers.openapi(testRoute, async (c) => {
           'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
-          model: model || 'claude-haiku-4-5-20251001',
+          model,
           max_tokens: 1,
           messages: [{ role: 'user', content: 'hi' }],
         }),
@@ -381,13 +387,12 @@ providers.openapi(testRoute, async (c) => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${effective.api_key}`,
       }
-      const testModel = model || 'gpt-4o-mini'
 
       res = await fetch(`${baseUrl}/v1/responses`, {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          model: testModel,
+          model,
           input: 'hi',
           max_output_tokens: 1,
         }),
@@ -400,7 +405,7 @@ providers.openapi(testRoute, async (c) => {
             method: 'POST',
             headers,
             body: JSON.stringify({
-              model: testModel,
+              model,
               max_tokens: 1,
               messages: [{ role: 'user', content: 'hi' }],
             }),

--- a/web/src/components/management/ProvidersSection.tsx
+++ b/web/src/components/management/ProvidersSection.tsx
@@ -15,8 +15,14 @@ import { ConfirmButton } from '@/components/ui/confirm-button'
 import { DocumentedDialog } from '@/components/ui/documented-dialog'
 import { EmptyHero } from '@/components/ui/empty-hero'
 import { EmptyIllustration } from '@/components/ui/empty-illustration'
+import { Label } from '@/components/ui/label'
 import { SaveButton } from '@/components/ui/save-button'
-import { TestButton, TestResult } from '@/components/workspace/agent-config/ModelPicker'
+import {
+  ModelInput,
+  TestButton,
+  TestResult,
+  useProviderModels,
+} from '@/components/workspace/agent-config/ModelPicker'
 import { useDialogStack } from '@/contexts/DialogStackContext'
 import { getProviderDoc, getProviderDocsHint } from '@/docs/inline-help/provider-docs'
 import { useDeleteProvider, useProviders, useUpdateProvider } from '@/hooks/useProviders'
@@ -79,6 +85,12 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
   const [form, setForm] = useState<ProviderForm>(INITIAL_FORM)
   const [testState, setTestState] = useState<'idle' | 'testing' | 'ok' | 'fail'>('idle')
   const [testDetail, setTestDetail] = useState('')
+  // Model to probe with. The provider config itself carries no model, so the
+  // test needs one explicitly — there is no backend default any more.
+  const [testModel, setTestModel] = useState('')
+  const { models: testModels, loading: testModelsLoading } = useProviderModels(
+    dialogOpen ? (editingId ?? '') : '',
+  )
 
   // Pre-load existing grants when opening edit dialog for a team-shared provider
   useEffect(() => {
@@ -112,6 +124,7 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
     setGeneralError(null)
     setTestState('idle')
     setTestDetail('')
+    setTestModel('')
     setDialogOpen(true)
   }
 
@@ -123,6 +136,7 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
     setTestDetail('')
     try {
       const res = await api.testProvider(editingId, {
+        model: testModel || undefined,
         provider_type: form.provider_type,
         base_url: form.base_url,
         api_key: form.api_key,
@@ -282,6 +296,28 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
           errors={localizedErrors}
           isEditing
         />
+        <div className="mt-4 space-y-1.5">
+          <Label htmlFor="provider-test-model" className="text-sm font-medium">
+            {t('components.management.providers.fields.testModel')}
+          </Label>
+          <ModelInput
+            value={testModel}
+            onChange={(v) => {
+              // A model change invalidates the previous probe result.
+              setTestState('idle')
+              setTestDetail('')
+              setTestModel(v)
+            }}
+            providerId={editingId ?? ''}
+            models={testModels}
+            modelsLoading={testModelsLoading}
+            placeholder={t('components.modelPicker.placeholders.selectModel')}
+            className="h-9"
+          />
+          <p className="text-tiny text-muted-foreground">
+            {t('components.management.providers.fields.testModelHint')}
+          </p>
+        </div>
         {testState !== 'idle' && (
           <div className="mt-3">
             <TestResult state={testState} detail={testDetail} />

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3198,7 +3198,9 @@
           "editTitle": "Edit Provider"
         },
         "fields": {
-          "apiKey": "API Key (leave empty to keep current)"
+          "apiKey": "API Key (leave empty to keep current)",
+          "testModel": "Test Model",
+          "testModelHint": "Pick or type a model to probe — required for the connection test."
         },
         "empty": {
           "noProviders": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3222,7 +3222,9 @@
           "editTitle": "编辑 API 供应商"
         },
         "fields": {
-          "apiKey": "API Key（留空则保留当前值）"
+          "apiKey": "API Key（留空则保留当前值）",
+          "testModel": "测试模型",
+          "testModelHint": "选择或输入一个模型用于探测——连接测试必填。"
         },
         "empty": {
           "noProviders": {


### PR DESCRIPTION
## Problem

The provider connectivity test (`POST /providers/:id/test`) issues a real completion request. When the caller passed no model, the backend fell back to a hardcoded model (`claude-haiku-4-5-...` for Anthropic, `gpt-4o-mini` for OpenAI).

For custom OpenAI-compatible endpoints (self-hosted vLLM, proxies, etc.) that don't host that exact model name, the probe returned 404/400 and was surfaced as a **failed connection** — even though the credentials and base URL were correct. The provider app's edit dialog had no model selector, so it *always* hit this fallback path.

## Changes

**Backend** (`control-plane/src/routes/providers.ts`)
- Remove the hardcoded fallback models.
- When no model is supplied, return `{ ok: false, detail: "Select a model to test this provider." }` instead of probing with a default.

**Web** (`ProvidersSection.tsx`)
- Add an optional **Test Model** combobox to the provider edit dialog, reusing `ModelInput` + `useProviderModels` (same pattern as the workspace model picker).
- Pass the chosen model to the test request; changing the model or any config invalidates the prior probe result.

**i18n** — `providers.fields.testModel` / `testModelHint` (en + zh).

## Notes

- Behavior change: the test now **requires** a model. Picking no model yields a clear prompt rather than a misleading "connection failed".
- Verified: `tsc --noEmit` passes for both `web` and `control-plane`; pre-commit knip + biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)