### PR TITLE
fix(afs): don't tag afs-controller pods with the runner's selectorLabels

### DIFF
--- a/charts/env-runner-k8s/templates/afs.yaml
+++ b/charts/env-runner-k8s/templates/afs.yaml
@@ -58,9 +58,11 @@ spec:
       app: afs-controller
   template:
     metadata:
+      # Only `app: afs-controller` — NOT the chart selectorLabels: the runner
+      # Deployment selects on those, so tagging afs-controller pods with them
+      # would make the runner's ReplicaSet adopt/evict this pod.
       labels:
         app: afs-controller
-        {{- include "env-runner-k8s.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Bug

`templates/afs.yaml` gave the afs-controller pod template `env-runner-k8s.selectorLabels` (`app.kubernetes.io/name` + `app.kubernetes.io/instance`) in addition to `app: afs-controller`. Those selectorLabels are exactly what the **runner Deployment** selects on:

```yaml
# deployment.yaml
selector:
  matchLabels:
    {{- include "env-runner-k8s.selectorLabels" . | nindent 6 }}
```

So the runner's ReplicaSet matched afs-controller pods too. With `replicas: 1`, a ReplicaSet that sees "extra" pods matching its selector evicts them — i.e. the runner could delete the afs-controller (or get confused about which pod is its own).

## Fix

Keep only `app: afs-controller` on the afs-controller pod template. Its own Deployment selector and Service selector already use that label; it must not carry the runner's selectorLabels.

## How found

Surfaced while testing afs on a live remote environment — `kubectl -l app.kubernetes.io/name=env-runner-k8s` and `kubectl logs deploy/<runner>` both matched two pods, and the afs-controller churned during a `helm upgrade`. After the fix, the runner selector matches only its own pod and the afs-controller is stable; the full share flow (create → grant → cross-workspace read/write) works, and cross-environment grants are rejected.

Follows up #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)