### PR TITLE
fix(web): show error and allow manual input when model list is empty

### DIFF
--- a/web/src/components/workspace/ModelFields.tsx
+++ b/web/src/components/workspace/ModelFields.tsx
@@ -68,7 +68,7 @@ export function ModelFields({
 }: ModelFieldsProps) {
   const { t } = useTranslation()
   const [providers, setProviders] = useState<ApiModelProvider[]>([])
-  const { models, loading: modelsLoading } = useProviderModels(providerId)
+  const { models, loading: modelsLoading, error: modelsError } = useProviderModels(providerId)
   const test = useProviderTest(providerId, model)
 
   useEffect(() => {
@@ -165,6 +165,9 @@ export function ModelFields({
             />
           )}
         </div>
+        {modelsError && (
+          <p className="text-xs text-destructive">{modelsError}</p>
+        )}
         {providerId && <TestResult state={test.state} detail={test.detail} />}
       </div>
 

--- a/web/src/components/workspace/agent-config/ModelPicker.tsx
+++ b/web/src/components/workspace/agent-config/ModelPicker.tsx
@@ -152,7 +152,10 @@ export function ModelInput({
   placeholder?: string
   className?: string
 }) {
-  if (providerId) {
+  // Show combobox only when models are available or still loading; fall back to
+  // plain text input so the user can type a model ID manually when the list is
+  // empty (e.g. fetch failed or provider returns no models).
+  if (providerId && (modelsLoading || models.length > 0)) {
     return (
       <ModelCombobox
         value={value}
@@ -249,19 +252,28 @@ export function TestResult({ state, detail }: { state: TestState; detail: string
 export function useProviderModels(providerId: string) {
   const [models, setModels] = useState<{ id: string; name: string }[]>([])
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!providerId) {
       setModels([])
+      setError(null)
       return
     }
     setLoading(true)
+    setError(null)
     api
       .listProviderModels(providerId)
-      .then(setModels)
-      .catch(() => setModels([]))
+      .then(({ models, error }) => {
+        setModels(models)
+        setError(error ?? null)
+      })
+      .catch(() => {
+        setModels([])
+        setError('Failed to load models')
+      })
       .finally(() => setLoading(false))
   }, [providerId])
 
-  return { models, loading }
+  return { models, loading, error }
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1367,11 +1367,13 @@ class ApiClient {
     })
   }
 
-  async listProviderModels(id: string): Promise<{ id: string; name: string }[]> {
+  async listProviderModels(
+    id: string,
+  ): Promise<{ models: { id: string; name: string }[]; error?: string }> {
     const res = await this.request<{ models: { id: string; name: string }[]; error?: string }>(
       `/providers/${id}/models`,
     )
-    return res.models ?? []
+    return { models: res.models ?? [], error: res.error }
   }
 
   async testProvider(


### PR DESCRIPTION
## Summary

- When fetching a provider's model list fails (invalid API key, unsupported provider type, network error), the upstream error message is now surfaced below the model selector instead of silently showing an empty list
- The model selector falls back to a plain text input when the list is empty, so users can type a model ID manually without being stuck
- `listProviderModels` API client method now returns `{ models, error? }` instead of discarding the backend error field

## Test plan

- [ ] Add a provider with an invalid API key → select it in Template creation → verify an error message appears below the model field
- [ ] Add a provider that doesn't support model listing → verify the model field becomes a text input and you can type a model ID manually
- [ ] Add a valid provider → verify the combobox still loads and shows the model list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)