### PR TITLE
fix(web): allow drag-and-drop upload when dropping onto a file row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install
         run: |
           npm ci
-          for ws in control-plane web browser-service channel-gateway sandbox-service scheduler skills-content-service docs-site; do
+          for ws in control-plane web browser-service channel-gateway sandbox-service scheduler skills-content-service env-runner-k8s docs-site; do
             # web needs --legacy-peer-deps for @base-ui/react's date-fns peer (see check job).
             if [ "$ws" = "web" ]; then (cd "$ws" && npm ci --legacy-peer-deps); else (cd "$ws" && npm ci); fi
           done

--- a/web/src/components/workspace/WorkspaceFilesPanel.tsx
+++ b/web/src/components/workspace/WorkspaceFilesPanel.tsx
@@ -963,8 +963,14 @@ export function WorkspaceFilesPanel({
       externalDragCounter.current = 0
       setIsExternalDragging(false)
       setInternalDropTarget(null)
-      if (!writeAllowed || !isDir(entry)) return
-      const destDir = `${currentPath}${currentPath.endsWith('/') ? '' : '/'}${entry.name}/`
+      if (!writeAllowed) return
+      // Folder rows upload into that subdirectory; file rows fall back to the
+      // current directory (same as the container's handleDrop). Without this
+      // fallback, dropping onto a file row early-returns and the upload is
+      // swallowed — which is all that's reachable once the list fills the panel.
+      const destDir = isDir(entry)
+        ? `${currentPath}${currentPath.endsWith('/') ? '' : '/'}${entry.name}/`
+        : currentPath
       await uploadDataTransfer(e.dataTransfer, destDir)
       return
     }


### PR DESCRIPTION
## Problem

In the workspace Files panel, dropping external files to upload silently failed whenever the file list filled the visible area. The "Drop files to upload" overlay appeared, but releasing did nothing. Uploads only worked when there was empty space below the list to drop onto.

## Root cause

Every file/folder row binds its own `onDrop` (`handleFolderDrop`). For an external drop, that handler calls `stopPropagation()` (so the container's upload `handleDrop` never sees the event) and then early-returns unless the row is a directory:

```ts
if (!writeAllowed || !isDir(entry)) return
```

When the drop lands on a *file* row, it hits this early-return and the drop is swallowed. Once the list fills the panel there is no empty drop target left, so every drop lands on a file row → uploads become impossible.

## Fix

File rows now fall back to uploading into the current directory — the same behavior as the container's `handleDrop`. Folder rows still upload into that subdirectory.

## Testing

- `npx tsc --noEmit` passes.
- Manual: dropping files onto a file row in a full list now uploads into the current directory; dropping onto a folder row still uploads into that folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)