### PR TITLE
feat(scheduler): background LLM generation of session titles

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -96,6 +96,10 @@ COPY internal/sse-consumer /internal/sse-consumer
 # from /app/src/services/k8s.ts. Both resolve to /internal/* from /app/src/*.
 COPY internal/env-tunnel /internal/env-tunnel
 COPY internal/k8s-provider /internal/k8s-provider
+# titlegen registry is imported via ../../../../internal/titlegen/src from
+# /app/src/routes/admin/system-settings.ts (used to validate admin config and
+# list available providers; the periodic sweep itself runs in the scheduler).
+COPY internal/titlegen /internal/titlegen
 
 RUN npm run build
 

--- a/control-plane/migrations/123_titlegen_settings.sql
+++ b/control-plane/migrations/123_titlegen_settings.sql
@@ -1,0 +1,7 @@
+-- System-level LLM config for automatic session-title generation.
+-- Mirrors the ASR columns: an active-provider name plus a jsonb map of
+-- per-provider configs keyed by provider name. Both nullable/empty by default
+-- so the feature ships dormant until an admin selects an active provider.
+ALTER TABLE public.system_settings
+    ADD COLUMN IF NOT EXISTS titlegen_active_provider text,
+    ADD COLUMN IF NOT EXISTS titlegen_providers jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/control-plane/src/routes/admin/system-settings.ts
+++ b/control-plane/src/routes/admin/system-settings.ts
@@ -1,7 +1,18 @@
 import { Hono } from 'hono'
+import { REGISTRY as TITLEGEN_REGISTRY } from '../../../../internal/titlegen/src'
 import type { AppEnv } from '../../lib/types'
 import { REGISTRY as ASR_REGISTRY } from '../../services/asr'
 import { type SystemSettings, getSettings, updateSettings } from '../../services/db/system-settings'
+
+// Structural shape of a provider config validator — only the `safeParse` we use.
+// Kept loose so registries backed by different zod installs (cp's own vs the
+// shared internal/titlegen package) are both assignable.
+interface ConfigSchemaLike {
+  safeParse(
+    v: unknown,
+  ): { success: true; data: unknown } | { success: false; error: { issues: unknown } }
+}
+type ProviderRegistry = Record<string, { configSchema: ConfigSchemaLike }>
 
 const settings = new Hono<AppEnv>()
 
@@ -67,12 +78,40 @@ settings.get('/', async (c) => {
     ...data,
     asr_providers: stripSecrets(data.asr_providers),
     asr_available_providers: Object.keys(ASR_REGISTRY),
+    titlegen_providers: stripSecrets(data.titlegen_providers),
+    titlegen_available_providers: Object.keys(TITLEGEN_REGISTRY),
   })
 })
