### PR TITLE
feat(web): expose session navigation to plugins via window.tos

### DIFF
--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -20,6 +20,7 @@ import { useSlotContext } from '@/contexts/SlotContext'
 import { registerPlugin } from '@/plugins/registry'
 import type { WorkspacePlugin } from '@/plugins/types'
 import { useAgentSessionActions, useAgentSessionStore } from '@/stores/AgentSessionContext'
+import { useSessionNavigation } from '@/stores/active-session-store'
 import { useInstancePersistentState, useInstanceState } from '@/stores/instance-state-store'
 import { useResolvedTheme } from '@neutree-ai/theme'
 import {
@@ -54,6 +55,7 @@ interface TosHost {
     useSlotContext: typeof useSlotContext
     useAgentSessionActions: typeof useAgentSessionActions
     useAgentSessionStore: typeof useAgentSessionStore
+    useSessionNavigation: typeof useSessionNavigation
     useInstanceState: typeof useInstanceState
     useInstancePersistentState: typeof useInstancePersistentState
   }
@@ -91,6 +93,7 @@ export function installHost(): void {
       useSlotContext,
       useAgentSessionActions,
       useAgentSessionStore,
+      useSessionNavigation,
       useInstanceState,
       useInstancePersistentState,
     },

--- a/web/src/stores/active-session-store.ts
+++ b/web/src/stores/active-session-store.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { create } from 'zustand'
 
 /**
@@ -42,3 +43,25 @@ export const useActiveSession = create<ActiveSessionStore>()((set) => ({
 
   switchTo: (workspaceId, sessionId, context) => set({ workspaceId, sessionId, context }),
 }))
+
+/**
+ * Plugin-facing session navigation. Exposed on `window.tos.workspace` so
+ * embedded plugins can ask the host to focus a specific session — e.g. "click
+ * an item → jump to the session it belongs to" — without reaching into host UI
+ * themselves. The plugin only calls a generic capability; the host owns the
+ * actual switch (sidebar highlight, provider load, URL sync).
+ *
+ * Returns a stable callback. `sessionId` is the raw nap session id; the plugin
+ * passes its own `workspaceId` (the task always lives in the same workspace).
+ */
+export function useSessionNavigation(): {
+  switchToSession: (workspaceId: string, sessionId: string) => void
+} {
+  const switchTo = useActiveSession((s) => s.switchTo)
+  return useMemo(
+    () => ({
+      switchToSession: (workspaceId: string, sessionId: string) => switchTo(workspaceId, sessionId),
+    }),
+    [switchTo],
+  )
+}


### PR DESCRIPTION
## What

Adds a generic **session navigation** capability to the plugin host surface (`window.tos.workspace`), so embedded workspace plugins can ask the host to focus a specific session — e.g. "click an item → jump to the session it belongs to" — without reaching into host UI themselves.

- `stores/active-session-store.ts`: new `useSessionNavigation()` hook returning a stable `switchToSession(workspaceId, sessionId)`, backed by the existing `useActiveSession.switchTo`.
- `lib/host.ts`: expose `useSessionNavigation` on `window.tos.workspace`.

## Why

The plugin boundary principle is that **plugins must not intrude into host UI**. Previously a plugin had no way to drive session focus, so any "navigate to the originating session" behavior was impossible — and plugin actions that send a message implicitly targeted whichever session happened to be active, not the one the item belongs to.

Exposing a single generic capability lets plugins implement "jump to session" / route-an-action-to-the-right-session purely by *calling* the host, keeping the boundary intact (the host still owns sidebar highlight, provider load, and URL sync).

## Notes

- Additive only; no behavior change for existing host/plugin code.
- The first consumer is the Citewright plugin (separate repo): clickable session chip on task cards + routing task actions back to the task's originating session. The hook is intentionally generic and not coupled to that consumer.
- Typecheck (`tsc --noEmit`) and pre-commit (knip + biome) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)