### PR TITLE
feat(titlegen): sharper prompt, symbol-safe output, larger token budget, faster drain

### DIFF
--- a/internal/titlegen/src/index.ts
+++ b/internal/titlegen/src/index.ts
@@ -9,11 +9,12 @@ const MAX_TITLE_LEN = 60
 const MAX_INPUT_LEN = 2000
 
 const SYSTEM_PROMPT = [
-  "You generate a short title for a chat session based on the user's first message.",
+  "You generate a short title for a chat session from the user's first message.",
   'Rules:',
-  '- Reply with the title text only — no quotes, no punctuation at the ends, no prefix like "Title:".',
-  '- Keep it under 8 words. Be concise and specific.',
-  "- Use the same language as the user's message.",
+  '- Output the title text ONLY: no quotes, no trailing punctuation, no prefix like "Title:", and no emoji, checkmarks, or symbols.',
+  '- Keep it under 8 words. Use the same language as the message.',
+  '- Use ONLY information explicitly present in the message. Never invent project names, IDs, status, or conclusions that are not written there.',
+  '- Maximize distinctiveness. Many messages follow the same template (e.g. "check job X", "check the Slack message", "translate file Y"); a generic title like "check job" would collide with dozens of others. Surface the concrete identifier that makes THIS one different — the specific job id, Slack channel/message id, file name, ticket, or branch — and put it in the title.',
 ].join('\n')
 
 /**
@@ -35,9 +36,18 @@ export function resolveTitleGenProvider(
   return mod.create(parsed.data)
 }
 
-/** Collapse whitespace, strip wrapping quotes, and clamp length. */
+/**
+ * Collapse whitespace, strip wrapping quotes, drop leaked emoji/symbol/label
+ * prefixes the model sometimes adds despite instructions, and clamp length.
+ * Note: leading brackets (e.g. "[JA glossary]") are intentionally preserved —
+ * only emoji, checkmarks, bullets, and a "Title:" label are stripped.
+ */
 function sanitizeTitle(raw: string): string {
   let t = raw.trim().replace(/\s+/g, ' ')
+  // Drop a leading "Title:" / "标题：" label.
+  t = t.replace(/^(title|标题)\s*[:：]\s*/i, '')
+  // Drop leading emoji / checkmarks / bullets / arrows (but not brackets/quotes).
+  t = t.replace(/^[\s\p{Extended_Pictographic}✅✔☑•·→»>]+/u, '')
   // Models sometimes wrap the title in quotes despite instructions.
   t = t.replace(/^["'“”‘’]+|["'“”‘’]+$/g, '').trim()
   if (t.length > MAX_TITLE_LEN) t = t.slice(0, MAX_TITLE_LEN).trim()
@@ -54,7 +64,9 @@ export async function generateTitle(
   firstUserMessage: string,
 ): Promise<string | null> {
   const user = firstUserMessage.slice(0, MAX_INPUT_LEN)
-  const raw = await provider.chat({ system: SYSTEM_PROMPT, user, maxTokens: 32 })
+  // Token budget is a per-provider config concern (config.max_tokens, 0 =
+  // unlimited); the caller just supplies the prompt.
+  const raw = await provider.chat({ system: SYSTEM_PROMPT, user })
   const title = sanitizeTitle(raw)
   return title || null
 }

--- a/internal/titlegen/src/providers/openai.ts
+++ b/internal/titlegen/src/providers/openai.ts
@@ -4,11 +4,15 @@ import type { TitleGenChatInput, TitleGenProvider } from '../types'
 const name = 'openai'
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
+// Output token cap. 0 means unlimited — send no cap at all (model default),
+// which also lets reasoning models spend their reasoning budget freely.
+const DEFAULT_MAX_TOKENS = 256
 
 interface Config {
   api_key: string
   model: string
   base_url?: string
+  max_tokens: number
 }
 
 // Hand-rolled validator (no zod, to keep this shared package dependency-free).
@@ -38,12 +42,31 @@ const configSchema: TitleGenProviderModule<Config>['configSchema'] = {
         error: { issues: [{ path: ['base_url'], message: 'base_url must be a string' }] },
       }
     }
+    if (
+      raw.max_tokens !== undefined &&
+      (typeof raw.max_tokens !== 'number' ||
+        !Number.isInteger(raw.max_tokens) ||
+        raw.max_tokens < 0)
+    ) {
+      return {
+        success: false,
+        error: {
+          issues: [
+            {
+              path: ['max_tokens'],
+              message: 'max_tokens must be a non-negative integer (0 = unlimited)',
+            },
+          ],
+        },
+      }
+    }
     return {
       success: true,
       data: {
         api_key: raw.api_key,
         model: typeof raw.model === 'string' && raw.model ? raw.model : DEFAULT_MODEL,
         base_url: typeof raw.base_url === 'string' ? raw.base_url : undefined,
+        max_tokens: typeof raw.max_tokens === 'number' ? raw.max_tokens : DEFAULT_MAX_TOKENS,
       },
     }
   },
@@ -54,22 +77,39 @@ function create(config: Config): TitleGenProvider {
     name,
     async chat(input: TitleGenChatInput): Promise<string> {
       const baseUrl = config.base_url?.replace(/\/+$/, '') ?? 'https://api.openai.com/v1'
+      const messages = [
+        { role: 'system', content: input.system },
+        { role: 'user', content: input.user },
+      ]
 
-      const res = await fetch(`${baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${config.api_key}`,
-        },
-        body: JSON.stringify({
-          model: config.model,
-          max_tokens: input.maxTokens ?? 32,
-          messages: [
-            { role: 'system', content: input.system },
-            { role: 'user', content: input.user },
-          ],
-        }),
-      })
+      // Omit the token param entirely when max_tokens is 0 (unlimited).
+      const post = (tokenParam?: 'max_tokens' | 'max_completion_tokens') => {
+        const body: Record<string, unknown> = { model: config.model, messages }
+        if (tokenParam) body[tokenParam] = config.max_tokens
+        return fetch(`${baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${config.api_key}`,
+          },
+          body: JSON.stringify(body),
+        })
+      }
+
+      const capped = config.max_tokens > 0
+      let res = await post(capped ? 'max_tokens' : undefined)
+
+      // Reasoning models (o1/o3/gpt-5, …) reject `max_tokens` on /chat/completions
+      // and require `max_completion_tokens`. Retry once with the newer param when
+      // the error says so. (Only relevant when a cap is actually sent.)
+      if (capped && !res.ok && res.status === 400) {
+        const errText = await res.text().catch(() => '')
+        if (/max_completion_tokens/i.test(errText)) {
+          res = await post('max_completion_tokens')
+        } else {
+          throw new Error(`openai title-gen failed: 400 ${errText}`)
+        }
+      }
 
       if (!res.ok) {
         throw new Error(`openai title-gen failed: ${res.status} ${await res.text()}`)

--- a/internal/titlegen/src/types.ts
+++ b/internal/titlegen/src/types.ts
@@ -3,8 +3,6 @@ export interface TitleGenChatInput {
   system: string
   /** User content — the session's first user message (already truncated). */
   user: string
-  /** Upper bound on generated tokens. Titles are short; keep this small. */
-  maxTokens?: number
 }
 
 export interface TitleGenProvider {

--- a/scheduler/src/title-gen.ts
+++ b/scheduler/src/title-gen.ts
@@ -18,11 +18,19 @@ import { generateTitle, resolveTitleGenProvider } from '../../internal/titlegen/
 import { getTitleGenCandidates, getTitleGenSettings, setSessionTitleIfEmpty } from './db'
 
 const QUEUE_NAME = 'session-titlegen'
-const SWEEP_CRON = '*/5 * * * *' // every 5 minutes
+
+// Cron + batch are env-overridable so the temporary backlog drain (fast/large)
+// can be dialed back to steady state without a rebuild — just change the env on
+// the scheduler deployment and restart. pg-boss cron granularity is 1 minute
+// (sub-minute is not honored by its clock), so '*/1 * * * *' is the floor.
+const SWEEP_CRON = process.env.TITLEGEN_CRON || '*/1 * * * *'
 
 // How many untitled sessions to title per sweep. Bounds LLM fan-out and
 // wall-clock; the next tick picks up the remainder.
-const BATCH_SIZE = 10
+const BATCH_SIZE = (() => {
+  const n = Number(process.env.TITLEGEN_BATCH_SIZE)
+  return Number.isInteger(n) && n > 0 ? n : 30
+})()
 
 // Only title sessions quiet for this long, so we don't race an in-flight first
 // turn and title a half-finished exchange.


### PR DESCRIPTION
Follow-up to #88 after reviewing the first batch of live-generated titles.

## What & why

Observed problems in production output:
- Leaked emoji / `✅` prefixes in titles.
- Occasional **fabrication** — titles inventing a project name / status not in the message (e.g. `CloudTower Skills` from "is the skill loaded?", `Arcfra 日文进度更新` from a char-counting task).
- Low distinctiveness for templated prompts — many sessions are near-identical CI/webhook prompts ("check job X", "check the Slack message"); the distinguishing part is the concrete job/Slack id, which the generic titles dropped.

Changes:

1. **Prompt** (`internal/titlegen`): forbid emoji/symbol/`Title:` prefixes; forbid inventing names/IDs/status/conclusions absent from the message; and explicitly steer the model to surface the distinguishing identifier (job id, Slack id, file name, ticket, branch) so templated prompts get distinct titles.
2. **`sanitizeTitle`**: defensively strip a leaked leading emoji / checkmark / bullet / `Title:` label. Brackets (`[JA glossary]`) and CJK are preserved.
3. **Configurable token budget**: `max_tokens` is now a per-provider config field (default `256`), so admins can tune it from System Settings. **`0` = unlimited** — the request sends no token cap at all. This matters for reasoning models, which bill their hidden reasoning tokens against the output budget, so a tight cap can be fully consumed by reasoning and return an empty title. Existing configs without the field keep the 256 default (backward compatible).
4. **`max_completion_tokens` fallback** (openai provider): retry once with `max_completion_tokens` when a model rejects `max_tokens` (reasoning models on `/chat/completions` require the newer param); skipped entirely when `max_tokens` is `0`.
5. **Env-overridable cron + batch** (`scheduler`): `TITLEGEN_CRON` / `TITLEGEN_BATCH_SIZE`, defaulting to `*/1` min and `30`/sweep to drain the ~19k initial backlog (~11h); dial back to steady state via env, no rebuild. pg-boss cron granularity is 1 minute (its clock does not honor sub-minute), so `*/1` is the floor.

## Config example

```json
{
  "openai": {
    "api_key": "sk-...",
    "model": "gpt-4o-mini",
    "max_tokens": 0
  }
}
```

## Deploy notes

- **Rebuild BOTH control-plane and scheduler.** The admin config schema now knows `max_tokens`: cp's route validates+normalizes the saved config, and its normalizer drops unknown fields — so a stale cp would silently strip `max_tokens` on save. cp must be current for the field to persist; scheduler for the runtime behavior.
- No migration.
- After the backlog drains, set `TITLEGEN_CRON="*/5 * * * *"` (and optionally lower `TITLEGEN_BATCH_SIZE`) on the scheduler deployment to relax — no rebuild.

## Test plan

- [ ] `tsc --noEmit` green in control-plane + scheduler (verified locally).
- [ ] After rollout: new titles carry no emoji/prefixes and no invented names.
- [ ] Templated CI prompts produce distinct titles (job/Slack id surfaced).
- [ ] Saving `max_tokens` via admin persists it (not stripped); `max_tokens: 0` + a reasoning model returns a non-empty title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)