+
+// Validate + secret-merge a `{ providerName: config }` map against a registry,
+// mutating `patch[providersKey]`. Returns an error response to short-circuit on,
+// or null on success.
+function applyProviders(
+  registry: ProviderRegistry,
+  label: string,
+  incoming: unknown,
+  current: Record<string, unknown>,
+): { error: { message: string; issues?: unknown } } | { value: Record<string, unknown> } {
+  if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+    return { error: { message: `${label} must be an object` } }
+  }
+  const merged = mergeMissingSecrets(incoming as Record<string, unknown>, current)
+  for (const [name, raw] of Object.entries(merged)) {
+    const mod = registry[name]
+    if (!mod) continue
+    const result = mod.configSchema.safeParse(raw)
+    if (!result.success) {
+      return { error: { message: `invalid config for ${name}`, issues: result.error.issues } }
+    }
+    merged[name] = result.data
+  }
+  return { value: merged }
+}
 
 settings.put('/', async (c) => {
   const body = await c.req.json<Partial<SystemSettings>>()
   const patch: Partial<SystemSettings> = {}
+  const current = await getSettings()
 
   if ('asr_active_provider' in body) {
     const v = body.asr_active_provider
@@ -83,24 +122,33 @@ settings.put('/', async (c) => {
   }
 
   if ('asr_providers' in body) {
-    const providers = body.asr_providers
-    if (!providers || typeof providers !== 'object') {
-      return c.json({ error: 'asr_providers must be an object' }, 400)
-    }
+    const res = applyProviders(
+      ASR_REGISTRY,
+      'asr_providers',
+      body.asr_providers,
+      current.asr_providers,
+    )
+    if ('error' in res) return c.json({ error: res.error.message, issues: res.error.issues }, 400)
+    patch.asr_providers = res.value
+  }
 
-    const current = await getSettings()
-    const merged = mergeMissingSecrets(providers, current.asr_providers)
-
-    for (const [name, raw] of Object.entries(merged)) {
-      const mod = ASR_REGISTRY[name]
-      if (!mod) continue
-      const result = mod.configSchema.safeParse(raw)
-      if (!result.success) {
-        return c.json({ error: `invalid config for ${name}`, issues: result.error.issues }, 400)
-      }
-      merged[name] = result.data
+  if ('titlegen_active_provider' in body) {
+    const v = body.titlegen_active_provider
+    if (v !== null && (typeof v !== 'string' || !TITLEGEN_REGISTRY[v])) {
+      return c.json({ error: `unknown title-gen provider: ${v}` }, 400)
     }
-    patch.asr_providers = merged
+    patch.titlegen_active_provider = v
+  }
+
+  if ('titlegen_providers' in body) {
+    const res = applyProviders(
+      TITLEGEN_REGISTRY,
+      'titlegen_providers',
+      body.titlegen_providers,
+      current.titlegen_providers,
+    )
+    if ('error' in res) return c.json({ error: res.error.message, issues: res.error.issues }, 400)
+    patch.titlegen_providers = res.value
   }
 
   const userId = c.get('user').sub
@@ -108,6 +156,7 @@ settings.put('/', async (c) => {
   return c.json({
     ...updated,
     asr_providers: stripSecrets(updated.asr_providers),
+    titlegen_providers: stripSecrets(updated.titlegen_providers),
   })
 })
 

--- a/control-plane/src/services/db/system-settings.ts
+++ b/control-plane/src/services/db/system-settings.ts
@@ -3,16 +3,21 @@ import { pool } from './pool'
 export interface SystemSettings {
   asr_active_provider: string | null
   asr_providers: Record<string, unknown>
+  titlegen_active_provider: string | null
+  titlegen_providers: Record<string, unknown>
 }
 
 export async function getSettings(): Promise<SystemSettings> {
   const { rows } = await pool.query(
-    'SELECT asr_active_provider, asr_providers FROM system_settings WHERE id = 1',
+    `SELECT asr_active_provider, asr_providers, titlegen_active_provider, titlegen_providers
+     FROM system_settings WHERE id = 1`,
   )
   const row = rows[0] ?? {}
   return {
     asr_active_provider: row.asr_active_provider ?? null,
     asr_providers: row.asr_providers ?? {},
+    titlegen_active_provider: row.titlegen_active_provider ?? null,
+    titlegen_providers: row.titlegen_providers ?? {},
   }
 }
 
@@ -31,6 +36,16 @@ export async function updateSettings(
   if ('asr_providers' in patch) {
     values.push(patch.asr_providers)
     sets.push(`asr_providers = $${values.length}`)
+  }
+
+  if ('titlegen_active_provider' in patch) {
+    values.push(patch.titlegen_active_provider)
+    sets.push(`titlegen_active_provider = $${values.length}`)
+  }
+
+  if ('titlegen_providers' in patch) {
+    values.push(patch.titlegen_providers)
+    sets.push(`titlegen_providers = $${values.length}`)
   }
 
   if (sets.length === 0) return getSettings()

--- a/internal/titlegen/package.json
+++ b/internal/titlegen/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@neutree-ai/titlegen",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/internal/titlegen/src/index.ts
+++ b/internal/titlegen/src/index.ts
@@ -1,0 +1,60 @@
+import { REGISTRY } from './registry'
+import type { TitleGenProvider } from './types'
+
+export { REGISTRY } from './registry'
+export type { TitleGenProviderModule } from './registry'
+export type { TitleGenChatInput, TitleGenProvider } from './types'
+
+const MAX_TITLE_LEN = 60
+const MAX_INPUT_LEN = 2000
+
+const SYSTEM_PROMPT = [
+  "You generate a short title for a chat session based on the user's first message.",
+  'Rules:',
+  '- Reply with the title text only — no quotes, no punctuation at the ends, no prefix like "Title:".',
+  '- Keep it under 8 words. Be concise and specific.',
+  "- Use the same language as the user's message.",
+].join('\n')
+
+/**
+ * Resolve a title-gen provider from stored system settings, or null when the
+ * feature is not usable (no active provider, unknown provider name, or invalid
+ * stored config). Pure — no DB access — so callers inject their own settings.
+ * Consumers use this so a mis- or un-configured feature is a no-op rather than
+ * a crash.
+ */
+export function resolveTitleGenProvider(
+  activeProvider: string | null,
+  providers: Record<string, unknown>,
+): TitleGenProvider | null {
+  if (!activeProvider) return null
+  const mod = REGISTRY[activeProvider]
+  if (!mod) return null
+  const parsed = mod.configSchema.safeParse(providers[activeProvider] ?? {})
+  if (!parsed.success) return null
+  return mod.create(parsed.data)
+}
+
+/** Collapse whitespace, strip wrapping quotes, and clamp length. */
+function sanitizeTitle(raw: string): string {
+  let t = raw.trim().replace(/\s+/g, ' ')
+  // Models sometimes wrap the title in quotes despite instructions.
+  t = t.replace(/^["'“”‘’]+|["'“”‘’]+$/g, '').trim()
+  if (t.length > MAX_TITLE_LEN) t = t.slice(0, MAX_TITLE_LEN).trim()
+  return t
+}
+
+/**
+ * Generate a session title from its first user message using the given
+ * provider. Returns the sanitized title, or null if the model produced nothing
+ * usable.
+ */
+export async function generateTitle(
+  provider: TitleGenProvider,
+  firstUserMessage: string,
+): Promise<string | null> {
+  const user = firstUserMessage.slice(0, MAX_INPUT_LEN)
+  const raw = await provider.chat({ system: SYSTEM_PROMPT, user, maxTokens: 32 })
+  const title = sanitizeTitle(raw)
+  return title || null
+}

--- a/internal/titlegen/src/providers/openai.ts
+++ b/internal/titlegen/src/providers/openai.ts
@@ -1,0 +1,86 @@
+import type { TitleGenProviderModule } from '../registry'
+import type { TitleGenChatInput, TitleGenProvider } from '../types'
+
+const name = 'openai'
+
+const DEFAULT_MODEL = 'gpt-4o-mini'
+
+interface Config {
+  api_key: string
+  model: string
+  base_url?: string
+}
+
+// Hand-rolled validator (no zod, to keep this shared package dependency-free).
+// Applies the same defaults zod would and reports issues in the shape the
+// control-plane admin route expects.
+const configSchema: TitleGenProviderModule<Config>['configSchema'] = {
+  safeParse(v) {
+    if (!v || typeof v !== 'object' || Array.isArray(v)) {
+      return { success: false, error: { issues: [{ message: 'config must be an object' }] } }
+    }
+    const raw = v as Record<string, unknown>
+    if (typeof raw.api_key !== 'string' || raw.api_key.length === 0) {
+      return {
+        success: false,
+        error: { issues: [{ path: ['api_key'], message: 'api_key is required' }] },
+      }
+    }
+    if (raw.model !== undefined && typeof raw.model !== 'string') {
+      return {
+        success: false,
+        error: { issues: [{ path: ['model'], message: 'model must be a string' }] },
+      }
+    }
+    if (raw.base_url !== undefined && typeof raw.base_url !== 'string') {
+      return {
+        success: false,
+        error: { issues: [{ path: ['base_url'], message: 'base_url must be a string' }] },
+      }
+    }
+    return {
+      success: true,
+      data: {
+        api_key: raw.api_key,
+        model: typeof raw.model === 'string' && raw.model ? raw.model : DEFAULT_MODEL,
+        base_url: typeof raw.base_url === 'string' ? raw.base_url : undefined,
+      },
+    }
+  },
+}
+
+function create(config: Config): TitleGenProvider {
+  return {
+    name,
+    async chat(input: TitleGenChatInput): Promise<string> {
+      const baseUrl = config.base_url?.replace(/\/+$/, '') ?? 'https://api.openai.com/v1'
+
+      const res = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${config.api_key}`,
+        },
+        body: JSON.stringify({
+          model: config.model,
+          max_tokens: input.maxTokens ?? 32,
+          messages: [
+            { role: 'system', content: input.system },
+            { role: 'user', content: input.user },
+          ],
+        }),
+      })
+
+      if (!res.ok) {
+        throw new Error(`openai title-gen failed: ${res.status} ${await res.text()}`)
+      }
+
+      const data = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>
+      }
+      return data.choices?.[0]?.message?.content ?? ''
+    },
+  }
+}
+
+export default { name, configSchema, create } satisfies TitleGenProviderModule<Config>

--- a/internal/titlegen/src/registry.ts
+++ b/internal/titlegen/src/registry.ts
@@ -1,0 +1,27 @@
+import openai from './providers/openai'
+import type { TitleGenProvider } from './types'
+
+/**
+ * Minimal validator shape a provider config exposes. Kept dependency-free (no
+ * zod) so this shared package pulls in no external npm — matching the other
+ * internal/* packages — while still matching the `safeParse` interface the
+ * control-plane admin route validates against.
+ */
+export interface ConfigSchema<C> {
+  safeParse(v: unknown): { success: true; data: C } | { success: false; error: { issues: unknown } }
+}
+
+export interface TitleGenProviderModule<C = unknown> {
+  readonly name: string
+  readonly configSchema: ConfigSchema<C>
+  create(config: C): TitleGenProvider
+}
+
+/**
+ * Each title-gen provider is a self-contained module under ./providers/<name>.ts
+ * exporting `name`, `configSchema`, and `create`. Register here to make it
+ * resolvable by `resolveTitleGenProvider`.
+ */
+export const REGISTRY: Record<string, TitleGenProviderModule> = {
+  [openai.name]: openai,
+}

--- a/internal/titlegen/src/types.ts
+++ b/internal/titlegen/src/types.ts
@@ -1,0 +1,18 @@
+export interface TitleGenChatInput {
+  /** System instruction describing the title-generation task. */
+  system: string
+  /** User content — the session's first user message (already truncated). */
+  user: string
+  /** Upper bound on generated tokens. Titles are short; keep this small. */
+  maxTokens?: number
+}
+
+export interface TitleGenProvider {
+  readonly name: string
+  /**
+   * Single-shot chat completion returning the raw model text. The caller owns
+   * prompt construction and post-processing so behaviour stays uniform across
+   * providers.
+   */
+  chat(input: TitleGenChatInput): Promise<string>
+}

--- a/internal/titlegen/tsconfig.json
+++ b/internal/titlegen/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ESNext"]
+  },
+  "include": ["src/**/*"]
+}

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -16,6 +16,9 @@ COPY scheduler/src ./src
 # stage doesn't need them.
 COPY internal/sse-consumer/src /app/internal/sse-consumer/src
 COPY internal/types /app/internal/types
+# titlegen (LLM session-title generation) is imported via ../../internal/titlegen/src
+# from src/title-gen.ts; esbuild bundles it. It has no external deps of its own.
+COPY internal/titlegen/src /app/internal/titlegen/src
 
 RUN npm run build
 

--- a/scheduler/src/db.ts
+++ b/scheduler/src/db.ts
@@ -319,3 +319,66 @@ export async function cleanupOldThreadSessions(olderThanDays = 7): Promise<numbe
   )
   return rowCount ?? 0
 }
+
+// --- Session Title Generation ---
+
+/** Read the system-level title-gen config from the single system_settings row. */
+export async function getTitleGenSettings(): Promise<{
+  activeProvider: string | null
+  providers: Record<string, unknown>
+}> {
+  const { rows } = await pool.query(
+    'SELECT titlegen_active_provider, titlegen_providers FROM system_settings WHERE id = 1',
+  )
+  const row = rows[0] ?? {}
+  return {
+    activeProvider: row.titlegen_active_provider ?? null,
+    providers: row.titlegen_providers ?? {},
+  }
+}
+
+interface TitleGenCandidate {
+  id: string
+  first_user_message: string
+}
+
+/**
+ * Active sessions that still have an empty name but already contain a completed
+ * exchange (a first user message and at least one assistant reply). Restricted
+ * to sessions quiet for `quietSeconds` so we don't title a half-finished first
+ * turn. Returns the session id plus its first user message (the title source).
+ */
+export async function getTitleGenCandidates(
+  limit: number,
+  quietSeconds: number,
+): Promise<TitleGenCandidate[]> {
+  const { rows } = await pool.query(
+    `SELECT s.id, fm.content AS first_user_message
+       FROM sessions s
+       JOIN LATERAL (
+         SELECT content FROM messages m
+         WHERE m.session_id = s.id AND m.role = 'user'
+         ORDER BY m.created_at ASC LIMIT 1
+       ) fm ON true
+      WHERE s.name = ''
+        AND s.status = 'active'
+        AND s.last_active_at < now() - make_interval(secs => $1)
+        AND EXISTS (
+          SELECT 1 FROM messages m
+          WHERE m.session_id = s.id AND m.role = 'assistant'
+        )
+      ORDER BY s.last_active_at DESC
+      LIMIT $2`,
+    [quietSeconds, limit],
+  )
+  return rows as TitleGenCandidate[]
+}
+
+/**
+ * Set a session's title, but only if it is still empty. The `name = ''` guard
+ * makes concurrent titling (another scheduler replica, or a user rename)
+ * idempotent — a late writer is a no-op.
+ */
+export async function setSessionTitleIfEmpty(sessionId: string, title: string): Promise<void> {
+  await pool.query(`UPDATE sessions SET name = $1 WHERE id = $2 AND name = ''`, [title, sessionId])
+}

--- a/scheduler/src/index.ts
+++ b/scheduler/src/index.ts
@@ -10,6 +10,7 @@ import { registerDeadLetterWorker } from './dead-letter'
 import { type JobData, handleJob } from './handler'
 import { registerNotificationWorker } from './notifications'
 import { registerSkillReloadWorker } from './skill-reload'
+import { registerTitleGenWorker } from './title-gen'
 
 process.on('uncaughtException', (err) => {
   console.error('[fatal] Uncaught exception (process kept alive):', err)
@@ -106,6 +107,9 @@ await registerNotificationWorker(boss)
 // Register the shared dead-letter sink + the skill-reload fanout worker.
 await registerDeadLetterWorker(boss)
 await registerSkillReloadWorker(boss)
+
+// Register the session title-generation cron worker.
+await registerTitleGenWorker(boss)
 
 console.log('[Scheduler] Worker registered, waiting for jobs...')
 

--- a/scheduler/src/title-gen.ts
+++ b/scheduler/src/title-gen.ts
@@ -1,0 +1,77 @@
+/**
+ * Session title generation worker.
+ *
+ * A pg-boss cron schedule fires once per tick cluster-wide (the pgboss clock
+ * holds a singleton lock), so exactly one scheduler instance enqueues + runs
+ * each sweep — unlike a per-replica setInterval, this never fans the paid LLM
+ * calls out N times. The queue's singleton policy also prevents a slow sweep
+ * from overlapping the next tick.
+ *
+ * Each sweep titles active sessions that still have an empty name using the LLM
+ * configured in system_settings.titlegen_* (managed from the admin UI). Whether
+ * it does anything is driven entirely by that config: an unconfigured or invalid
+ * config resolves to no provider and the sweep is a no-op. DISABLE_SESSION_TITLEGEN=1
+ * is a hard kill-switch that also unschedules any previously-registered cron.
+ */
+import type { PgBoss } from 'pg-boss'
+import { generateTitle, resolveTitleGenProvider } from '../../internal/titlegen/src'
+import { getTitleGenCandidates, getTitleGenSettings, setSessionTitleIfEmpty } from './db'
+
+const QUEUE_NAME = 'session-titlegen'
+const SWEEP_CRON = '*/5 * * * *' // every 5 minutes
+
+// How many untitled sessions to title per sweep. Bounds LLM fan-out and
+// wall-clock; the next tick picks up the remainder.
+const BATCH_SIZE = 10
+
+// Only title sessions quiet for this long, so we don't race an in-flight first
+// turn and title a half-finished exchange.
+const QUIET_SECONDS = 30
+
+async function sweepSessionTitles(): Promise<void> {
+  const { activeProvider, providers } = await getTitleGenSettings()
+  const provider = resolveTitleGenProvider(activeProvider, providers)
+  if (!provider) return // feature not configured — no-op
+
+  const candidates = await getTitleGenCandidates(BATCH_SIZE, QUIET_SECONDS)
+  for (const row of candidates) {
+    if (!row.first_user_message.trim()) continue
+    try {
+      const title = await generateTitle(provider, row.first_user_message)
+      if (!title) continue
+      // Write guarded by name='' — idempotent against a concurrent user rename.
+      await setSessionTitleIfEmpty(row.id, title)
+    } catch (e) {
+      console.error(`[TitleGen] failed for session=${row.id}:`, e instanceof Error ? e.message : e)
+    }
+  }
+}
+
+export async function registerTitleGenWorker(boss: PgBoss): Promise<void> {
+  if (process.env.DISABLE_SESSION_TITLEGEN === '1') {
+    // Kill-switch: stop the cron from firing if it was registered by a prior boot.
+    await boss.unschedule(QUEUE_NAME).catch(() => {})
+    console.log('[TitleGen] Disabled (DISABLE_SESSION_TITLEGEN=1)')
+    return
+  }
+
+  await boss
+    .createQueue(QUEUE_NAME, {
+      // Only one sweep active at a time — a slow sweep never overlaps the next tick.
+      policy: 'singleton',
+      // A failed or skipped sweep just waits for the next tick; no retry needed.
+      retryLimit: 0,
+      expireInSeconds: 5 * 60,
+      retentionSeconds: 24 * 3600,
+    })
+    .catch(() => {})
+
+  // Idempotent upsert keyed by queue name; re-registering on each boot is safe.
+  await boss.schedule(QUEUE_NAME, SWEEP_CRON)
+
+  await boss.work(QUEUE_NAME, async () => {
+    await sweepSessionTitles()
+  })
+
+  console.log('[TitleGen] Worker registered (cron */5m)')
+}

--- a/web/src/components/admin/SystemSettingsSection.tsx
+++ b/web/src/components/admin/SystemSettingsSection.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { api } from '@/lib/api/client'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Card } from '@tremor/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
@@ -18,26 +18,31 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   )
 }
 
-// instanceId reserved for future per-instance UI state — currently unused.
-export function SystemSettingsSection(_: { instanceId: string }) {
+type UpdatePatch = Parameters<typeof api.updateSystemSettings>[0]
+
+// One provider-registry feature (ASR, title-gen, …): an active-provider select
+// plus a JSON config editor. Owns its own local form state and save, and PUTs
+// only its own slice via `buildPatch` so features stay independent.
+function ProviderConfigCard(props: {
+  labelPrefix: string
+  activeProvider: string | null
+  providers: Record<string, unknown>
+  available: string[]
+  buildPatch: (activeProvider: string | null, providers: Record<string, unknown>) => UpdatePatch
+}) {
   const { t } = useTranslation()
   const qc = useQueryClient()
-
-  const settings = useQuery({
-    queryKey: ['admin', 'system-settings'],
-    queryFn: () => api.getSystemSettings(),
-  })
+  const fieldId = useId()
 
   const [activeProvider, setActiveProvider] = useState<string>('')
   const [providersJson, setProvidersJson] = useState<string>('')
   const [jsonError, setJsonError] = useState<string | null>(null)
 
-  // Hydrate local form state once data arrives.
+  // Hydrate local form state whenever the upstream query data changes.
   useEffect(() => {
-    if (!settings.data) return
-    setActiveProvider(settings.data.asr_active_provider ?? '')
-    setProvidersJson(JSON.stringify(settings.data.asr_providers ?? {}, null, 2))
-  }, [settings.data])
+    setActiveProvider(props.activeProvider ?? '')
+    setProvidersJson(JSON.stringify(props.providers ?? {}, null, 2))
+  }, [props.activeProvider, props.providers])
 
   const save = useMutation({
     mutationFn: async () => {
@@ -47,10 +52,7 @@ export function SystemSettingsSection(_: { instanceId: string }) {
       } catch (e) {
         throw new Error(`Invalid JSON: ${(e as Error).message}`)
       }
-      return api.updateSystemSettings({
-        asr_active_provider: activeProvider || null,
-        asr_providers: parsed,
-      })
+      return api.updateSystemSettings(props.buildPatch(activeProvider || null, parsed))
     },
     onSuccess: () => {
       setJsonError(null)
@@ -59,6 +61,95 @@ export function SystemSettingsSection(_: { instanceId: string }) {
     onError: (e: Error) => {
       setJsonError(e.message)
     },
+  })
+
+  const tp = (key: string) =>
+    t(`components.admin.systemSettingsSection.${props.labelPrefix}.${key}`)
+  const noProviders = props.available.length === 0
+
+  return (
+    <Card className="!bg-card !ring-border !p-4">
+      <p className="text-xs text-muted-foreground">{tp('description')}</p>
+
+      {noProviders && (
+        <Alert className="mt-3">
+          <AlertDescription className="text-xs">{tp('noProviders')}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="mt-4 space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor={`${fieldId}-active`} className="text-xs">
+            {tp('activeProvider')}
+          </Label>
+          <select
+            id={`${fieldId}-active`}
+            value={activeProvider}
+            onChange={(e) => setActiveProvider(e.target.value)}
+            disabled={noProviders}
+            className="flex h-8 w-full rounded-md border border-input bg-background px-3 py-1 text-xs focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="">{tp('activeProviderNone')}</option>
+            {props.available.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor={`${fieldId}-json`} className="text-xs">
+            {tp('providersConfig')}
+          </Label>
+          <Textarea
+            id={`${fieldId}-json`}
+            value={providersJson}
+            onChange={(e) => setProvidersJson(e.target.value)}
+            rows={12}
+            className="font-mono text-xs"
+            spellCheck={false}
+          />
+          <p className="text-tiny text-muted-foreground">{tp('providersConfigHint')}</p>
+        </div>
+
+        {jsonError && (
+          <Alert variant="destructive">
+            <AlertDescription className="text-xs">{jsonError}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setActiveProvider(props.activeProvider ?? '')
+              setProvidersJson(JSON.stringify(props.providers ?? {}, null, 2))
+              setJsonError(null)
+            }}
+            disabled={save.isPending}
+          >
+            {t('components.admin.systemSettingsSection.actions.reset')}
+          </Button>
+          <Button size="sm" onClick={() => save.mutate()} disabled={save.isPending}>
+            {save.isPending
+              ? t('components.admin.systemSettingsSection.actions.saving')
+              : t('components.admin.systemSettingsSection.actions.save')}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+// instanceId reserved for future per-instance UI state — currently unused.
+export function SystemSettingsSection(_: { instanceId: string }) {
+  const { t } = useTranslation()
+
+  const settings = useQuery({
+    queryKey: ['admin', 'system-settings'],
+    queryFn: () => api.getSystemSettings(),
   })
 
   if (settings.isLoading) {
@@ -78,92 +169,32 @@ export function SystemSettingsSection(_: { instanceId: string }) {
   }
 
   const data = settings.data
-  const available = data.asr_available_providers
-  const noProviders = available.length === 0
 
   return (
     <div className="space-y-3 p-1">
       <SectionTitle>{t('components.admin.systemSettingsSection.sections.asr')}</SectionTitle>
-      <Card className="!bg-card !ring-border !p-4">
-        <p className="text-xs text-muted-foreground">
-          {t('components.admin.systemSettingsSection.asr.description')}
-        </p>
+      <ProviderConfigCard
+        labelPrefix="asr"
+        activeProvider={data.asr_active_provider}
+        providers={data.asr_providers}
+        available={data.asr_available_providers}
+        buildPatch={(activeProvider, providers) => ({
+          asr_active_provider: activeProvider,
+          asr_providers: providers,
+        })}
+      />
 
-        {noProviders && (
-          <Alert className="mt-3">
-            <AlertDescription className="text-xs">
-              {t('components.admin.systemSettingsSection.asr.noProviders')}
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <div className="mt-4 space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="asr-active-provider" className="text-xs">
-              {t('components.admin.systemSettingsSection.asr.activeProvider')}
-            </Label>
-            <select
-              id="asr-active-provider"
-              value={activeProvider}
-              onChange={(e) => setActiveProvider(e.target.value)}
-              disabled={noProviders}
-              className="flex h-8 w-full rounded-md border border-input bg-background px-3 py-1 text-xs focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <option value="">
-                {t('components.admin.systemSettingsSection.asr.activeProviderNone')}
-              </option>
-              {available.map((name) => (
-                <option key={name} value={name}>
-                  {name}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="asr-providers-json" className="text-xs">
-              {t('components.admin.systemSettingsSection.asr.providersConfig')}
-            </Label>
-            <Textarea
-              id="asr-providers-json"
-              value={providersJson}
-              onChange={(e) => setProvidersJson(e.target.value)}
-              rows={12}
-              className="font-mono text-xs"
-              spellCheck={false}
-            />
-            <p className="text-tiny text-muted-foreground">
-              {t('components.admin.systemSettingsSection.asr.providersConfigHint')}
-            </p>
-          </div>
-
-          {jsonError && (
-            <Alert variant="destructive">
-              <AlertDescription className="text-xs">{jsonError}</AlertDescription>
-            </Alert>
-          )}
-
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setActiveProvider(data.asr_active_provider ?? '')
-                setProvidersJson(JSON.stringify(data.asr_providers ?? {}, null, 2))
-                setJsonError(null)
-              }}
-              disabled={save.isPending}
-            >
-              {t('components.admin.systemSettingsSection.actions.reset')}
-            </Button>
-            <Button size="sm" onClick={() => save.mutate()} disabled={save.isPending}>
-              {save.isPending
-                ? t('components.admin.systemSettingsSection.actions.saving')
-                : t('components.admin.systemSettingsSection.actions.save')}
-            </Button>
-          </div>
-        </div>
-      </Card>
+      <SectionTitle>{t('components.admin.systemSettingsSection.sections.titlegen')}</SectionTitle>
+      <ProviderConfigCard
+        labelPrefix="titlegen"
+        activeProvider={data.titlegen_active_provider}
+        providers={data.titlegen_providers}
+        available={data.titlegen_available_providers}
+        buildPatch={(activeProvider, providers) => ({
+          titlegen_active_provider: activeProvider,
+          titlegen_providers: providers,
+        })}
+      />
     </div>
   )
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -2017,6 +2017,9 @@ class ApiClient {
     asr_active_provider: string | null
     asr_providers: Record<string, unknown>
     asr_available_providers: string[]
+    titlegen_active_provider: string | null
+    titlegen_providers: Record<string, unknown>
+    titlegen_available_providers: string[]
   }> {
     return this.request('/admin/system-settings')
   }
@@ -2024,9 +2027,13 @@ class ApiClient {
   async updateSystemSettings(patch: {
     asr_active_provider?: string | null
     asr_providers?: Record<string, unknown>
+    titlegen_active_provider?: string | null
+    titlegen_providers?: Record<string, unknown>
   }): Promise<{
     asr_active_provider: string | null
     asr_providers: Record<string, unknown>
+    titlegen_active_provider: string | null
+    titlegen_providers: Record<string, unknown>
   }> {
     return this.request('/admin/system-settings', {
       method: 'PUT',

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3071,11 +3071,20 @@
       },
       "systemSettingsSection": {
         "sections": {
-          "asr": "Speech Recognition (ASR)"
+          "asr": "Speech Recognition (ASR)",
+          "titlegen": "Session Title Generation"
         },
         "asr": {
           "description": "Configure the speech-to-text provider used by all clients. Settings are global and admin-only.",
           "noProviders": "No ASR providers are registered yet. The active provider dropdown will populate once a provider is wired in.",
+          "activeProvider": "Active provider",
+          "activeProviderNone": "(none — feature disabled)",
+          "providersConfig": "Provider configuration",
+          "providersConfigHint": "JSON keyed by provider name. Each provider validates its own config — see the provider's source for the expected schema."
+        },
+        "titlegen": {
+          "description": "Configure the LLM used to auto-generate titles for untitled sessions. A background job periodically titles sessions from their first message. Global and admin-only; leaving the active provider empty disables it.",
+          "noProviders": "No title-generation providers are registered yet. The active provider dropdown will populate once a provider is wired in.",
           "activeProvider": "Active provider",
           "activeProviderNone": "(none — feature disabled)",
           "providersConfig": "Provider configuration",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3095,11 +3095,20 @@
       },
       "systemSettingsSection": {
         "sections": {
-          "asr": "语音识别（ASR）"
+          "asr": "语音识别（ASR）",
+          "titlegen": "会话标题生成"
         },
         "asr": {
           "description": "配置所有客户端使用的语音转文字 provider。设置全局生效，仅 admin 可改。",
           "noProviders": "尚未注册 ASR provider。接入第一个 provider 后，可选项会自动出现在下拉框中。",
+          "activeProvider": "当前 provider",
+          "activeProviderNone": "（无 — 功能未启用）",
+          "providersConfig": "Provider 配置",
+          "providersConfigHint": "JSON 对象，key 为 provider 名。每个 provider 自己校验配置形状，具体字段见 provider 源码。"
+        },
+        "titlegen": {
+          "description": "配置用于自动生成会话标题的 LLM。后台任务会定期用会话首条消息为未命名会话生成标题。设置全局生效，仅 admin 可改；当前 provider 留空即关闭该功能。",
+          "noProviders": "尚未注册标题生成 provider。接入第一个 provider 后，可选项会自动出现在下拉框中。",
           "activeProvider": "当前 provider",
           "activeProviderNone": "（无 — 功能未启用）",
           "providersConfig": "Provider 配置",


### PR DESCRIPTION
## What

Adds an **admin-configurable LLM that periodically generates titles** for sessions whose name is still empty. Modeled on the existing ASR system-settings pattern (registry + zod config schema + secret-stripping admin route + provider-config card in the UI).

Config lives in `control-plane`; the periodic execution runs in the `scheduler` worker as a pg-boss cron job; the provider logic is shared via a new `internal/titlegen` package so the config-plane (validation) and the execution-plane (generation) never diverge.

## How it works

1. Admin picks the active provider + config in **System Settings → Session Title Generation**. Only **OpenAI Chat Completions v1** is supported (`base_url` overridable, so any OpenAI-compatible gateway works).
2. A `scheduler` pg-boss cron worker (`session-titlegen`, every 5 min) selects active sessions with an empty `name` that already have a completed first exchange (a first user message **and** an assistant reply), quiet for ≥30s.
3. It generates a short title from the **first user message** and writes it back with `UPDATE ... WHERE name = ''`.

## Design notes

- **pg-boss cron, not per-replica `setInterval`.** The cron fires once per tick cluster-wide (the pgboss clock holds a singleton lock), so exactly one scheduler instance runs each sweep — the paid LLM calls are never fanned out N times across replicas. The queue's `singleton` policy also prevents a slow sweep from overlapping the next tick.
- **Ships dormant.** With no active provider configured the sweep resolves to no provider and is a no-op — the feature is turned on entirely from the admin UI, no restart. `DISABLE_SESSION_TITLEGEN=1` is a hard kill-switch that also unschedules the cron.
- **One-shot, empty-name only.** User-renamed sessions are never touched (the `name = ''` write guard also keeps writes idempotent).
- **Config plane vs execution plane.** `control-plane` only reads/writes/validates the config and lists available providers; it does not run the sweep. The registry is imported from `internal/titlegen` for validation + the provider dropdown.
- **Shared package.** `internal/titlegen` exposes the pure `resolveTitleGenProvider()` / `generateTitle()` (config injected, no DB), consumed by both cp (validation) and scheduler (execution). The provider is a plain `fetch`, no SDK deps.

## Files

- `internal/titlegen/` — new shared package (registry, OpenAI provider, resolve + generate).
- `control-plane` — new `system_settings.titlegen_*` columns (migration `123`), db service + admin route wiring, Dockerfile `COPY internal/titlegen`.
- `scheduler` — `title-gen.ts` pg-boss cron worker, db candidate/write queries, `zod` runtime dep, Dockerfile `COPY internal/titlegen/src`.
- `web` — `ProviderConfigCard` factored out and reused for ASR + title-gen; client types; en/zh copy.

## Deploy notes

- Requires migration `123_titlegen_settings.sql`.
- Two images to roll out: **control-plane** (new columns + validation) and **scheduler** (execution). Both build contexts already `COPY internal/titlegen`.

## Test plan

- [ ] `tsc --noEmit` green in control-plane, scheduler, web (verified locally).
- [ ] Configure a provider in admin → confirm an untitled session gets a title within ~5 min.
- [ ] Rename a session manually → confirm the sweep never overwrites it.
- [ ] Leave provider unset → confirm sweep is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)