### PR TITLE
fix(web): reload plugin manifest after auth so plugin apps aren't missing until refresh

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { api } from '@/lib/api/client'
 import type { User } from '@/lib/api/types'
 import { i18n } from '@/lib/i18n'
+import { loadExternalPlugins } from '@/lib/plugin-loader'
 import { type ReactNode, createContext, useCallback, useContext, useEffect, useState } from 'react'
 
 interface AuthContextType {
@@ -24,6 +25,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .catch(() => setUser(null))
       .finally(() => setIsLoading(false))
   }, [])
+
+  // Boot loads plugins before auth, so a first-of-day load with an expired
+  // cookie 401s the manifest fetch and external plugin apps go missing until
+  // a full page reload. Retry once we have an authenticated user;
+  // loadExternalPlugins no-ops if the boot load already succeeded.
+  useEffect(() => {
+    if (user) void loadExternalPlugins()
+  }, [user])
 
   const login = useCallback(async (username: string, password: string) => {
     const user = await api.login(username, password)

--- a/web/src/lib/plugin-loader.ts
+++ b/web/src/lib/plugin-loader.ts
@@ -40,20 +40,31 @@ interface PluginManifestEntry {
   owns?: PluginOwnsManifest | null
 }
 
-async function fetchManifest(): Promise<PluginManifestEntry[]> {
+/**
+ * Fetches the cp-published manifest. Returns the entry array on success
+ * (possibly empty when no plugins are enabled), or `null` when the fetch
+ * couldn't authenticate / failed transiently. The `null` case matters:
+ * `/api/plugins` requires a session, and boot runs before auth, so a
+ * first-of-day load with an expired cookie 401s here. Returning `null`
+ * (vs `[]`) lets `loadExternalPlugins` avoid caching an empty result and
+ * retry once the user authenticates — otherwise plugin apps stay missing
+ * until a full page reload.
+ */
+async function fetchManifest(): Promise<PluginManifestEntry[] | null> {
   try {
     const res = await fetch('/api/plugins', { credentials: 'include' })
     if (!res.ok) {
-      if (res.status !== 404) {
-        console.warn(`[plugins] manifest fetch returned ${res.status}`)
-      }
-      return []
+      // 404 = endpoint/manifest genuinely absent → treat as empty (final).
+      // Everything else (401/403/5xx) is a retryable failure → null.
+      if (res.status === 404) return []
+      console.warn(`[plugins] manifest fetch returned ${res.status}`)
+      return null
     }
     const body = (await res.json()) as PluginManifestEntry[]
     return Array.isArray(body) ? body : []
   } catch (err) {
     console.warn('[plugins] manifest fetch failed', err)
-    return []
+    return null
   }
 }
 
@@ -115,10 +126,33 @@ export function ensurePluginLoaded(pluginId: string): Promise<void> {
   return p
 }
 
-export async function loadExternalPlugins(): Promise<void> {
+// Boot runs `loadExternalPlugins` before auth (main.tsx), so its manifest
+// fetch can 401 on a first-of-day load with an expired cookie. We therefore
+// keep this callable again after the user authenticates (AuthProvider). These
+// guards make re-invocation safe and cheap:
+//  - `manifestLoaded` flips true only once a manifest actually resolved, so a
+//    successful boot load makes the post-auth call a no-op.
+//  - `inflight` dedupes overlapping calls (boot + auth effect racing).
+let manifestLoaded = false
+let inflight: Promise<void> | null = null
+
+export function loadExternalPlugins(): Promise<void> {
+  if (manifestLoaded) return Promise.resolve()
+  if (inflight) return inflight
+  inflight = doLoadExternalPlugins().finally(() => {
+    inflight = null
+  })
+  return inflight
+}
+
+async function doLoadExternalPlugins(): Promise<void> {
   const [published, dev] = await Promise.all([fetchManifest(), fetchDevManifest()])
+  // Manifest fetch failed to authenticate and no dev override to fall back on:
+  // leave `manifestLoaded` false so the post-auth retry re-fetches. Caching an
+  // empty list here is exactly the bug that hid plugin apps until reload.
+  if (published === null && dev.length === 0) return
   const byId = new Map<string, PluginManifestEntry>()
-  for (const e of published) byId.set(e.id, e)
+  for (const e of published ?? []) byId.set(e.id, e)
   for (const e of dev) byId.set(e.id, e) // dev wins on conflict; new ids added
   if (dev.length > 0) {
     console.info(`[plugins] dev override active: ${dev.map((e) => e.id).join(', ')}`)
@@ -127,7 +161,8 @@ export async function loadExternalPlugins(): Promise<void> {
     bundleUrlById.set(entry.id, entry.bundleUrl)
     if (entry.lazy) {
       registerLazyDescriptors(entry)
-    } else {
+    } else if (!loaded.has(entry.id)) {
+      // Guard against double-injection when this runs a second time post-auth.
       try {
         await injectScript(entry.bundleUrl)
         loaded.add(entry.id)
@@ -137,6 +172,7 @@ export async function loadExternalPlugins(): Promise<void> {
       }
     }
   }
+  manifestLoaded = true
 }
 
 function registerLazyDescriptors(entry: PluginManifestEntry): void {


### PR DESCRIPTION
## Problem

External plugin apps (the launcher's **Extensions** column) intermittently fail to appear until the user does a full page refresh — reproducibly on the first visit of the day.

### Root cause

The plugin manifest (`GET /api/plugins`) is fetched **exactly once**, in `boot()` in `web/src/main.tsx`, **before render and before `AuthProvider`**. That endpoint requires an authenticated session.

On a first-of-day load the session cookie has expired, so:

1. Boot's manifest fetch returns **401**, and `fetchManifest` caches an empty list → no plugin descriptors registered.
2. The user is redirected to `/login` and signs in, but `login()` sets the user **client-side with no full page reload**, so `boot()` never re-runs with the now-valid cookie.
3. The launcher therefore shows no Extensions until a manual refresh re-runs boot.

`useWsApps` already reacts to late panel/descriptor registration and to the `mcp-catalog` / `mcp_config` queries (which do re-fetch post-login) — the single-shot boot manifest fetch was the only piece that never retried.

## Fix

- **`fetchManifest`** returns `null` on a retryable failure (401/403/5xx/network) vs `[]` for a genuinely-empty manifest (2xx/404). An auth failure is no longer indistinguishable from "no plugins".
- **`loadExternalPlugins`** is now idempotent and retry-aware: `manifestLoaded` only flips true once a manifest actually resolves, overlapping calls are deduped via an in-flight promise, and eager bundles are guarded against double-injection on re-run.
- **`AuthProvider`** calls `loadExternalPlugins()` when a user becomes authenticated. It no-ops when the boot load already succeeded (valid-cookie path pays no extra fetch).

## Testing

- `npx tsc --noEmit` in `web/` — clean.
- biome + knip pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)