### PR TITLE
feat(web): add built-in `goal` slash command

### DIFF
--- a/web/src/components/workspace/CommandTrigger.tsx
+++ b/web/src/components/workspace/CommandTrigger.tsx
@@ -127,6 +127,21 @@ const BUILTIN_COMMANDS: WorkspaceCommand[] = [
     created_at: '',
     updated_at: '',
   },
+  {
+    id: '__builtin_goal__',
+    workspace_id: '',
+    user_id: '',
+    name: 'goal',
+    type: 'struct',
+    prompt_id: null,
+    prompt_content: null,
+    content: '/goal {{condition}}',
+    sort_order: -1,
+    source: 'local',
+    disabled: false,
+    created_at: '',
+    updated_at: '',
+  },
 ]
 
 export const RESERVED_COMMAND_NAMES = new Set(BUILTIN_COMMANDS.map((c) => c.name))


### PR DESCRIPTION
Adds a `goal` entry to `BUILTIN_COMMANDS` in `web/src/components/workspace/CommandTrigger.tsx`.

- **Type:** `struct` with a single `{{condition}}` variable.
- **Behavior:** selecting `/goal` from the slash menu opens the variable form dialog (one `condition` field); on submit it sends `/goal <condition>`.
- Merges into the slash menu and registers as a reserved name automatically — no other files changed.

Typecheck (`tsc --noEmit`) and biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)