### PR TITLE
feat(environments): consistent status·kind meta + capability chips

### DIFF
--- a/internal/k8s-provider/index.ts
+++ b/internal/k8s-provider/index.ts
@@ -1061,7 +1061,6 @@ export class KubernetesProvider implements EnvironmentProvider {
     return {
       sharedFs: this.cfg.afs.enabled,
       persistentMemory: this.cfg.memoryFuseImage !== '',
-      gpu: false,
     }
   }
 }

--- a/internal/types/environments.ts
+++ b/internal/types/environments.ts
@@ -83,8 +83,6 @@ export interface WorkspaceSpec {
 export interface Capabilities {
   sharedFs: boolean
   persistentMemory: boolean
-  gpu: boolean
-  maxStorageGi?: number
   [key: string]: boolean | number | string | undefined
 }
 

--- a/web/src/components/management/EnvironmentsSection.tsx
+++ b/web/src/components/management/EnvironmentsSection.tsx
@@ -11,6 +11,7 @@ import { ResourceGrid } from '@/components/resource/ResourceGrid'
 import type { ResourceScope } from '@/components/resource/ScopeBadge'
 import { AppHeaderButton } from '@/components/shell/windows/AppHeaderButton'
 import { useAppHeaderSlot } from '@/components/shell/windows/AppWindow'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ConfirmButton } from '@/components/ui/confirm-button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -33,7 +34,7 @@ import {
 import type { ApiEnvironment } from '@/lib/api/types'
 import { cn } from '@/lib/utils'
 import { useInstancePersistentState } from '@/stores/instance-state-store'
-import { KeyRound, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Brain, FolderSymlink, KeyRound, type LucideIcon, Pencil, Plus, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
@@ -184,7 +185,6 @@ export function EnvironmentsSection({ instanceId }: { instanceId: string }) {
             <ResourceGrid>
               {filtered.map((e) => {
                 const scope: ResourceScope = e.visibility
-                const caps = capabilityLabels(e)
                 return (
                   <ResourceCard
                     key={e.id}
@@ -197,14 +197,21 @@ export function EnvironmentsSection({ instanceId }: { instanceId: string }) {
                           )}
                         />
                         <span className="min-w-0 truncate">{e.name}</span>
+                        {e.is_builtin && (
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 px-1.5 py-0 text-tiny font-normal"
+                          >
+                            {t('components.management.environments.labels.builtin')}
+                          </Badge>
+                        )}
                       </span>
                     }
-                    type={
-                      e.is_builtin
-                        ? t('components.management.environments.labels.builtin')
-                        : t(`components.management.environments.status.${e.status}`, e.status)
-                    }
-                    meta={caps.length > 0 ? caps.join(' · ') : e.kind}
+                    // Consistent across every card: liveness · provisioning kind.
+                    // Advertised capabilities render as their own chips (body).
+                    type={t(`components.management.environments.status.${e.status}`, e.status)}
+                    meta={e.kind}
+                    body={<CapabilityChips env={e} />}
                     scope={scope}
                     owned={e.is_own && !e.is_builtin}
                     actions={
@@ -280,13 +287,33 @@ export function EnvironmentsSection({ instanceId }: { instanceId: string }) {
   )
 }
 
-/** Short capability labels (only advertised/truthy ones). */
-function capabilityLabels(e: ApiEnvironment): string[] {
-  const caps = e.capabilities ?? {}
-  const labels: string[] = []
-  if (caps.persistentMemory) labels.push('memory')
-  if (caps.sharedFs) labels.push('afs')
-  return labels
+// The capabilities a k8s environment actually advertises today (sharedFs via
+// afs, persistentMemory via memory-fuse). Rendered as chips so the card's meta
+// line can stay a consistent status · kind.
+const CAPABILITY_CHIPS: {
+  key: 'sharedFs' | 'persistentMemory'
+  label: string
+  Icon: LucideIcon
+}[] = [
+  { key: 'sharedFs', label: 'afs', Icon: FolderSymlink },
+  { key: 'persistentMemory', label: 'memory', Icon: Brain },
+]
+
+/** Chips for the advertised capabilities (only truthy ones); null when none. */
+function CapabilityChips({ env }: { env: ApiEnvironment }) {
+  const caps = env.capabilities ?? {}
+  const present = CAPABILITY_CHIPS.filter((c) => caps[c.key])
+  if (present.length === 0) return null
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {present.map(({ key, label, Icon }) => (
+        <Badge key={key} variant="muted-soft" className="gap-1 px-2 py-0 text-tiny font-normal">
+          <Icon className="h-3 w-3 shrink-0" strokeWidth={2} />
+          {label}
+        </Badge>
+      ))}
+    </div>
+  )
 }
 
 function ManageTokensDialog({


### PR DESCRIPTION
## What

Two related cleanups to the **Environments** management cards.

### 1. Drop dead capability fields (`gpu`, `maxStorageGi`)

The k8s provider only ever reported `gpu: false` and never populated `maxStorageGi`. The only capabilities that are real and actually gate placement (`chooseEnvironment`) are `sharedFs` (afs) and `persistentMemory` (memory). Removed the two dead fields from the `Capabilities` type and the provider's report.

### 2. Consistent card meta line

The meta line was inconsistent across cards:
- Built-in → `内置环境 · kubernetes` (a label · the kind)
- Remote → `在线 · afs` (status · a capability)

Two different axes crammed into one slot — and a remote env's kind was hidden whenever it advertised a capability. Now:
- **Every card**: `status · kind` (e.g. `Online · kubernetes`).
- **Built-in** gets its own chip next to the name instead of overloading the status slot.
- **Capabilities** (afs / memory) render as their own chips (with icons), only for truthy ones.

## Test

- `tsc --noEmit` clean: web + (types/provider compile via their consumers).
- knip + biome clean.
- Verified against a live remote env: `{sharedFs:true, persistentMemory:true}` → card shows `Online · kubernetes` with `afs` + `memory` chips; built-in shows `Online · kubernetes` + a built-in chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)