### PR TITLE
feat(web): filter shared skills by team in the library

### DIFF
--- a/web/src/components/library/SkillTeamFilter.tsx
+++ b/web/src/components/library/SkillTeamFilter.tsx
@@ -1,0 +1,77 @@
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import { Check, ChevronDown, Users } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface SkillTeamOption {
+  id: string
+  name: string
+}
+
+interface Props {
+  /** Teams that currently have skills shared with the user. */
+  teams: SkillTeamOption[]
+  /** Selected team id, or `null` for "all teams". */
+  value: string | null
+  onChange: (next: string | null) => void
+}
+
+/**
+ * Team filter for the skill library's "Shared with me" group. As shared
+ * skills pile up across teams, this narrows the grid to a single team's
+ * skills (matched on `shared_via_teams`). Filtering is client-side off the
+ * already-loaded list, so picking a team also hides the owned groups — the
+ * intended behavior, mirroring how the scope tabs collapse the view.
+ *
+ * Renders nothing when no team has shared anything (no value in offering a
+ * one-option filter).
+ */
+export function SkillTeamFilter({ teams, value, onChange }: Props) {
+  const { t } = useTranslation()
+  if (teams.length === 0) return null
+  const selected = value ? (teams.find((tm) => tm.id === value) ?? null) : null
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={t('components.library.skills.teamFilter.label')}
+          className={cn(
+            'h-7 max-w-[12rem] gap-1.5 rounded-full px-2.5 text-xs',
+            selected && 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/15',
+          )}
+        >
+          <Users className="h-3 w-3 shrink-0" />
+          <span className="truncate">
+            {selected ? selected.name : t('components.library.skills.teamFilter.all')}
+          </span>
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-72 w-48 overflow-y-auto">
+        <DropdownMenuItem className="justify-between gap-2" onClick={() => onChange(null)}>
+          {t('components.library.skills.teamFilter.all')}
+          {!selected && <Check className="h-3 w-3 shrink-0" />}
+        </DropdownMenuItem>
+        {teams.map((tm) => (
+          <DropdownMenuItem
+            key={tm.id}
+            className="justify-between gap-2"
+            onClick={() => onChange(tm.id)}
+          >
+            <span className="truncate">{tm.name}</span>
+            {selected?.id === tm.id && <Check className="h-3 w-3 shrink-0" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/src/components/library/SkillsSection.tsx
+++ b/web/src/components/library/SkillsSection.tsx
@@ -68,6 +68,7 @@ import { toast } from 'sonner'
 import { EditSourceDialog } from './EditSourceDialog'
 import { SkillCategoryChips } from './SkillCategoryChips'
 import { SkillDetailView } from './SkillDetailView'
+import { SkillTeamFilter } from './SkillTeamFilter'
 
 export function SkillsSection({ instanceId }: { instanceId: string }) {
   const { t, i18n } = useTranslation()
@@ -101,6 +102,15 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
   const selectedCategories = useMemo(
     () => new Set<SkillCategoryChip>(selectedCategoryList),
     [selectedCategoryList],
+  )
+  // Team filter for the "Shared with me" group — narrows to skills granted
+  // via one team. Persistent so a returning user keeps their drill-in.
+  // Applied client-side (off `shared_via_teams`); the server query is
+  // unaware of it.
+  const [selectedTeamId, setSelectedTeamId] = useInstancePersistentState<string | null>(
+    instanceId,
+    'skillsTeamFilter',
+    () => null,
   )
   const [search, setSearch] = useState('')
   // 300ms debounce — fires the server query after the user pauses typing
@@ -464,10 +474,38 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
     )
   }
 
-  // Server-filtered grid data. Local-side we only sort for stable order
-  // (server already orders by name, but tanstack-query may hand us a
-  // previous-filter snapshot during refetch — keep it deterministic).
-  const visibleSkills = filteredSkills
+  // Teams that have shared something with the user, derived from the
+  // server-filtered list (i.e. before the team filter is applied) so the
+  // options stay stable no matter which team is currently selected. Empty
+  // when nothing is team-shared — the filter control then hides itself.
+  const teamOptions = useMemo(() => {
+    const byId = new Map<string, string>()
+    for (const skill of filteredSkills) {
+      for (const tm of skill.shared_via_teams) {
+        if (!byId.has(tm.id)) byId.set(tm.id, tm.name)
+      }
+    }
+    return [...byId]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [filteredSkills])
+
+  // Effective selection: ignore a stale id that no longer matches any
+  // available team (e.g. after a category/search change dropped it), but
+  // keep it in storage so it re-applies once the team reappears.
+  const activeTeamId =
+    selectedTeamId && teamOptions.some((tm) => tm.id === selectedTeamId) ? selectedTeamId : null
+
+  // Server-filtered grid data, then the client-side team filter. Narrowing
+  // to one team naturally collapses the owned groups (their skills carry no
+  // `shared_via_teams`), leaving just that team's shared skills.
+  const visibleSkills = useMemo(
+    () =>
+      activeTeamId
+        ? filteredSkills.filter((s) => s.shared_via_teams.some((tm) => tm.id === activeTeamId))
+        : filteredSkills,
+    [filteredSkills, activeTeamId],
+  )
 
   // Group skills into Library sections so source-level actions (Sync /
   // Edit / Delete source) live on a single header row instead of dangling
@@ -590,7 +628,10 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
   // when a filter is active we show the "no match" message instead of the
   // first-run empty hero.
   const isFiltered =
-    !!debouncedSearch.trim() || selectedCategoryList.length > 0 || scopeFilter !== 'all'
+    !!debouncedSearch.trim() ||
+    selectedCategoryList.length > 0 ||
+    scopeFilter !== 'all' ||
+    activeTeamId !== null
 
   return (
     <>
@@ -622,6 +663,11 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
             <div className="min-w-0 flex-1">
               <SkillCategoryChips selected={selectedCategories} onToggle={toggleCategory} />
             </div>
+            <SkillTeamFilter
+              teams={teamOptions}
+              value={activeTeamId}
+              onChange={setSelectedTeamId}
+            />
             <AppHeaderSearch value={search} onChange={setSearch} width="md" />
           </div>
         </div>

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -785,6 +785,10 @@
         "badges": {
           "yours": "Yours"
         },
+        "teamFilter": {
+          "label": "Team",
+          "all": "All teams"
+        },
         "categories": {
           "title": "Categories",
           "coding": "Coding",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -815,6 +815,10 @@
         "badges": {
           "yours": "您的"
         },
+        "teamFilter": {
+          "label": "团队",
+          "all": "全部团队"
+        },
         "categories": {
           "title": "分类",
           "coding": "编码",


### PR DESCRIPTION
## What

Adds a **team filter** to the skill library so users can narrow the "Shared with me" group to a single team's skills. As team-shared skills accumulate, finding a specific one gets harder; this gives a per-team drill-in.

A dropdown sits in the skills filter bar (next to search). It lists only teams that currently have skills shared with the user — derived from each skill's `shared_via_teams` — and hides itself entirely when nothing is team-shared.

## How

- **Client-side filter**, no API change. The server query (`q` / `category` / `visibility`) is untouched; the team filter runs over the already-loaded list.
- Picking a team narrows the grid to skills granted via that team. This naturally collapses the owned ("authored" / per-Git-source) groups, since those skills carry no `shared_via_teams` — mirroring how the scope tabs narrow the view.
- **Stable options:** team choices are derived from the list *before* the team filter is applied, so selecting a team never empties the dropdown.
- **Persistent selection** per instance (like scope/category filters). A stale id (e.g. dropped after a category/search change) is ignored but retained, so it re-applies once the team reappears.

## Files

- `web/src/components/library/SkillTeamFilter.tsx` — new dropdown component
- `web/src/components/library/SkillsSection.tsx` — option derivation + client-side filter + wiring into the sticky filter bar
- `web/src/locales/{zh-CN,en-US}.json` — `components.library.skills.teamFilter.{label,all}`

## Verification

- `tsc --noEmit` clean
- Biome + knip pass (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)