### PR TITLE
fix(environments): reject deleting an environment that still has workspaces

### DIFF
--- a/control-plane/src/routes/environments.ts
+++ b/control-plane/src/routes/environments.ts
@@ -18,6 +18,7 @@ import {
 } from '../services/db/environment-tokens'
 import {
   type EnvironmentWithAccess,
+  countPlacementsInEnvironment,
   createEnvironment,
   deleteEnvironment,
   getEnvironmentForUser,
@@ -263,6 +264,10 @@ const deleteRouteDef = createRoute({
       description: 'Not found or not owner',
       content: { 'application/json': { schema: ErrorSchema } },
     },
+    409: {
+      description: 'Environment still has workspaces',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
   },
 })
 
@@ -273,7 +278,26 @@ environments.openapi(deleteRouteDef, async (c) => {
   if (!existing || !existing.is_owner || existing.is_builtin) {
     return c.json({ error: 'Environment not found' }, 404)
   }
-  await deleteEnvironment(id)
+  // Refuse to delete an environment that still hosts workspaces — their pods
+  // live in the customer cluster and would be orphaned. (The workspace_placements
+  // FK also blocks this at the DB, but as a raw 500; pre-check for a clean 409.)
+  const inUse = await countPlacementsInEnvironment(id)
+  if (inUse > 0) {
+    return c.json(
+      { error: `Environment still has ${inUse} workspace(s); delete or move them first` },
+      409,
+    )
+  }
+  try {
+    await deleteEnvironment(id)
+  } catch (e) {
+    // Concurrency backstop: a workspace placed between the check and the delete
+    // trips the FK (23503). Surface the same clean 409, not the raw pg error.
+    if ((e as { code?: string })?.code === '23503') {
+      return c.json({ error: 'Environment still has workspaces; delete or move them first' }, 409)
+    }
+    throw e
+  }
   return c.json({ success: true }, 200)
 })
 

--- a/control-plane/src/services/db/environments.ts
+++ b/control-plane/src/services/db/environments.ts
@@ -284,6 +284,15 @@ export async function deleteEnvironment(id: string): Promise<boolean> {
   return (result.rowCount ?? 0) > 0
 }
 
+/** How many workspaces are currently placed on an environment. */
+export async function countPlacementsInEnvironment(id: string): Promise<number> {
+  const { rows } = await pool.query(
+    'SELECT count(*)::int AS n FROM workspace_placements WHERE environment_id = $1',
+    [id],
+  )
+  return rows[0].n as number
+}
+
 export async function listEnvironmentGrants(environmentId: string): Promise<EnvironmentGrantRow[]> {
   const { rows } = await pool.query(
     `SELECT eg.team_id, t.name AS team_name, eg.permission, eg.granted_at


### PR DESCRIPTION
## Bug

Deleting an environment that still hosts workspaces failed with a **raw 500** — the `workspace_placements → environments` FK is `NO ACTION`, so Postgres rejects the delete, and the raw error (including the constraint name) leaked to the client.

## Fix

- Pre-check the placement count in the DELETE handler; if > 0, return a clean **409** with a reason (`Environment still has N workspace(s); delete or move them first`).
- Keep a `23503` (FK violation) catch as a **concurrency backstop**: if a workspace is placed between the count and the delete, still return 409 instead of leaking the raw pg error.

The DB FK stays the ultimate guarantee (no orphaned workspaces); this just makes the API surface graceful.

## Test

- `tsc --noEmit` clean; biome + knip clean.
- Verified against a live env earlier: deleting an env with 2 workspaces returned the FK 500; with this change it returns 409 with the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)