### PR TITLE
feat(codex): migrate agent to upstream @agentclientprotocol/codex-acp

### DIFF
--- a/agents/codex/Dockerfile
+++ b/agents/codex/Dockerfile
@@ -87,20 +87,17 @@ RUN case "$TARGETARCH" in amd64) AB_ARCH=x64 ;; arm64) AB_ARCH=arm64 ;; \
     && chmod +x /usr/local/bin/agent-browser \
     && rm -rf /tmp/agent-browser-* /tmp/package
 
-# Install codex-acp globally (pre-install to avoid npx cold start)
-# Fork of https://github.com/zed-industries/codex-acp on upstream v0.14.0 (codex
-# 0.129) with the collab subagent tool_call patch plus a bridge for codex 0.129's
-# new turn-item events: ItemStarted/Completed(TurnItem::ImageGeneration) are
-# remapped to the legacy ImageGenerationBegin/End handlers so the web UI keeps
-# rendering image generation tool calls. Upstream v0.14.0 ships the
-# exec_command_output_delta O(N²) memory fix.
-# arm64 package is built + published separately (see codex-acp fork).
-RUN case "$TARGETARCH" in \
-        amd64) PKG=nap-codex-acp@0.14.0-nap.5 ;; \
-        arm64) PKG=nap-codex-acp-arm64@0.14.0-nap.5 ;; \
-        *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
-    esac \
-    && npm install -g --registry=https://registry.npmjs.org "$PKG"
+# Install codex-acp globally (pre-install to avoid npx cold start).
+# Upstream rewrite: github.com/agentclientprotocol/codex-acp — a TypeScript ACP
+# server that drives codex over its app-server JSON-RPC protocol (codex 0.142+)
+# and bundles the codex binary through @openai/codex (per-arch native dep, npm
+# resolves the host arch — no TARGETARCH switch needed, no glibc constraint).
+# Replaces the previous Rust-based codex-acp fork: its collab-subagent and
+# image-generation event patches are subsumed by codex 0.142's first-class
+# ItemStarted/ItemCompleted lifecycle (collabAgentToolCall / imageGeneration
+# items), so they no longer need to be carried here. bin name `codex-acp`
+# and no-arg stdio-server invocation match the bridge's BRIDGE_OPTS.
+RUN npm install -g --registry=https://registry.npmjs.org @agentclientprotocol/codex-acp@1.0.2
 
 WORKDIR /app
 

