### PR TITLE
fix(web): migrate __new__ composer draft to real session id on start

### DIFF
--- a/web/src/stores/agent-session-store.ts
+++ b/web/src/stores/agent-session-store.ts
@@ -30,7 +30,7 @@ import {
   transcriptI18n,
 } from '@neutree-ai/ui-sdk'
 import { type StoreApi, createStore } from 'zustand/vanilla'
-import { clearDraftFor, getDraftFor } from './draft-store'
+import { clearDraftFor, getDraftFor, migrateDraft } from './draft-store'
 
 // ── UI types ──
 // Re-exported from the UI SDK so existing importers of this module keep working.
@@ -348,6 +348,14 @@ export function createAgentSessionStore(
       chatEndpoint: options?.chatEndpoint,
 
       onSessionStarted: guard((sessionId) => {
+        // A brand-new session had no id until now, so any composer draft typed
+        // during the first turn (e.g. a queued follow-up) landed under the
+        // `__new__` slot. Re-key it to the real session slot *before* flipping
+        // `activeSessionId` — the composer reads the draft reactively off that
+        // id, so migrating first keeps the text visible continuously (no blank
+        // flash) and lets the drain-time clear, which keys off the real id,
+        // actually reach it.
+        migrateDraft(workspaceId, undefined, sessionId)
         store.setState({ activeSessionId: sessionId, loadedSessionId: sessionId })
         deps.effects.onSessionCreated(sessionId)
         deps.effects.invalidateSessions(workspaceId)

--- a/web/src/stores/draft-store.ts
+++ b/web/src/stores/draft-store.ts
@@ -36,6 +36,29 @@ export function clearDraftFor(workspaceId: string, sessionId: string | undefined
   useDraftStore.getState().clearDraft(draftKey(workspaceId, sessionId))
 }
 
+/**
+ * Re-key a composer draft from one session slot to another (for non-React
+ * callers). Used when a brand-new session finally gets its id: a draft armed
+ * under the `__new__` slot before `session.started` arrived must follow the
+ * session to its real-id slot, or the draft-clear on drain — which keys off the
+ * real id — would miss it and the composer would surface stale text. No-op when
+ * the source slot is empty; overwrites the target slot when it isn't.
+ */
+export function migrateDraft(
+  workspaceId: string,
+  fromSessionId: string | undefined,
+  toSessionId: string | undefined,
+): void {
+  const fromKey = draftKey(workspaceId, fromSessionId)
+  const toKey = draftKey(workspaceId, toSessionId)
+  if (fromKey === toKey) return
+  const store = useDraftStore.getState()
+  const value = store.drafts[fromKey]
+  if (value === undefined) return
+  store.setDraft(toKey, value)
+  store.clearDraft(fromKey)
+}
+
 export function useDraft(workspaceId: string, sessionId: string | undefined) {
   const key = draftKey(workspaceId, sessionId)
   const draft = useDraftStore((s) => s.drafts[key] ?? '')


### PR DESCRIPTION
## Problem

On a **brand-new session's first turn**, if the user types into the composer (most notably clicking **Queue** to arm a follow-up), that draft is keyed under the `__new__` slot — because `activeSessionId` is still `undefined` until the `session.started` event returns.

The drain-time draft-clear (both the inline clear in `onSessionEnded` and `followPendingTurn`) keys off the **real** session id. So it clears `w:<sessionId>` and never reaches the `__new__` entry:

- the queued message is sent (becomes a chat bubble) but the composer keeps showing the same text — the reported "输入框未清空";
- when `activeSessionId` flips `undefined → S`, the composer's reactive key flips too, briefly blanking the text;
- the orphaned `__new__` draft persists in localStorage and resurfaces the next time a new session is opened.

Whether it triggers is a **race between the user's queue action and the `session.started` round-trip** — fast user / slow backend lands the draft under `__new__`; slow user / fast backend lands it under the real id and everything works. Hence intermittent.

## Fix

Re-key the `__new__` draft to the real session slot in `onSessionStarted`, **before** flipping `activeSessionId`. Since the composer reads the draft reactively off that id, migrating first:

- keeps the text visible continuously (no blank flash),
- lets the existing drain-time clear reach it (now under the real id),
- leaves no orphaned `__new__` draft to leak into the next new session.

One synchronous re-key at the moment the window closes — no change to the drain paths.

## Test plan

- New workspace/session → send first message → immediately type + **Queue** a follow-up while still busy → on turn end the follow-up drains and the composer clears.
- Verify text typed during the first turn no longer blank-flashes when the session id arrives.
- Existing sessions (id present from the start) unaffected.
- `tsc --noEmit` clean; biome/knip pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)