### PR TITLE
fix(ui-sdk): render codex exec output from `formatted_output`

### DIFF
--- a/internal/ui-sdk/src/tool-renderers/codex/exec.tsx
+++ b/internal/ui-sdk/src/tool-renderers/codex/exec.tsx
@@ -134,7 +134,9 @@ export const codexExecRenderer: ToolRendererDef = {
     }
     if (!parsed || typeof parsed !== 'object') return <div />
 
-    const stdout = parsed.stdout ?? parsed.aggregated_output ?? ''
+    // `formatted_output` is the field name the current codex-acp uses for a
+    // command's combined output (older shapes used stdout / aggregated_output).
+    const stdout = parsed.stdout ?? parsed.aggregated_output ?? parsed.formatted_output ?? ''
     const stderr = parsed.stderr ?? ''
 
     return (


### PR DESCRIPTION
## Problem
codex `read` / `execute` tool cards render with an empty body (only the red exit-code line for non-zero exits) — the command output is missing.

## Cause
The codex exec renderer (`internal/ui-sdk/src/tool-renderers/codex/exec.tsx`) builds its body from `parsed.stdout ?? parsed.aggregated_output`, but the current codex-acp names a command's combined output **`formatted_output`** (`CodexToolCallMapper` maps `aggregatedOutput → formatted_output`). With no matching field, `stdout`/`stderr` are both empty and only the exit-code line shows. `formatted_output` is already declared on the `ExecResult` type — the renderer just never read it.

## Fix
Add `formatted_output` to the stdout fallback chain:
```ts
const stdout = parsed.stdout ?? parsed.aggregated_output ?? parsed.formatted_output ?? ''
```

Purely display-layer — the raw output was always intact in the DB / model context. Ships via a `web` rollout (ui-sdk is compiled into the web bundle). Typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)