--- a/internal/acp-adapter/acp-bridge.ts
+++ b/internal/acp-adapter/acp-bridge.ts
@@ -85,12 +85,13 @@ export class AcpBridge {
    * Spawn the ACP child process and perform the `initialize` handshake.
    */
   async start(): Promise<void> {
-    // Set RUST_LOG so codex-acp emits McpStartupComplete on stderr (WARN level).
-    // Default to 'warn' which captures MCP startup events without the per-token
-    // INFO noise from codex_acp::thread and codex_otel.
-    const existingRustLog = this.options.env?.RUST_LOG ?? process.env.RUST_LOG ?? ''
-    const rustLog = existingRustLog || 'warn'
-    const env = { ...process.env, ...this.options.env, RUST_LOG: rustLog }
+    // The TypeScript codex-acp (app-server protocol) has no global stderr
+    // startup marker: MCP servers start per-session and only *failures* surface,
+    // as tool_call_update notifications routed through the normal session
+    // handler. So we don't set RUST_LOG (a Rust-only knob) and don't gate the
+    // first turn on a stderr line that never arrives — see waitForMcpReady,
+    // which now resolves once `initialize` succeeds.
+    const env = { ...process.env, ...this.options.env }
 
     this.child = spawn(this.options.program, this.options.args, {
       cwd: this.options.cwd,
@@ -102,19 +103,17 @@ export class AcpBridge {
       console.error(`[acp-bridge] Process error: ${err.message}`)
     })
 
-    // Track MCP startup completion via stderr parsing
-    let mcpReadyResolve: (() => void) | null = null
+    // Readiness gate (see waitForMcpReady). Non-null no-op default so it's
+    // always callable; resolving a Promise more than once is a harmless no-op.
+    let resolveReady: () => void = () => {}
     this.mcpReadyPromise = new Promise<void>((resolve) => {
-      mcpReadyResolve = resolve
+      resolveReady = resolve
     })
 
     this.child.on('exit', (code, signal) => {
       console.warn(`[acp-bridge] Process exited: code=${code} signal=${signal}`)
-      // Resolve MCP ready if process exits before startup completes
-      if (mcpReadyResolve) {
-        mcpReadyResolve()
-        mcpReadyResolve = null
-      }
+      // Resolve MCP ready if the process exits before the handshake unblocks it.
+      resolveReady()
       // Reject any in-flight prompt promises so the awaiting /chat handler
       // doesn't hang forever. Skip if destroy() was called intentionally —
       // those rejections are issued explicitly below.
@@ -126,17 +125,13 @@ export class AcpBridge {
       }
     })
 
-    // Capture stderr: forward to console and detect McpStartupComplete
+    // Capture stderr: forward to console for diagnostics. (Readiness is no
+    // longer derived from stderr — see start()'s comment and waitForMcpReady.)
     const stderrRl = createInterface({ input: this.child.stderr! })
     stderrRl.on('line', (line) => {
       // Strip ANSI escape codes for cleaner log output
       const clean = line.replace(/\x1b\[[0-9;]*m/g, '')
       console.error(`[codex-acp] ${clean}`)
-      if (mcpReadyResolve && /McpStartupComplete/.test(line)) {
-        console.log('[acp-bridge] MCP startup complete detected')
-        mcpReadyResolve()
-        mcpReadyResolve = null
-      }
     })
 
     const input = Writable.toWeb(this.child.stdin!) as WritableStream<Uint8Array>
@@ -173,12 +168,23 @@ export class AcpBridge {
     })
 
     console.log('[acp-bridge] Initialized')
+
+    // The new codex-acp manages MCP startup per-session internally and emits no
+    // positive "ready" signal (only per-server failures, as tool_call_update
+    // notifications). There is nothing to wait for, so unblock waitForMcpReady
+    // now that the handshake is up; MCP failures still surface through the
+    // normal session handler.
+    resolveReady()
   }
 
   /**
-   * Wait for MCP servers to finish startup (ready or failed).
-   * Resolves when codex-acp emits McpStartupComplete on stderr,
-   * or after timeoutMs if the event is never seen.
+   * Legacy hook from the Rust codex-acp era, where the first turn was gated on
+   * a global `McpStartupComplete` stderr marker. The TypeScript codex-acp has
+   * no such marker — MCP servers start per-session and only failures are
+   * reported — so this now resolves as soon as the `initialize` handshake
+   * completes. Kept (rather than removed at the call sites) so the orchestration
+   * in acp-server.ts stays untouched and a future readiness signal can re-hook
+   * here. `timeoutMs` is retained as a backstop for the pre-handshake window.
    */
   async waitForMcpReady(timeoutMs = 35_000): Promise<void> {
     if (!this.mcpReadyPromise) return

--- a/internal/acp-adapter/universal-events.ts
+++ b/internal/acp-adapter/universal-events.ts
@@ -62,6 +62,7 @@ export class AcpEventTranslator {
       rawInput: unknown
       lastStatus: 'pending' | 'in_progress' | 'completed' | 'failed'
       terminalEmitted: boolean
+      isImageGen: boolean
     }
   >()
   /** Last usage_update received (for stats extraction) */
@@ -172,6 +173,13 @@ export class AcpEventTranslator {
       }
 
       case 'tool_call': {
+        // Suppress codex-acp's MCP-startup pseudo-tool-calls (id `mcp_startup.*`,
+        // kind "other", already-terminal). They are infra diagnostics, not tools
+        // the agent invoked; the old Rust codex-acp never surfaced them, and the
+        // adapter's start handler would render them as a stuck "other" spinner
+        // that never persists. Route MCP health elsewhere, not the chat stream.
+        if (update.toolCallId.startsWith('mcp_startup.')) break
+
         // Finalize any in-progress text message before the tool call
         if (this.currentMessageItem) {
           this.currentMessageItem.status = 'completed'
@@ -197,12 +205,19 @@ export class AcpEventTranslator {
         // `title` as `name` causes the same string to render twice.
         const itemId = nextItemId()
         const stableName = update.kind ?? update.title
+        // codex's built-in image-generation tool surfaces as a tool_call with
+        // kind "other" / title "Image generation" and a call id prefixed `ig_`.
+        // Flag it so the completion compensation below can fire — see the
+        // tool_call_update handler.
+        const isImageGen =
+          update.title === 'Image generation' || update.toolCallId.startsWith('ig_')
         this.activeToolCalls.set(update.toolCallId, {
           itemId,
           title: stableName,
           rawInput: update.rawInput,
           lastStatus: update.status ?? 'pending',
           terminalEmitted: false,
+          isImageGen,
         })
 
         const toolItem: UniversalItem = {
@@ -225,6 +240,18 @@ export class AcpEventTranslator {
           session_id: this.sessionId,
           item: toolItem,
         })
+
+        // Terminal-on-start: codex-acp can deliver a tool_call that already
+        // carries a terminal status with no follow-up tool_call_update. Without
+        // this the card spins forever and never persists (cp writes tool_calls
+        // only on item.completed). Synthesize the completion by replaying this
+        // event through the tool_call_update path (the tracked entry is set
+        // above), which reuses all the terminal/output handling.
+        if (update.status === 'completed' || update.status === 'failed') {
+          events.push(
+            ...this.translateUpdate({ ...update, sessionUpdate: 'tool_call_update' } as SessionUpdate),
+          )
+        }
         break
       }
 
@@ -240,7 +267,25 @@ export class AcpEventTranslator {
         // from the tracked state and only emit once on the real transition
         // into a terminal state.
         const tracked = this.activeToolCalls.get(update.toolCallId)
-        const effectiveStatus = update.status ?? tracked?.lastStatus ?? 'in_progress'
+        let effectiveStatus = update.status ?? tracked?.lastStatus ?? 'in_progress'
+
+        // codex reports the image-generation item's status as "generating" even
+        // on its item/completed event, so codex-acp maps the completion to a
+        // tool_call_update that stays "in_progress" while already carrying the
+        // finished image in `content`. Without compensation the terminal
+        // transition never fires, cp never persists the tool_call, and the image
+        // never renders (cp only writes tool_calls on item.completed). When an
+        // image-generation call delivers image content, treat it as completed.
+        // (Upstream fix belongs in codex-acp's createImageGenerationCompleteUpdate.)
+        if (
+          tracked?.isImageGen &&
+          effectiveStatus !== 'failed' &&
+          ((update as any).content ?? []).some(
+            (tc: any) => tc?.type === 'image' || tc?.content?.type === 'image',
+          )
+        ) {
+          effectiveStatus = 'completed'
+        }
 
         if (tracked) {
           if (update.rawInput !== undefined) tracked.rawInput = update.rawInput
@@ -315,6 +360,22 @@ export class AcpEventTranslator {
               )
               return ''
             })
+            .filter(Boolean)
+            .join('\n')
+        }
+
+        // Image generation: codex-acp's raw output carries the full base64 image
+        // under `result` (megabytes). Dumping it as tool_result text would bloat
+        // the model context and the DB, so replace the output with a concise
+        // summary that points the model at the saved file. (Inline thumbnail
+        // rendering is a separate follow-up: ContentPart only carries base64
+        // `data`, so showing the image in-chat would mean persisting MBs per
+        // generation — that needs a uri-based design + cp/UI work.)
+        if (tracked?.isImageGen) {
+          const ro = (update.rawOutput ?? {}) as Record<string, unknown>
+          const saved = typeof ro.savedPath === 'string' ? ro.savedPath : undefined
+          const revised = typeof ro.revisedPrompt === 'string' ? ro.revisedPrompt : undefined
+          output = ['Image generated.', revised && `Revised prompt: ${revised}`, saved && `Saved to: ${saved}`]
             .filter(Boolean)
             .join('\n')
         }


### PR DESCRIPTION
## What

Migrate the codex agent off our Rust `codex-acp` fork onto upstream
[`@agentclientprotocol/codex-acp`](https://github.com/agentclientprotocol/codex-acp)`@1.0.2`.

Upstream rewrote codex-acp Rust → TypeScript: it now drives codex over its
**app-server JSON-RPC protocol** as a subprocess and bundles the codex binary
via `@openai/codex` (codex 0.142). This retires the fork entirely — its
collab-subagent and image-generation patches are subsumed by codex 0.142's
first-class `ItemStarted`/`ItemCompleted` lifecycle.

## Changes

- **`agents/codex/Dockerfile`** — install upstream `@agentclientprotocol/codex-acp@1.0.2`
  instead of the forked package. Drops the per-arch package split (npm resolves
  the `@openai/codex` native dep per arch) and the glibc constraint. `bin` name
  and no-arg stdio invocation match the bridge's `BRIDGE_OPTS`.

- **`internal/acp-adapter/acp-bridge.ts`** — the TS codex-acp emits no global
  stderr MCP-startup marker (that was Rust-only). Readiness now resolves once
  `initialize` succeeds instead of waiting on a marker that never arrives, which
  otherwise stalled the first turn ~35s. Also drops the `RUST_LOG` env.

- **`internal/acp-adapter/universal-events.ts`** — honor a terminal status
  delivered on the `tool_call` itself, not only via a follow-up
  `tool_call_update`:
  - codex reports **image-generation** completion with status `"generating"`
    (image already present in `content`) → the tool_call would spin forever and
    never persist (cp writes tool_calls only on `item.completed`). Detect it and
    complete the call; also replace the megabyte base64 payload in the
    tool_result with a concise `saved to <path>` summary.
  - **MCP-startup** failures arrive as a single already-terminal tool_call
    (`mcp_startup.*`, kind `other`). These are infra diagnostics the old agent
    never surfaced; suppress them from the chat stream.
  - General terminal-on-start handling covers any other such tool_call.

## Testing

Validated on a canary agent image against a live workspace:
- Basic chat round-trips (wire protocol interop confirmed — our ACP SDK client
  and the upstream agent negotiate protocol version 1).
- Image generation completes, persists, and reports the saved path.
- `/compact` triggers compaction and the session continues with context intact.
- Session resume (loadSession across a restart) rebuilds context correctly.

## Known follow-up (not in this PR)

- Cold session resume / session-switch pays a bridge cold-start (codex
  app-server subprocess boot + session load). The existing per-session bridge
  cache amortizes repeat access; a warm bridge pool and slimmer/async MCP
  startup would cut the first-hit latency. Tracked separately.
- The image-generation terminal-status quirk is compensated adapter-side here;
  the cleaner fix is upstream in codex-acp's `createImageGenerationCompleteUpdate`
  (a completion event should carry a terminal status). Worth an upstream PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)