### PR TITLE
chore(claude-code): bump Claude Agent SDK to ^0.3.197 + route workspace model to tier aliases

### DIFF
--- a/agents/claude-code/package-lock.json
+++ b/agents/claude-code/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "tos-agent-claude-code",
+  "name": "@neutree-ai/agent-claude-code",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tos-agent-claude-code",
+      "name": "@neutree-ai/agent-claude-code",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.161",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.197",
         "@anthropic-ai/sdk": "^0.100.1",
         "@hono/node-server": "^1.19.9",
         "@hono/node-ws": "^1.3.0",
@@ -28,22 +28,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.161.tgz",
-      "integrity": "sha512-TWVFmPsGePXPNnNuWAAuKagQai9kNj99tuu2KLo8FN3oWF5r82OnWTNpQ3IubpWYPyO1vC0+kQu2GfqoEme/hA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
+      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.161"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.161.tgz",
-      "integrity": "sha512-KwDpi1O2P++uAskFt454K/sShPmhHSYhSbBxaap2KLFoVFti1pttDcEqDPfmKCk2XzKTwlpnVSI1IwTiawPJTw==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
+      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
       "cpu": [
         "arm64"
       ],
@@ -65,9 +65,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.161.tgz",
-      "integrity": "sha512-VoLz1BfKDc6UOYL+UhRKNSFA1k4l6kvOUrWqkHJ34V5zI5/7VzQilaGl7hU5JECE1TleXMzrWpDrLZO7akApJA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
+      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
       "cpu": [
         "x64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.161.tgz",
-      "integrity": "sha512-QQbGTJ+2AFeP6+vsZQtafqeGZGX72jaHOjOyrhEcMk1T2DSrJV05J0xnkZT4yIOsByGosntTcY6963EfkuwuTg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
+      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.161.tgz",
-      "integrity": "sha512-y+RPkQ6ZFje6LP0WyGvM4yHp7IQAaxAbcKSP9QVzKtT9yWiDeqWSnPzdP2Rp3B+6Kd12MuhwIMAbiKS4onAusA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
+      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.161.tgz",
-      "integrity": "sha512-gq4tvNRRcfSf8o35mLWKN351I6FowQa2n28YiZJBvZU1glQ3HKQM4srrXzjwLwv1VcndyWBfLxoaDB1I9BS++w==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
+      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.161.tgz",
-      "integrity": "sha512-ev0eJhypbyatvSL+Cl2LqOos5+XZbgBMV6MJk7jIh/9dirMLwDj2JFlLlOnHdmIpFcznESZ/Z2wgMtqmOMUCHQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
+      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.161.tgz",
-      "integrity": "sha512-toJhVo/7RKyPc/IEGvgIcN/mPmGs38gnuDOrdtdxXoPR7WRkHcHfwprD5S9zV/pZAhuLhj/cznhno3G7b4Pnkg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
+      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
       "cpu": [
         "arm64"
       ],
@@ -143,9 +143,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.161.tgz",
-      "integrity": "sha512-QmYFeX/P7bt4diCZhXgazkmzLxL+uK1zwPaCSL2sIQyYGWAXiUulZ41TVLQbHglCBlKzUzVP9kwEXaAZye7LPA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
+      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
       "cpu": [
         "x64"
       ],

--- a/agents/claude-code/package.json
+++ b/agents/claude-code/package.json
@@ -11,11 +11,11 @@
     "format": "biome format --write ."
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.161",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
     "@anthropic-ai/sdk": "^0.100.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@hono/node-server": "^1.19.9",
     "@hono/node-ws": "^1.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.6.0",
     "mustache": "^4.2.0",
     "ws": "^8.19.0",

--- a/agents/claude-code/src/config.ts
+++ b/agents/claude-code/src/config.ts
@@ -326,7 +326,14 @@ export function applyProviderEnv(rc: RuntimeConfig): void {
   } else if (rc.provider_type === 'claude-code-oauth') {
     process.env.CLAUDE_CODE_OAUTH_TOKEN = rc.api_key || ''
   }
-  // openai → not supported by claude-code, no env vars set
+
+  // Route the workspace's configured model onto Claude Code's opus/sonnet tier
+  // aliases so BYO / custom-base_url workspaces run their configured model
+  // regardless of which tier Claude Code requests internally.
+  if (rc.model) {
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = rc.model
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = rc.model
+  }
 
   if (rc.small_model) {
     process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = rc.small_model
@@ -334,4 +341,7 @@ export function applyProviderEnv(rc: RuntimeConfig): void {
     // biome-ignore lint/performance/noDelete: env vars must be removed, not set to "undefined"
     delete process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL
   }
+
+  // Suppress telemetry / update-check traffic in isolated workspace pods.
+  process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = '1'
 }


### PR DESCRIPTION
Two small claude-code agent changes:

## 1. Bump `@anthropic-ai/claude-agent-sdk` → `^0.3.197`
Moves the SDK floor from `^0.3.161` to the latest `^0.3.197` (patch-level within
0.3.x, no breaking changes). Lockfile regenerated.

## 2. Route the workspace model to Claude Code's tier aliases
`applyProviderEnv` now maps the workspace's configured model onto
`ANTHROPIC_DEFAULT_OPUS_MODEL` and `ANTHROPIC_DEFAULT_SONNET_MODEL`, so BYO /
custom-`base_url` workspaces actually run their configured model regardless of
which tier alias Claude Code requests internally (pairs with the existing
`ANTHROPIC_DEFAULT_HAIKU_MODEL = small_model` mapping). Also sets
`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` to suppress telemetry / update-check
traffic in isolated workspace pods.

Typecheck (`tsc --noEmit`) and biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)