### PR TITLE
feat(environments): restrict public visibility to admins

### DIFF
--- a/control-plane/src/routes/environments.ts
+++ b/control-plane/src/routes/environments.ts
@@ -134,6 +134,10 @@ const createRouteDef = createRoute({
       description: 'Invalid grants for visibility',
       content: { 'application/json': { schema: ErrorSchema } },
     },
+    403: {
+      description: 'Non-admin attempting to create a public environment',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
     409: {
       description: 'Name already in use',
       content: { 'application/json': { schema: ErrorSchema } },
@@ -146,6 +150,14 @@ environments.openapi(createRouteDef, async (c) => {
   const body = c.req.valid('json')
   const visibility = body.visibility ?? 'private'
   const grants = body.grants ?? []
+  // Unlike content resources (prompts/skills/templates/providers), a public
+  // environment shares *infrastructure*: any user on the instance can schedule
+  // workspace pods onto the owner's cluster (their cost, capacity, and security
+  // blast radius). Offering an instance-wide shared environment is an operator
+  // decision, so creating one is admin-only; regular users get private + team.
+  if (visibility === 'public' && user.role !== 'admin') {
+    return c.json({ error: 'Only admins can create public environments' }, 403)
+  }
   if (visibility === 'team' && grants.length === 0) {
     return c.json({ error: 'visibility=team requires at least one grant' }, 400)
   }
@@ -188,6 +200,10 @@ const updateRouteDef = createRoute({
       description: 'Invalid grants for visibility',
       content: { 'application/json': { schema: ErrorSchema } },
     },
+    403: {
+      description: 'Non-admin attempting to make an environment public',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
     404: {
       description: 'Not found or not owner',
       content: { 'application/json': { schema: ErrorSchema } },
@@ -203,6 +219,11 @@ environments.openapi(updateRouteDef, async (c) => {
     return c.json({ error: 'Environment not found' }, 404)
   }
   const body = c.req.valid('json')
+  // Same guard as create, but only on *promotion*: a non-admin owner of an
+  // already-public environment can still rename it without tripping this.
+  if (body.visibility === 'public' && existing.visibility !== 'public' && user.role !== 'admin') {
+    return c.json({ error: 'Only admins can make an environment public' }, 403)
+  }
   const nextVisibility = body.visibility ?? existing.visibility
   const nextGrants = body.grants
   if (nextGrants !== undefined) {

--- a/web/src/components/dialogs/EnvironmentFormFields.tsx
+++ b/web/src/components/dialogs/EnvironmentFormFields.tsx
@@ -3,6 +3,7 @@ import { Combobox } from '@/components/ui/combobox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { useAuth } from '@/contexts/AuthContext'
 import { api } from '@/lib/api/client'
 import type { ApiTeam, EnvironmentVisibility } from '@/lib/api/types'
 import { useQuery } from '@tanstack/react-query'
@@ -30,6 +31,12 @@ interface EnvironmentFormFieldsProps {
 
 export function EnvironmentFormFields({ form, setForm, errors }: EnvironmentFormFieldsProps) {
   const { t } = useTranslation()
+  const { user } = useAuth()
+  // A public environment shares infrastructure instance-wide, so creating one is
+  // an operator decision — admin-only (enforced server-side; hidden here so
+  // non-admins don't pick an option that would 403). Still surface the option
+  // when editing an already-public env so its current value renders correctly.
+  const canPublish = user?.role === 'admin' || form.visibility === 'public'
 
   const { data: teams = [] } = useQuery<ApiTeam[]>({
     queryKey: ['teams'],
@@ -80,10 +87,14 @@ export function EnvironmentFormFields({ form, setForm, errors }: EnvironmentForm
                 label: t('components.environmentForm.visibility.team'),
                 icon: Users,
               },
-              {
-                value: 'public',
-                label: t('components.environmentForm.visibility.public'),
-              },
+              ...(canPublish
+                ? [
+                    {
+                      value: 'public' as const,
+                      label: t('components.environmentForm.visibility.public'),
+                    },
+                  ]
+                : []),
             ]}
           />
           <div className="text-tiny text-muted-foreground">


### PR DESCRIPTION
## What

A **public** environment shares *infrastructure* instance-wide: any user on the instance can schedule workspace pods onto the owner's cluster — their cost, capacity, and security blast radius. Unlike content resources (prompts, skills, templates, providers) where public sharing is open to all users, offering an instance-wide shared environment is an operator decision. This restricts creating/promoting a public environment to admins.

## Changes

- **`POST /environments`** — reject `visibility=public` from non-admins (403).
- **`PUT /environments/:id`** — reject *promotion* to public from non-admins (403), scoped to actual promotion (`existing.visibility !== 'public'`) so a non-admin owner of an already-public env can still rename it.
- **web (`EnvironmentFormFields`)** — hide the `public` option in the visibility selector for non-admins; still render it when editing an already-public environment so the current value displays correctly. Server-side gate is authoritative; the UI just avoids a guaranteed 403.

Regular users keep `private` + `team`.

## Notes

- `team` visibility already covers the common BYOI sharing case (share a cluster with your team); and the built-in environment is already the instance-wide public option.
- This is an intentional divergence from the other resource types — documented in code comments.

## Test

- `tsc --noEmit` clean on both `web` and `control-plane`.
- pre-commit (knip + biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)