### PR TITLE
feat(web): source icon + start time on session history rows

### DIFF
--- a/control-plane/src/routes/system-workspaces.ts
+++ b/control-plane/src/routes/system-workspaces.ts
@@ -206,6 +206,7 @@ function toApiSession(s: any): ApiSession {
     name: s.name,
     status: s.status,
     chat_status: s.chat_status,
+    source: s.source ?? 'web',
     created_at: s.created_at,
     last_active_at: s.last_active_at,
     message_count: s.message_count ?? 0,

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -23,6 +23,7 @@ function toApiSession(s: SessionWithPreview) {
     name: s.name,
     status: s.status,
     chat_status: s.chat_status,
+    source: s.source,
     created_at: s.created_at,
     last_active_at: s.last_active_at,
     message_count: s.message_count,

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -55,6 +55,8 @@ export interface Session {
   name: string
   status: string
   chat_status: string
+  /** How the session was created: 'web' | 'agent' | 'schedule' | 'slack' | 'wecom' | 'webhook'. */
+  source: string
   created_at: string
   last_active_at: string
   last_turn_stats: SessionTurnStats | null

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -196,6 +196,8 @@ export const ApiSessionSchema = z.object({
   name: z.string(),
   status: z.string(),
   chat_status: z.string(),
+  /** How the session was created: 'web' | 'agent' | 'schedule' | 'slack' | 'wecom' | 'webhook'. New connector types may add values, so kept as a free string. */
+  source: z.string(),
   created_at: z.string(),
   last_active_at: z.string(),
   message_count: z.number().int(),

--- a/web/src/components/workspace/WorkspaceSessionsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSessionsPanel.tsx
@@ -10,12 +10,30 @@ import { useMarkSeen, useUnreadCount } from '@/hooks/useUnread'
 import { api } from '@/lib/api/client'
 import type { Session } from '@/lib/api/types'
 import { isCommitEnter } from '@/lib/keyboard'
+import { formatFullTime, formatRelativeTime } from '@/lib/relative-time'
 import { cleanSessionPreview } from '@/lib/session-utils'
 import { cn } from '@/lib/utils'
 import { useActiveSession } from '@/stores/active-session-store'
 import { useInstanceState } from '@/stores/instance-state-store'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { Check, CheckCheck, Pencil, Search, Share2, SquarePen, Star, Trash2, X } from 'lucide-react'
+import {
+  Bot,
+  CalendarClock,
+  Check,
+  CheckCheck,
+  Globe,
+  type LucideIcon,
+  MessageCircle,
+  Pencil,
+  Search,
+  Share2,
+  Slack,
+  SquarePen,
+  Star,
+  Trash2,
+  Webhook,
+  X,
+} from 'lucide-react'
 import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
@@ -31,6 +49,27 @@ function classifyStatus(chatStatus: string): SessionStatus {
   if (s === 'agent') return 'running'
   if (s.includes('error') || s.includes('fail')) return 'error'
   return 'idle'
+}
+
+// Per-source leading icon. Every row carries one so titles stay left-aligned.
+// Literal switch (not `icons[source]`) keeps each source greppable and lets
+// new connector types fail loudly into the muted fallback.
+function sourceVisual(source: string): { Icon: LucideIcon; labelKey: string } {
+  switch (source) {
+    case 'schedule':
+      return { Icon: CalendarClock, labelKey: 'schedule' }
+    case 'slack':
+      return { Icon: Slack, labelKey: 'slack' }
+    case 'wecom':
+      return { Icon: MessageCircle, labelKey: 'wecom' }
+    case 'webhook':
+      return { Icon: Webhook, labelKey: 'webhook' }
+    case 'agent':
+      return { Icon: Bot, labelKey: 'agent' }
+    default:
+      // 'web' (manual) and any unknown source.
+      return { Icon: Globe, labelKey: 'web' }
+  }
 }
 
 type Bucket = 'today' | 'week' | 'month' | 'earlier'
@@ -77,9 +116,19 @@ function SessionRow({
   onMarkSeen,
   onToggleStar,
 }: SessionRowProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const status = classifyStatus(session.chat_status)
   const starred = !!session.starred_at
+  const { Icon: SourceIcon, labelKey: sourceLabelKey } = sourceVisual(session.source)
+  const sourceLabel = t(`components.sessions.source.${sourceLabelKey}`)
+  const relTime = useMemo(
+    () => formatRelativeTime(session.created_at, i18n.language),
+    [session.created_at, i18n.language],
+  )
+  const fullTime = useMemo(
+    () => formatFullTime(session.created_at, i18n.language),
+    [session.created_at, i18n.language],
+  )
   const previewTitle = useMemo(
     () => (session.preview ? cleanSessionPreview(session.preview) : ''),
     [session.preview],
@@ -198,6 +247,13 @@ function SessionRow({
 
   const inner = (
     <>
+      <SourceIcon
+        className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50"
+        strokeWidth={2}
+        aria-label={sourceLabel}
+      >
+        <title>{sourceLabel}</title>
+      </SourceIcon>
       <div className="min-w-0 flex-1">{titleNode}</div>
       {starred && (
         <Star
@@ -235,12 +291,24 @@ function SessionRow({
       {inner}
       <div
         className={cn(
-          'absolute right-0 top-0 bottom-0 flex items-center gap-0 pl-3 pr-2',
+          'absolute right-0 top-0 bottom-0 flex items-center gap-0 pl-2 pr-2',
           'opacity-0 transition-opacity duration-150',
           'group-hover:opacity-100 focus-within:opacity-100',
-          'bg-gradient-to-l from-card from-85% to-transparent',
+          // Solid card behind the date + actions so the date stays legible, with
+          // a short gradient lead-in strip to the left so it doesn't hard-cut
+          // the title underneath.
+          'bg-card',
+          'before:pointer-events-none before:absolute before:right-full before:inset-y-0 before:w-8 before:bg-gradient-to-l before:from-card before:to-transparent',
         )}
       >
+        {relTime && (
+          <span
+            className="mr-1.5 shrink-0 whitespace-nowrap text-mini text-muted-foreground/70"
+            title={fullTime}
+          >
+            {relTime}
+          </span>
+        )}
         {status === 'needs-you' && (
           <button
             type="button"

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3368,6 +3368,14 @@
         "needsYou": "Needs you",
         "running": "Running",
         "error": "Error"
+      },
+      "source": {
+        "web": "Manual",
+        "agent": "Agent-initiated",
+        "schedule": "Scheduled",
+        "slack": "Slack",
+        "wecom": "WeCom",
+        "webhook": "Webhook"
       }
     },
     "automation": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3392,6 +3392,14 @@
         "needsYou": "待你回复",
         "running": "运行中",
         "error": "出错"
+      },
+      "source": {
+        "web": "手动创建",
+        "agent": "Agent 发起",
+        "schedule": "计划任务",
+        "slack": "Slack",
+        "wecom": "企业微信",
+        "webhook": "Webhook"
       }
     },
     "automation": {


### PR DESCRIPTION
## What

Surfaces per-row metadata on the workspace session history list so sessions are easier to tell apart at a glance:

- **Leading source icon** on every row (`web` / `agent` / `schedule` / `slack` / `wecom` / `webhook`), a single muted color with the shape carrying the meaning. Icons match the connectors settings UI (`Slack`, `MessageCircle`, `Webhook`, …).
- **Start time** (`created_at`) revealed on hover at the left of the row actions, on a solid card backing with a short gradient lead-in so it stays legible over the title underneath.
- Idle sessions intentionally show no status dot (unchanged); the existing live status dot system is untouched.

## Backend

Exposes the existing `sessions.source` column — **no migration**; the column was already selected and populated by the scheduler/connectors. Added `source` to `ApiSessionSchema` and to both `toApiSession` mappers (`workspaces/read.ts`, `system-workspaces.ts`), plus the `Session` DB-row interface.

## Test

- `tsc --noEmit` passes for `web`, `control-plane`, and `internal/types`.
- Pre-commit (knip + biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)