### PR TITLE
feat(afs): support shared filesystem on remote (BYOI) environments

### DIFF
--- a/charts/env-runner-k8s/README.md
+++ b/charts/env-runner-k8s/README.md
@@ -35,8 +35,35 @@ you can create workspaces on it.
 
 - **persistentMemory** — yes (set `provider.memoryFuseImage`); memory tunnels
   back to the control plane, no extra infra in your cluster.
-- **sharedFs (afs)** — not yet on remote environments; the runner advertises
-  `sharedFs=false` and the platform won't place afs-requiring workspaces here.
+- **sharedFs (afs)** — optional (set `afs.enabled=true`, see below). When off,
+  the runner advertises `sharedFs=false` and the platform won't place
+  afs-requiring workspaces here.
+
+## Shared filesystem (afs)
+
+afs is a **shared** filesystem: enabling it deploys an afs-controller + shared
+storage **into your cluster**, and every workspace on this environment can mount
+the same volume. Unlike memory, afs data does **not** tunnel back to the control
+plane (bulk RWX I/O can't cross the WAN) — it stays local, so the sharing scope
+is **this environment only**.
+
+**Requires a ReadWriteMany-capable `storageClass`** (NFS, CephFS, …). RWO
+provisioners like `local-path`/`hostPath` will leave the afs pods `Pending`; the
+chart fails fast if `afs.enabled` is set without `afs.storageClass`.
+
+```bash
+helm install my-env ./charts/env-runner-k8s \
+  --namespace agent-runner --create-namespace \
+  --set controlPlane.url=https://platform.example.com \
+  --set envToken.token=env_xxxxxxxx \
+  --set provider.storageClass=standard \
+  --set afs.enabled=true \
+  --set afs.image=ghcr.io/neutree-ai/afs:latest \
+  --set afs.storageClass=nfs-csi
+```
+
+The environment then advertises `sharedFs=true` and can host afs-sharing
+workspaces.
 
 ## Notes
 

--- a/charts/env-runner-k8s/templates/afs.yaml
+++ b/charts/env-runner-k8s/templates/afs.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.afs.enabled }}
+{{- if not .Values.afs.storageClass }}
+{{- fail "afs.enabled requires afs.storageClass — it MUST be a ReadWriteMany-capable class (NFS/CephFS/…); RWO provisioners like local-path will leave pods Pending" }}
+{{- end }}
+# AgentFS (afs) data service, deployed into this cluster so the environment can
+# advertise sharedFs=true. afs is a *shared* filesystem: every workspace pod
+# mounting it shares one RWX volume, so the sharing scope is this environment.
+# The afs-fuse sidecar (injected by the runner's KubernetesProvider) mounts the
+# `afs-shared-storage` PVC and `afs-fuse-config` ConfigMap by name and reaches
+# `afs-controller` over cluster DNS — no tunnel is involved for afs.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: afs-shared-storage
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "env-runner-k8s.labels" . | nindent 4 }}
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: {{ .Values.afs.storageClass | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.afs.sharedStorageSize | quote }}
+---
+# Controller metadata DB (controller.db, SQLite). MUST persist across restarts:
+# if lost, every dir's id → base_path mapping disappears and all mounts fail
+# even though the data on afs-shared-storage is intact. Small (grows with #dirs).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: afs-controller-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "env-runner-k8s.labels" . | nindent 4 }}
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: {{ .Values.afs.storageClass | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.afs.controllerDbSize | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: afs-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "env-runner-k8s.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  # Recreate, not RollingUpdate: SQLite single-writer on an RWX PVC means two
+  # pods writing controller.db concurrently is a corruption risk.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: afs-controller
+  template:
+    metadata:
+      labels:
+        app: afs-controller
+        {{- include "env-runner-k8s.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: afs-controller
+          image: {{ .Values.afs.image | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["afs-controller"]
+          args: ["/etc/afs/controller.toml"]
+          ports:
+            - containerPort: 9100
+          volumeMounts:
+            - name: config
+              mountPath: /etc/afs
+            - name: data
+              mountPath: /var/lib/afs
+      volumes:
+        - name: config
+          configMap:
+            name: afs-controller-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: afs-controller-db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: afs-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "env-runner-k8s.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: afs-controller
+  ports:
+    - port: 9100
+      targetPort: 9100
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: afs-controller-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "env-runner-k8s.labels" . | nindent 4 }}
+data:
+  controller.toml: |
+    [server]
+    listen = "0.0.0.0:9100"
+
+    [storage]
+    db_path = "/var/lib/afs/controller.db"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: afs-fuse-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "env-runner-k8s.labels" . | nindent 4 }}
+data:
+  fuse-server.toml: |
+    [server]
+    listen = "0.0.0.0:9101"
+    controller_addr = "afs-controller.{{ .Release.Namespace }}.svc:9100"
+{{- end }}

--- a/charts/env-runner-k8s/templates/deployment.yaml
+++ b/charts/env-runner-k8s/templates/deployment.yaml
@@ -56,8 +56,9 @@ spec:
               value: {{ .Values.tunnel.afsProxyPort | quote }}
             - name: ENV_RUNNER_INTERVAL_MS
               value: {{ .Values.reconcileIntervalMs | quote }}
-            # Provider config for THIS cluster. No AFS_ENABLED → sharedFs=false;
-            # MEMORY_FUSE_IMAGE set → persistentMemory=true (tunnels to cp).
+            # Provider config for THIS cluster. sharedFs follows afs.enabled
+            # (AFS_ENABLED below); MEMORY_FUSE_IMAGE set → persistentMemory=true
+            # (tunnels to cp).
             - name: K8S_NAMESPACE
               value: {{ .Values.provider.namespace | quote }}
             - name: AGENT_IMAGE_PREFIX
@@ -74,6 +75,24 @@ spec:
             # never inherits the platform's default node-group selector.
             - name: AGENT_NODE_SELECTOR
               value: {{ .Values.provider.nodeSelector | quote }}
+            {{- if .Values.afs.enabled }}
+            # AgentFS (afs) — a *shared* RWX filesystem, deployed into THIS
+            # cluster (see templates/afs.yaml). afs-fuse reaches the local
+            # afs-controller via cluster DNS (no tunnel; the data plane is
+            # RWX-PVC-local and cannot cross the WAN). Enabling this flips the
+            # advertised capability to sharedFs=true; sharing scope is this
+            # environment only.
+            - name: AFS_ENABLED
+              value: "true"
+            - name: AFS_IMAGE
+              value: {{ .Values.afs.image | quote }}
+            - name: AFS_CONTROLLER_ADDR
+              value: "afs-controller.{{ .Release.Namespace }}.svc:9100"
+            - name: AFS_STORAGE_PVC
+              value: "afs-shared-storage"
+            - name: AFS_CONFIGMAP
+              value: "afs-fuse-config"
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/env-runner-k8s/values.yaml
+++ b/charts/env-runner-k8s/values.yaml
@@ -39,6 +39,26 @@ provider:
   # "" → no nodeSelector; "k=v,k2=v2" → that selector (matches provider parsing).
   nodeSelector: ""
 
+# Optional AgentFS (afs) data service. When enabled, the chart deploys an
+# afs-controller + shared storage INTO this cluster (templates/afs.yaml) and the
+# runner advertises sharedFs=true; workspaces on this environment can then share
+# a filesystem. Sharing scope is this environment only (afs data is RWX-PVC-local
+# and cannot cross the WAN, so it is not tunneled back to the control plane like
+# memory is). Leave disabled → sharedFs=false, no afs resources are created.
+#
+# REQUIREMENT: afs is a *shared* filesystem and needs a ReadWriteMany-capable
+# storageClass (NFS, CephFS, …). RWO provisioners (local-path, hostPath) will
+# leave the afs pods Pending — enabling afs without an RWX class is a mistake the
+# chart fails fast on.
+afs:
+  enabled: false
+  image: ghcr.io/neutree-ai/afs:latest
+  # RWX-capable storageClass for both the shared FS and the controller DB.
+  # Required when afs.enabled.
+  storageClass: ""
+  sharedStorageSize: 50Gi
+  controllerDbSize: 1Gi
+
 # Reverse tunnel listeners on the runner pod; a sidecar in a workspace reaches
 # the control plane through these (fronted by the chart's Service).
 tunnel:

--- a/control-plane/src/mcp/tools/afs.ts
+++ b/control-plane/src/mcp/tools/afs.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import {
+  afsEnvForWorkspace,
   createDir,
   ensureDefaultFs,
   mountAtWorkspace,
@@ -22,10 +23,11 @@ const NAME_RE = /^[a-z0-9][a-z0-9-]{0,47}$/
 async function ensureLocalShare(workspaceId: string, name: string) {
   let share = await getAfsShareByName(workspaceId, name)
   if (share) return share
-  await ensureDefaultFs()
-  const dir = await createDir()
+  const afsEnv = await afsEnvForWorkspace(workspaceId)
+  await ensureDefaultFs(afsEnv)
+  const dir = await createDir(afsEnv)
   share = await createAfsShare(workspaceId, name, dir.id, dir.accessKey)
-  await mountAtWorkspace(workspaceId, dir.id, dir.accessKey, name, false)
+  await mountAtWorkspace(afsEnv, workspaceId, dir.id, dir.accessKey, name, false)
   await addAfsShareMember(share.id, workspaceId, 'read_write')
   return share
 }
@@ -101,7 +103,21 @@ Default readonly=true is correct for most hand-off cases. Only pass readonly=fal
         const share = await getAfsShareByName(workspaceId, name)
         if (!share) return textResult(`Error: no folder named "${name}" — call share_folder first`)
 
-        await mountAtWorkspace(target.id, share.afs_dir_id, share.access_key, name, readonly)
+        // afs sharing scope is one environment; a cross-environment target could
+        // never mount this share's dir.
+        const afsEnv = await afsEnvForWorkspace(workspaceId)
+        const targetEnv = await afsEnvForWorkspace(target.id)
+        if (targetEnv.environmentId !== afsEnv.environmentId) {
+          return textResult('Error: target agent is on a different environment')
+        }
+        await mountAtWorkspace(
+          afsEnv,
+          target.id,
+          share.afs_dir_id,
+          share.access_key,
+          name,
+          readonly,
+        )
         await addAfsShareMember(share.id, target.id, readonly ? 'read_only' : 'read_write')
 
         return textResult(JSON.stringify({ path: `/mnt/afs/${name}`, target: slug, readonly }))
@@ -126,11 +142,12 @@ Default readonly=true is correct for most hand-off cases. Only pass readonly=fal
         const share = await getAfsShareByName(workspaceId, name)
         if (!share) return textResult(`Error: no share named "${name}"`)
 
+        const afsEnv = await afsEnvForWorkspace(workspaceId)
         const members = await listAfsShareMembers(share.id)
-        await revokeDir(share.afs_dir_id, share.access_key)
+        await revokeDir(afsEnv, share.afs_dir_id, share.access_key)
         for (const m of members) {
           try {
-            await unmountAtWorkspace(m.workspace_id, name)
+            await unmountAtWorkspace(afsEnv, m.workspace_id, name)
           } catch {
             // Best-effort: mount may already be gone after revoke.
           }

--- a/control-plane/src/routes/workspaces/afs-shares.ts
+++ b/control-plane/src/routes/workspaces/afs-shares.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import type { AppEnv } from '../../lib/types'
 import {
+  afsEnvForWorkspace,
   createDir,
   ensureDefaultFs,
   mountAtWorkspace,
@@ -161,10 +162,11 @@ afsShares.openapi(
     try {
       let share = await getAfsShareByName(id, name)
       if (!share) {
-        await ensureDefaultFs()
-        const dir = await createDir()
+        const afsEnv = await afsEnvForWorkspace(id)
+        await ensureDefaultFs(afsEnv)
+        const dir = await createDir(afsEnv)
         share = await createAfsShare(id, name, dir.id, dir.accessKey)
-        await mountAtWorkspace(id, dir.id, dir.accessKey, name, false)
+        await mountAtWorkspace(afsEnv, id, dir.id, dir.accessKey, name, false)
         await addAfsShareMember(share.id, id, 'read_write')
       }
       return c.json(
@@ -220,15 +222,16 @@ afsShares.openapi(
     if (!share) return c.json({ error: 'Share not found' }, 404)
     if (share.owner_workspace_id !== id) return c.json({ error: 'Not owner' }, 403)
 
+    const afsEnv = await afsEnvForWorkspace(id)
     const members = await listAfsShareMembers(share.id)
     try {
-      await revokeDir(share.afs_dir_id, share.access_key)
+      await revokeDir(afsEnv, share.afs_dir_id, share.access_key)
     } catch {
       // Best-effort: still clean up DB + local mounts below.
     }
     for (const m of members) {
       try {
-        await unmountAtWorkspace(m.workspace_id, share.name)
+        await unmountAtWorkspace(afsEnv, m.workspace_id, share.name)
       } catch {
         // Mount may already be gone after revoke.
       }
@@ -307,6 +310,10 @@ afsShares.openapi(
         description: 'Granted',
         content: { 'application/json': { schema: AfsShareMemberSchema } },
       },
+      400: {
+        description: 'Target on a different environment',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
       403: {
         description: 'Not owner',
         content: { 'application/json': { schema: ErrorSchema } },
@@ -336,6 +343,14 @@ afsShares.openapi(
       // Keep the same scope rule as grant_access MCP tool: same-user only.
       return c.json({ error: 'Target workspace belongs to another user' }, 403)
     }
+    // afs sharing scope is one environment: a share's dir + storage live in the
+    // owner's environment, so a member on a different environment could never
+    // mount it. Reject cross-environment grants with a clear reason.
+    const afsEnv = await afsEnvForWorkspace(id)
+    const targetEnv = await afsEnvForWorkspace(targetId)
+    if (targetEnv.environmentId !== afsEnv.environmentId) {
+      return c.json({ error: 'Target workspace is on a different environment' }, 400)
+    }
 
     try {
       // If target is already a member, re-mount with the (possibly changed)
@@ -344,12 +359,19 @@ afsShares.openapi(
       const existing = await listAfsShareMembers(share.id)
       if (existing.some((m) => m.workspace_id === targetId)) {
         try {
-          await unmountAtWorkspace(targetId, share.name)
+          await unmountAtWorkspace(afsEnv, targetId, share.name)
         } catch {
           // Best-effort — continue even if stale unmount fails.
         }
       }
-      await mountAtWorkspace(targetId, share.afs_dir_id, share.access_key, share.name, readonly)
+      await mountAtWorkspace(
+        afsEnv,
+        targetId,
+        share.afs_dir_id,
+        share.access_key,
+        share.name,
+        readonly,
+      )
       await addAfsShareMember(share.id, targetId, readonly ? 'read_only' : 'read_write')
     } catch (e) {
       return c.json({ error: `afs mount failed: ${(e as Error).message}` }, 502)
@@ -410,7 +432,7 @@ afsShares.openapi(
     const removed = await removeAfsShareMember(share.id, memberWorkspaceId)
     if (removed) {
       try {
-        await unmountAtWorkspace(memberWorkspaceId, share.name)
+        await unmountAtWorkspace(await afsEnvForWorkspace(id), memberWorkspaceId, share.name)
       } catch {
         // Best-effort.
       }

--- a/control-plane/src/services/afs.ts
+++ b/control-plane/src/services/afs.ts
@@ -1,6 +1,39 @@
 import path from 'node:path'
 import * as grpc from '@grpc/grpc-js'
 import * as protoLoader from '@grpc/proto-loader'
+import { callControl } from '../../../internal/env-tunnel'
+import { getWorkspacePlacementEnv } from './db/environments'
+import { openControlStream } from './env-gateway/registry'
+
+// Which environment an afs op runs against. Built-in uses the platform-local
+// gRPC path below (controller in cp's cluster, fuse via cluster DNS). A remote
+// (BYOI) environment's afs data plane lives in the customer cluster, so the op
+// is shipped over the tunnel and executed by that environment's runner (option
+// A) — see env-runner-k8s/src/afs-control.ts.
+interface AfsEnv {
+  environmentId: string
+  isBuiltin: boolean
+}
+
+/**
+ * Resolve which environment a workspace's afs ops run against. A workspace with
+ * no placement row (shouldn't happen post-backfill) is treated as built-in.
+ */
+export async function afsEnvForWorkspace(workspaceId: string): Promise<AfsEnv> {
+  const p = await getWorkspacePlacementEnv(workspaceId)
+  return p
+    ? { environmentId: p.environmentId, isBuiltin: p.isBuiltin }
+    : { environmentId: 'builtin', isBuiltin: true }
+}
+
+/** Run an afs op on a remote environment's runner via the afsctl control stream. */
+async function callRemote(env: AfsEnv, req: Record<string, unknown>): Promise<any> {
+  const stream = openControlStream(env.environmentId, 'afsctl')
+  if (!stream) throw new Error(`environment '${env.environmentId}' has no live runner`)
+  const res = await callControl<{ error?: string } & Record<string, unknown>>(stream, req)
+  if (res?.error) throw new Error(res.error)
+  return res
+}
 
 const AFS_CONTROLLER_ADDR = process.env.AFS_CONTROLLER_ADDR || 'afs-controller.default.svc:9100'
 const AFS_DEFAULT_FS = process.env.AFS_DEFAULT_FS || 'shared'
@@ -51,7 +84,11 @@ interface AfsDir {
   permission: Permission
 }
 
-export async function createDir(fsName = AFS_DEFAULT_FS): Promise<AfsDir> {
+export async function createDir(env: AfsEnv, fsName = AFS_DEFAULT_FS): Promise<AfsDir> {
+  if (!env.isBuiltin) {
+    const r = await callRemote(env, { op: 'createDir', fsName })
+    return { id: r.id, accessKey: r.accessKey, permission: r.permission }
+  }
   const res = await unary<
     { fs_name: string },
     { id: string; access_key: string; permission: Permission }
@@ -59,7 +96,11 @@ export async function createDir(fsName = AFS_DEFAULT_FS): Promise<AfsDir> {
   return { id: res.id, accessKey: res.access_key, permission: res.permission }
 }
 
-export async function revokeDir(id: string, accessKey: string): Promise<number> {
+export async function revokeDir(env: AfsEnv, id: string, accessKey: string): Promise<number> {
+  if (!env.isBuiltin) {
+    const r = await callRemote(env, { op: 'revokeDir', id, accessKey })
+    return r.sessionsRevoked ?? 0
+  }
   const res = await unary<
     { id: string; access_key: string },
     { sessions_revoked: number; errors: number }
@@ -73,12 +114,24 @@ export async function revokeDir(id: string, accessKey: string): Promise<number> 
  * with the controller and mounts at /mnt/afs/<name>.
  */
 export async function mountAtWorkspace(
+  env: AfsEnv,
   workspaceId: string,
   dirId: string,
   accessKey: string,
   name: string,
   readonly = false,
 ): Promise<void> {
+  if (!env.isBuiltin) {
+    await callRemote(env, {
+      op: 'mount',
+      workspaceId,
+      dirId,
+      accessKey,
+      name,
+      readonly,
+    })
+    return
+  }
   const mountpoint = `/mnt/afs/${name}`
   await unary<
     {
@@ -98,7 +151,15 @@ export async function mountAtWorkspace(
   })
 }
 
-export async function unmountAtWorkspace(workspaceId: string, name: string): Promise<void> {
+export async function unmountAtWorkspace(
+  env: AfsEnv,
+  workspaceId: string,
+  name: string,
+): Promise<void> {
+  if (!env.isBuiltin) {
+    await callRemote(env, { op: 'unmount', workspaceId, name })
+    return
+  }
   const mountpoint = `/mnt/afs/${name}`
   await unary<{ mountpoint: string }, Record<string, never>>(
     getFuseClient(workspaceId),
@@ -108,7 +169,11 @@ export async function unmountAtWorkspace(workspaceId: string, name: string): Pro
 }
 
 /** Register the default fs once. Safe to call repeatedly. */
-export async function ensureDefaultFs(): Promise<void> {
+export async function ensureDefaultFs(env: AfsEnv): Promise<void> {
+  if (!env.isBuiltin) {
+    await callRemote(env, { op: 'ensureDefaultFs' })
+    return
+  }
   try {
     await unary(controllerClient, 'RegisterFs', {
       name: AFS_DEFAULT_FS,

--- a/control-plane/src/services/env-gateway/registry.ts
+++ b/control-plane/src/services/env-gateway/registry.ts
@@ -36,3 +36,13 @@ export function openForwardStream(environmentId: string, meta: string): Duplex |
   const session = sessions.get(environmentId)
   return session ? session.mux.openStream(meta) : null
 }
+
+/**
+ * Open a control stream (request/response, e.g. `afsctl`) to a remote
+ * environment's runner. Same mux, different intent from a forward byte pipe:
+ * the caller drives it with callControl(). Returns null if no live runner.
+ */
+export function openControlStream(environmentId: string, meta: string): Duplex | null {
+  const session = sessions.get(environmentId)
+  return session ? session.mux.openStream(meta) : null
+}

--- a/control-plane/src/services/teamwork.ts
+++ b/control-plane/src/services/teamwork.ts
@@ -1,4 +1,11 @@
-import { createDir, ensureDefaultFs, mountAtWorkspace, revokeDir, unmountAtWorkspace } from './afs'
+import {
+  afsEnvForWorkspace,
+  createDir,
+  ensureDefaultFs,
+  mountAtWorkspace,
+  revokeDir,
+  unmountAtWorkspace,
+} from './afs'
 import {
   addAfsShareMember,
   createAfsShare,
@@ -22,11 +29,12 @@ function teamworkShareName(taskId: string): string {
  * the coordinator. The task row is updated in-place with `afs_share_id`.
  */
 export async function provisionTeamworkShare(task: TeamworkTask): Promise<string> {
-  await ensureDefaultFs()
-  const dir = await createDir()
+  const afsEnv = await afsEnvForWorkspace(task.coordinator_workspace_id)
+  await ensureDefaultFs(afsEnv)
+  const dir = await createDir(afsEnv)
   const name = teamworkShareName(task.id)
   const share = await createAfsShare(task.coordinator_workspace_id, name, dir.id, dir.accessKey)
-  await mountAtWorkspace(task.coordinator_workspace_id, dir.id, dir.accessKey, name, false)
+  await mountAtWorkspace(afsEnv, task.coordinator_workspace_id, dir.id, dir.accessKey, name, false)
   await addAfsShareMember(share.id, task.coordinator_workspace_id, 'read_write')
   await updateTeamworkTask(task.id, { afs_share_id: share.id })
   return share.id
@@ -41,7 +49,10 @@ export async function mountTeamworkShareForMember(
 ): Promise<void> {
   const share = await getAfsShareById(shareId)
   if (!share) throw new Error(`Teamwork share ${shareId} not found`)
+  // The mount targets this member's pod, so use its environment (which for a
+  // teamwork roster is the same as the coordinator's — afs sharing is env-local).
   await mountAtWorkspace(
+    await afsEnvForWorkspace(workspaceId),
     workspaceId,
     share.afs_dir_id,
     share.access_key,
@@ -59,7 +70,11 @@ export async function unmountTeamworkShareForMember(
 ): Promise<void> {
   await removeAfsShareMember(shareId, workspaceId)
   try {
-    await unmountAtWorkspace(workspaceId, teamworkShareName(taskId))
+    await unmountAtWorkspace(
+      await afsEnvForWorkspace(workspaceId),
+      workspaceId,
+      teamworkShareName(taskId),
+    )
   } catch {
     // Mount may already be gone (workspace stopped, manual unmount, etc.).
     // Membership row removal above is the source of truth.
@@ -74,7 +89,11 @@ export async function teardownTeamworkShare(shareId: string): Promise<void> {
   const share = await getAfsShareById(shareId)
   if (!share) return
   try {
-    await revokeDir(share.afs_dir_id, share.access_key)
+    await revokeDir(
+      await afsEnvForWorkspace(share.owner_workspace_id),
+      share.afs_dir_id,
+      share.access_key,
+    )
   } catch {
     // Even if the controller errors, drop the DB row so we don't leak it.
   }

--- a/env-runner-k8s/Dockerfile
+++ b/env-runner-k8s/Dockerfile
@@ -33,5 +33,8 @@ COPY env-runner-k8s/package.json env-runner-k8s/package-lock.json ./
 RUN npm ci --omit=dev
 
 COPY --from=builder /app/env-runner-k8s/dist ./dist
+# afs.proto is read at runtime by @grpc/proto-loader (afs-control.ts) — resolved
+# from cwd (/app/env-runner-k8s) as ./proto/afs.proto.
+COPY env-runner-k8s/proto ./proto
 
 CMD ["node", "dist/index.js"]

--- a/env-runner-k8s/package-lock.json
+++ b/env-runner-k8s/package-lock.json
@@ -8,6 +8,8 @@
       "name": "@neutree-ai/env-runner-k8s",
       "version": "0.1.0",
       "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@grpc/proto-loader": "^0.8.0",
         "@kubernetes/client-node": "0.22.3",
         "multiplex": "^6.7.0",
         "pg": "^8.13.0",
@@ -603,6 +605,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -613,6 +646,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@jsep-plugin/assignment": {
@@ -660,11 +703,67 @@
         "openid-client": "^6.1.3"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@types/node": {
       "version": "25.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
       "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -706,6 +805,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/argparse": {
@@ -786,6 +909,38 @@
         "node": ">=18"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -847,6 +1002,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -895,6 +1056,15 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/extend": {
@@ -961,6 +1131,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1013,6 +1192,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
@@ -1138,6 +1326,18 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -1376,6 +1576,29 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -1457,6 +1680,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rfc4648": {
@@ -1555,6 +1787,32 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.17",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
@@ -1644,7 +1902,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -1692,6 +1949,23 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1728,6 +2002,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -1735,6 +2018,33 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/env-runner-k8s/package.json
+++ b/env-runner-k8s/package.json
@@ -11,6 +11,8 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.14.3",
+    "@grpc/proto-loader": "^0.8.0",
     "@kubernetes/client-node": "0.22.3",
     "multiplex": "^6.7.0",
     "pg": "^8.13.0",

--- a/env-runner-k8s/proto/afs.proto
+++ b/env-runner-k8s/proto/afs.proto
@@ -1,0 +1,198 @@
+syntax = "proto3";
+package afs;
+
+// --- Controller Service ---
+
+service ControllerService {
+  // Filesystem management
+  rpc RegisterFs(RegisterFsRequest) returns (RegisterFsResponse);
+  rpc UnregisterFs(UnregisterFsRequest) returns (UnregisterFsResponse);
+  rpc ListFs(ListFsRequest) returns (ListFsResponse);
+
+  // Directory management
+  rpc CreateDir(CreateDirRequest) returns (CreateDirResponse);
+  rpc DeleteDir(DeleteDirRequest) returns (DeleteDirResponse);
+  rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse);
+  rpc ListDirs(ListDirsRequest) returns (ListDirsResponse);
+
+  // Session management
+  rpc RegisterSession(RegisterSessionRequest) returns (RegisterSessionResponse);
+  rpc DeregisterSession(DeregisterSessionRequest) returns (DeregisterSessionResponse);
+  rpc RevokeDir(RevokeDirRequest) returns (RevokeDirResponse);
+  rpc SessionStream(stream Heartbeat) returns (stream SessionCommand);
+}
+
+// --- FUSE Service ---
+
+service FuseService {
+  rpc Mount(MountRequest) returns (MountResponse);
+  rpc Unmount(UnmountRequest) returns (UnmountResponse);
+  rpc ListMounts(ListMountsRequest) returns (ListMountsResponse);
+}
+
+// --- Enums ---
+
+enum Permission {
+  READ_ONLY = 0;
+  READ_WRITE = 1;
+}
+
+// --- Filesystem messages ---
+
+message RegisterFsRequest {
+  string name = 1;
+  string fs_type = 2;
+  map<string, string> config = 3;
+}
+
+message RegisterFsResponse {
+  string name = 1;
+}
+
+message UnregisterFsRequest {
+  string name = 1;
+}
+
+message UnregisterFsResponse {}
+
+message ListFsRequest {}
+
+message ListFsResponse {
+  repeated FsInfo filesystems = 1;
+}
+
+message FsInfo {
+  string name = 1;
+  string fs_type = 2;
+  map<string, string> config = 3;
+  string created_at = 4;
+}
+
+// --- Directory messages ---
+
+message CreateDirRequest {
+  string fs_name = 1;
+}
+
+message CreateDirResponse {
+  string id = 1;
+  string access_key = 2;
+  Permission permission = 3;
+}
+
+message DeleteDirRequest {
+  string id = 1;
+  string access_key = 2;
+}
+
+message DeleteDirResponse {}
+
+message ValidateTokenRequest {
+  string id = 1;
+  string access_key = 2;
+}
+
+message ValidateTokenResponse {
+  bool valid = 1;
+  Permission permission = 2;
+  string fs_type = 3;
+  map<string, string> fs_config = 4;
+}
+
+message ListDirsRequest {
+  string fs_name = 1;
+}
+
+message ListDirsResponse {
+  repeated DirInfo dirs = 1;
+}
+
+message DirInfo {
+  string id = 1;
+  string fs_name = 2;
+  Permission permission = 3;
+  string status = 4;
+  string created_at = 5;
+}
+
+// --- Mount messages ---
+
+message MountRequest {
+  string id = 1;
+  string access_key = 2;
+  string mountpoint = 3;
+  string controller_addr = 4;
+  bool readonly = 5;
+}
+
+message MountResponse {
+  string mountpoint = 1;
+}
+
+message UnmountRequest {
+  string mountpoint = 1;
+}
+
+message UnmountResponse {}
+
+message ListMountsRequest {}
+
+message ListMountsResponse {
+  repeated MountInfo mounts = 1;
+}
+
+message MountInfo {
+  string id = 1;
+  string mountpoint = 2;
+  Permission permission = 3;
+}
+
+// --- Session messages ---
+
+message RegisterSessionRequest {
+  string dir_id = 1;
+  string mountpoint = 2;
+  string stream_id = 3;
+}
+
+message RegisterSessionResponse {
+  string session_id = 1;
+}
+
+message DeregisterSessionRequest {
+  string session_id = 1;
+}
+
+message DeregisterSessionResponse {}
+
+message RevokeDirRequest {
+  string id = 1;
+  string access_key = 2;
+}
+
+message RevokeDirResponse {
+  int32 sessions_revoked = 1;
+  int32 errors = 2;
+}
+
+// --- Session stream messages ---
+
+message Heartbeat {
+  string stream_id = 1;
+  repeated MountStatus mounts = 2;
+}
+
+message MountStatus {
+  string dir_id = 1;
+  string mountpoint = 2;
+}
+
+message SessionCommand {
+  oneof command {
+    ForceUnmount force_unmount = 1;
+  }
+}
+
+message ForceUnmount {
+  string mountpoint = 1;
+}

--- a/env-runner-k8s/src/afs-control.ts
+++ b/env-runner-k8s/src/afs-control.ts
@@ -1,0 +1,116 @@
+import path from 'node:path'
+import type { Duplex } from 'node:stream'
+import * as grpc from '@grpc/grpc-js'
+import * as protoLoader from '@grpc/proto-loader'
+import { serveControl } from '../../internal/env-tunnel'
+
+// Runner-side afs orchestration (BYOI option A). cp cannot reach a remote
+// environment's afs-controller/afs-fuse — they live in the customer cluster on a
+// RWX data plane that can't cross the WAN. Instead cp opens an `afsctl` control
+// stream over the tunnel and the runner, which IS in-cluster, executes the afs
+// gRPC calls locally (controller via cluster DNS, fuse via the workspace pod's
+// Service) and returns the result. This mirrors the built-in path in
+// control-plane/src/services/afs.ts — same proto, same ops — just relocated to
+// where the afs data plane actually lives.
+
+const NAMESPACE = process.env.K8S_NAMESPACE || 'default'
+const NAME_PREFIX = 'tos' // must match internal/k8s-provider NAME_PREFIX
+const AFS_CONTROLLER_ADDR =
+  process.env.AFS_CONTROLLER_ADDR || `afs-controller.${NAMESPACE}.svc:9100`
+const AFS_DEFAULT_FS = process.env.AFS_DEFAULT_FS || 'shared'
+const AFS_DEFAULT_FS_BASE_PATH = process.env.AFS_DEFAULT_FS_BASE_PATH || '/data/afs'
+// Mirrors control-plane/proto/afs.proto; shipped in the runner image at
+// ./proto/afs.proto (cwd = /app/env-runner-k8s).
+const AFS_PROTO_PATH = process.env.AFS_PROTO_PATH || path.resolve(process.cwd(), 'proto/afs.proto')
+
+let afsPkg: any
+function pkg() {
+  if (!afsPkg) {
+    const def = protoLoader.loadSync(AFS_PROTO_PATH, {
+      keepCase: true,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true,
+    })
+    afsPkg = (grpc.loadPackageDefinition(def) as any).afs
+  }
+  return afsPkg
+}
+
+let controllerClient: any
+function controller() {
+  if (!controllerClient) {
+    controllerClient = new (pkg().ControllerService)(
+      AFS_CONTROLLER_ADDR,
+      grpc.credentials.createInsecure(),
+    )
+  }
+  return controllerClient
+}
+
+const fuseClients: Record<string, any> = {}
+function fuse(workspaceId: string) {
+  let c = fuseClients[workspaceId]
+  if (!c) {
+    const addr = `${NAME_PREFIX}-${workspaceId}.${NAMESPACE}.svc:9101`
+    c = new (pkg().FuseService)(addr, grpc.credentials.createInsecure())
+    fuseClients[workspaceId] = c
+  }
+  return c
+}
+
+function unary(client: any, method: string, req: unknown): Promise<any> {
+  return new Promise((resolve, reject) => {
+    client[method](req, (err: grpc.ServiceError | null, res: unknown) =>
+      err ? reject(err) : resolve(res),
+    )
+  })
+}
+
+async function dispatch(req: any): Promise<unknown> {
+  switch (req?.op) {
+    case 'ensureDefaultFs': {
+      try {
+        await unary(controller(), 'RegisterFs', {
+          name: AFS_DEFAULT_FS,
+          fs_type: 'local',
+          config: { base_path: AFS_DEFAULT_FS_BASE_PATH },
+        })
+      } catch (e) {
+        if ((e as grpc.ServiceError).code !== grpc.status.ALREADY_EXISTS) throw e
+      }
+      return { ok: true }
+    }
+    case 'createDir': {
+      const r = await unary(controller(), 'CreateDir', { fs_name: req.fsName || AFS_DEFAULT_FS })
+      return { id: r.id, accessKey: r.access_key, permission: r.permission }
+    }
+    case 'revokeDir': {
+      const r = await unary(controller(), 'RevokeDir', { id: req.id, access_key: req.accessKey })
+      return { sessionsRevoked: r.sessions_revoked }
+    }
+    case 'mount': {
+      await unary(fuse(req.workspaceId), 'Mount', {
+        id: req.dirId,
+        access_key: req.accessKey,
+        mountpoint: `/mnt/afs/${req.name}`,
+        // The fuse-server validates against THIS cluster's controller.
+        controller_addr: AFS_CONTROLLER_ADDR,
+        readonly: !!req.readonly,
+      })
+      return { ok: true }
+    }
+    case 'unmount': {
+      await unary(fuse(req.workspaceId), 'Unmount', { mountpoint: `/mnt/afs/${req.name}` })
+      return { ok: true }
+    }
+    default:
+      throw new Error(`unknown afs op: ${req?.op}`)
+  }
+}
+
+/** Handle an `afsctl` control stream cp opened: one request → one response. */
+export function handleAfsControl(stream: Duplex): void {
+  void serveControl(stream, dispatch)
+}

--- a/env-runner-k8s/src/index.ts
+++ b/env-runner-k8s/src/index.ts
@@ -5,7 +5,7 @@ import { pool } from './db'
 import { DbTransport } from './db-transport'
 import { HttpTransport } from './http-transport'
 import { connectTunnel } from './tunnel-client'
-import { forwardDial, startReverseListeners } from './tunnel-dataplane'
+import { onTunnelStream, startReverseListeners } from './tunnel-dataplane'
 
 // env-runner-k8s: the standalone runner for kind='kubernetes' environments. One
 // reconcile core (internal/env-runner-core), two shapes selected by RUNNER_MODE:
@@ -45,7 +45,7 @@ function startTunnel(cpUrl: string, token: string): void {
     for (;;) {
       try {
         const closed = new Promise<void>((resolve) => {
-          connectTunnel({ gatewayUrl, token, onStream: forwardDial, onClose: resolve })
+          connectTunnel({ gatewayUrl, token, onStream: onTunnelStream, onClose: resolve })
             .then((client) => {
               currentMux = client.mux
               console.log('[env-runner-k8s] tunnel data plane up')

--- a/env-runner-k8s/src/tunnel-dataplane.ts
+++ b/env-runner-k8s/src/tunnel-dataplane.ts
@@ -1,6 +1,7 @@
 import type { Server } from 'node:net'
 import type { Duplex } from 'node:stream'
 import { type Mux, listenAndTunnel, pipeToTcp } from '../../internal/env-tunnel'
+import { handleAfsControl } from './afs-control'
 
 // Runner-side data plane. Two directions over the tunnel mux:
 //   - forward (cp→workspace): cp opens `fwd:<wsId>:<port>`; we dial the pod's
@@ -28,13 +29,26 @@ function resolveForwardTarget(meta: string): { host: string; port: number } | nu
 }
 
 /** Handle a forward stream cp opened: validate, dial the pod, pipe. */
-export function forwardDial(stream: Duplex, meta: string): void {
+function forwardDial(stream: Duplex, meta: string): void {
   const target = resolveForwardTarget(meta)
   if (!target) {
     stream.destroy()
     return
   }
   pipeToTcp(stream, target.host, target.port)
+}
+
+/**
+ * Dispatch an incoming tunnel stream by its meta tag. `afsctl` is a control
+ * stream (request/response afs op executed locally); everything else is a
+ * forward byte pipe to a workspace pod.
+ */
+export function onTunnelStream(stream: Duplex, meta: string): void {
+  if (meta === 'afsctl') {
+    handleAfsControl(stream)
+    return
+  }
+  forwardDial(stream, meta)
 }
 
 /**

--- a/internal/env-tunnel/control.ts
+++ b/internal/env-tunnel/control.ts
@@ -1,0 +1,113 @@
+import type { Duplex } from 'node:stream'
+
+// A tiny request/response RPC over a single mux substream, used for control
+// operations that need a reply (unlike forward/reverse streams, which are raw
+// byte pipes). One stream carries exactly one request frame and one response
+// frame, then closes. Framing is a 4-byte big-endian length prefix + a JSON
+// body — small messages only (afs control ops), never bulk data.
+//
+// cp opens the stream and calls `callControl`; the runner receives it and
+// `serveControl` runs a handler and writes the reply. The mux never parses these
+// bytes — it just carries the substream.
+
+const MAX_FRAME = 1 << 20 // 1 MiB — control messages are tiny; cap guards against a runaway/hostile peer.
+
+/** Read exactly one length-prefixed JSON frame from a stream. */
+function readFrame(stream: Duplex, timeoutMs: number): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let need = -1 // -1 until the 4-byte length header is in hand
+    let total = 0
+
+    const timer = setTimeout(() => fail(new Error('control frame timeout')), timeoutMs)
+    function cleanup() {
+      clearTimeout(timer)
+      stream.off('data', onData)
+      stream.off('error', fail)
+      stream.off('close', onClose)
+    }
+    function fail(err: Error) {
+      cleanup()
+      reject(err)
+    }
+    function onClose() {
+      fail(new Error('control stream closed before a full frame'))
+    }
+    function onData(chunk: Buffer) {
+      chunks.push(chunk)
+      total += chunk.length
+      const buf = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks)
+      if (chunks.length > 1) {
+        chunks.length = 0
+        chunks.push(buf)
+      }
+      if (need < 0) {
+        if (buf.length < 4) return
+        need = buf.readUInt32BE(0)
+        if (need > MAX_FRAME) return fail(new Error(`control frame too large: ${need}`))
+      }
+      if (need >= 0 && total >= need + 4) {
+        cleanup()
+        try {
+          resolve(JSON.parse(buf.subarray(4, 4 + need).toString('utf8')))
+        } catch (e) {
+          reject(e as Error)
+        }
+      }
+    }
+    stream.on('data', onData)
+    stream.on('error', fail)
+    stream.on('close', onClose)
+  })
+}
+
+function writeFrame(stream: Duplex, value: unknown): void {
+  const body = Buffer.from(JSON.stringify(value), 'utf8')
+  const header = Buffer.allocUnsafe(4)
+  header.writeUInt32BE(body.length, 0)
+  stream.write(Buffer.concat([header, body]))
+}
+
+/**
+ * Send one request over `stream` and await the single response frame. Resolves
+ * with the parsed response, rejects on timeout / stream error / malformed frame.
+ * Always destroys the stream when done.
+ */
+export async function callControl<Res = unknown>(
+  stream: Duplex,
+  req: unknown,
+  timeoutMs = 15_000,
+): Promise<Res> {
+  try {
+    writeFrame(stream, req)
+    const res = (await readFrame(stream, timeoutMs)) as Res
+    return res
+  } finally {
+    stream.destroy()
+  }
+}
+
+/**
+ * Receive one request on `stream`, run `handler`, and write its result back as
+ * the response frame. A thrown handler is reported as `{ error }`. Closes the
+ * stream after replying.
+ */
+export async function serveControl(
+  stream: Duplex,
+  handler: (req: unknown) => Promise<unknown>,
+  timeoutMs = 15_000,
+): Promise<void> {
+  try {
+    const req = await readFrame(stream, timeoutMs)
+    let res: unknown
+    try {
+      res = await handler(req)
+    } catch (e) {
+      res = { error: (e as Error).message }
+    }
+    writeFrame(stream, res)
+    stream.end()
+  } catch {
+    stream.destroy()
+  }
+}

--- a/internal/env-tunnel/index.ts
+++ b/internal/env-tunnel/index.ts
@@ -1,2 +1,3 @@
 export { Mux } from './mux'
 export { listenAndTunnel, pipeToTcp } from './pipe'
+export { callControl, serveControl } from './control'


### PR DESCRIPTION
## What

afs (AgentFS, the shared `/mnt/afs` filesystem) was **built-in only**: its data plane is a shared ReadWriteMany volume that can't cross the WAN, so remote environments advertised `sharedFs=false` and cp's afs orchestration was hardcoded to the platform cluster. This adds afs to remote (BYOI) environments end to end.

Sharing scope for a remote afs is **one environment** — the afs-controller + storage live in the customer cluster, so a workspace can only share with others on the same environment.

## Two parts

### 1. Infra — helm chart deploys the afs data service

A new `afs.enabled` flag (`charts/env-runner-k8s`) renders an afs-controller + shared storage + config into the customer cluster (`templates/afs.yaml`) and sets the provider env so the runner injects the afs-fuse sidecar and advertises `sharedFs=true`.

- **Requires a ReadWriteMany-capable `storageClass`** (NFS/CephFS/…). RWO provisioners (local-path/hostPath) can't back a shared FS; the chart **fails fast** if `afs.enabled` is set without `afs.storageClass`.

### 2. Control plane — option A: runner-mediated afs ops

cp can't reach a remote environment's afs-controller (`:9100`, a cluster Service, not a per-workspace forward target) or afs-fuse over cluster DNS. Instead cp ships each afs op over the tunnel and the **runner**, which is in-cluster, executes the gRPC locally — so all afs gRPC stays in the customer cluster.

- `internal/env-tunnel/control.ts` — a minimal request/response RPC (`callControl` / `serveControl`) over one mux substream (forward/reverse streams are raw byte pipes; this one needs a reply).
- `env-runner-k8s/src/afs-control.ts` — runner-side afs gRPC client + handler for the `afsctl` control stream; `mount` uses the runner's **local** controller address.
- `control-plane/src/services/afs.ts` — every op now takes an `AfsEnv`; built-in keeps the direct gRPC path, remote routes via `afsctl`. `afsEnvForWorkspace` resolves the target from a workspace's placement.
- Callers (`afs-shares`, `mcp/tools/afs`, `teamwork`) thread the environment and **reject cross-environment share members** with a clear error.

Built-in afs is unchanged (same direct path, `isBuiltin` short-circuit).

## Test

- `tsc --noEmit` clean: control-plane + env-runner-k8s.
- knip + biome clean on the changed files.
- Chart: `helm template` verified for enabled / disabled / missing-storageClass (fail-fast) paths.
- End-to-end (create share on env A owner → grant same-env member → write/read across `/mnt/afs`) pending a cp + env-runner rollout on a live remote environment.

## Notes

- `afs.enabled` and the cp changes should ship together — advertising `sharedFs=true` without the cp orchestration would let workspaces be placed but fail to create shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)