### PR TITLE
feat(titlegen): expose extra_body passthrough on the openai provider

### DIFF
--- a/internal/titlegen/src/providers/openai.ts
+++ b/internal/titlegen/src/providers/openai.ts
@@ -13,6 +13,11 @@ interface Config {
   model: string
   base_url?: string
   max_tokens: number
+  // Extra fields merged into the /chat/completions request body — the escape
+  // hatch for provider-specific params (temperature, top_p, presence_penalty,
+  // and OpenAI-compatible gateway extras like top_k or chat_template_kwargs).
+  // Mirrors the OpenAI SDK's `extra_body`, which likewise flattens into the body.
+  extra_body?: Record<string, unknown>
 }
 
 // Hand-rolled validator (no zod, to keep this shared package dependency-free).
@@ -60,6 +65,17 @@ const configSchema: TitleGenProviderModule<Config>['configSchema'] = {
         },
       }
     }
+    if (
+      raw.extra_body !== undefined &&
+      (typeof raw.extra_body !== 'object' ||
+        raw.extra_body === null ||
+        Array.isArray(raw.extra_body))
+    ) {
+      return {
+        success: false,
+        error: { issues: [{ path: ['extra_body'], message: 'extra_body must be an object' }] },
+      }
+    }
     return {
       success: true,
       data: {
@@ -67,6 +83,7 @@ const configSchema: TitleGenProviderModule<Config>['configSchema'] = {
         model: typeof raw.model === 'string' && raw.model ? raw.model : DEFAULT_MODEL,
         base_url: typeof raw.base_url === 'string' ? raw.base_url : undefined,
         max_tokens: typeof raw.max_tokens === 'number' ? raw.max_tokens : DEFAULT_MAX_TOKENS,
+        extra_body: (raw.extra_body as Record<string, unknown> | undefined) ?? undefined,
       },
     }
   },
@@ -83,8 +100,14 @@ function create(config: Config): TitleGenProvider {
       ]
 
       // Omit the token param entirely when max_tokens is 0 (unlimited).
+      // extra_body is spread first so structural fields (model/messages/token)
+      // always win and can't be clobbered by user config.
       const post = (tokenParam?: 'max_tokens' | 'max_completion_tokens') => {
-        const body: Record<string, unknown> = { model: config.model, messages }
+        const body: Record<string, unknown> = {
+          ...config.extra_body,
+          model: config.model,
+          messages,
+        }
         if (tokenParam) body[tokenParam] = config.max_tokens
         return fetch(`${baseUrl}/chat/completions`, {
           method: 'POST',


### PR DESCRIPTION
Follow-up to #88 / #90. Lets admins pass provider-specific sampling / template params to the title-gen model, needed for OpenAI-compatible gateways (Qwen on vLLM/SGLang, etc.).

## What

Adds an optional `extra_body` object to the openai provider config, merged into the `/chat/completions` request body. Mirrors the OpenAI SDK's `extra_body`, which flattens its keys into the body — so the same config covers standard params (`temperature`, `top_p`, `presence_penalty`) and gateway extras (`top_k`, `chat_template_kwargs`).

`extra_body` is spread **first**, so structural fields (`model`, `messages`, and the token param) always win and can't be clobbered. Validated as an object; absent = unchanged behavior.

## Config example (Qwen on an OpenAI-compatible gateway)

```json
{
  "openai": {
    "api_key": "...",
    "base_url": "https://your-gateway/v1",
    "model": "Qwen/Qwen3.6-35B-A3B-FP8",
    "max_tokens": 256,
    "extra_body": {
      "temperature": 0.7,
      "top_p": 0.8,
      "presence_penalty": 1.5,
      "top_k": 20,
      "chat_template_kwargs": { "enable_thinking": false }
    }
  }
}
```

(`max_tokens` stays the dedicated field; `0` = unlimited as before.)

## Deploy notes

- **Rebuild both control-plane and scheduler** — `internal/titlegen` is bundled into both; cp validates/normalizes the config (a stale cp would strip the unknown `extra_body` on save), scheduler runs it.
- No migration, no web change.

## Test plan

- [ ] `tsc --noEmit` green in control-plane + scheduler (verified locally).
- [ ] Save a config with `extra_body` via admin → it persists (not stripped).
- [ ] A Qwen gateway model with `chat_template_kwargs.enable_thinking=false` returns a title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)