### PR TITLE
fix(workspace): don't collapse MCP group when unchecking its last server

### DIFF
--- a/web/src/components/workspace/McpConfigEditor.tsx
+++ b/web/src/components/workspace/McpConfigEditor.tsx
@@ -572,14 +572,18 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
     setEnabled(state.enabled)
     setParamValues(state.paramValues)
     setCustoms(state.customs)
-    // Auto-open groups that have enabled servers or required servers
-    const openState: Record<string, boolean> = {}
-    for (const { group, servers } of catalog.groups) {
-      const hasRequired = servers.some(([, d]) => d.required)
-      const hasEnabled = servers.some(([k]) => state.enabled[k])
-      openState[group] = hasRequired || hasEnabled
-    }
-    setGroupOpen(openState)
+    // Auto-open groups that have enabled servers or required servers.
+    // Only ever open, never close: OR against prev so unchecking the last
+    // server (or a manual expand) doesn't collapse a group the user is using.
+    setGroupOpen((prev) => {
+      const openState: Record<string, boolean> = { ...prev }
+      for (const { group, servers } of catalog.groups) {
+        const hasRequired = servers.some(([, d]) => d.required)
+        const hasEnabled = servers.some(([k]) => state.enabled[k])
+        openState[group] = (prev[group] ?? false) || hasRequired || hasEnabled
+      }
+      return openState
+    })
   }, [value, catalog])
 
   function emitChange(


### PR DESCRIPTION
## Problem

When creating a workspace and configuring MCP servers, unchecking the **last** enabled server in a group (selected count 1 → 0) auto-collapses the entire group. Users don't expect unchecking to trigger a collapse.

## Root cause

The value-sync `useEffect` in `McpConfigEditor.tsx` recomputes the whole `groupOpen` map on every selection change:

```ts
openState[group] = hasRequired || hasEnabled
setGroupOpen(openState)   // overwrites user state
```

Once the last server in a group is unchecked, `hasEnabled`/`hasRequired` are both false → `open=false` → collapse. The same overwrite also wipes any group the user had manually expanded.

## Fix

Make the effect **open-only** by OR-ing against the previous state via a functional `setGroupOpen` update:

```ts
openState[group] = (prev[group] ?? false) || hasRequired || hasEnabled
```

- Groups with no selection still start collapsed.
- Groups auto-open when a server is enabled.
- Unchecking the last server (or a manual expand) no longer collapses a group the user is working in.

## Test

- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)