### PR TITLE
fix: guard PVC shrink attempts in expandInstanceStorage

### DIFF
--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -15,6 +15,31 @@ import {
   resolveDeploymentStatus,
 } from './workspace-spec'
 
+const STORAGE_UNITS: Record<string, number> = {
+  Ki: 2 ** 10,
+  Mi: 2 ** 20,
+  Gi: 2 ** 30,
+  Ti: 2 ** 40,
+  Pi: 2 ** 50,
+  Ei: 2 ** 60,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+}
+
+/** Parse a k8s resource quantity string (e.g. "50Gi", "100000000") into bytes. */
+function parseStorageQuantity(quantity: string): number {
+  const match = quantity.match(/^([0-9.]+)([A-Za-z]*)$/)
+  if (!match) throw new Error(`Unparseable storage quantity: ${quantity}`)
+  const [, num, unit] = match
+  const multiplier = unit ? STORAGE_UNITS[unit] : 1
+  if (multiplier === undefined) throw new Error(`Unknown storage unit: ${unit}`)
+  return Number(num) * multiplier
+}
+
 interface K8sInstance {
   workspaceId: string
   status: 'pending' | 'running' | 'failed'
@@ -344,10 +369,32 @@ export class KubernetesProvider implements EnvironmentProvider {
     }
   }
 
-  /** Expand PVC storage (only increases, requires StorageClass support) */
+  /**
+   * Expand PVC storage. K8s only ever allows a PVC to grow, never shrink —
+   * patching a smaller size is rejected by the API. A desired spec asking for
+   * less than what's provisioned (e.g. a stale/lowered compute_resources
+   * value) is treated as a no-op here rather than an error, so it can't block
+   * spec convergence for every other field forever (see incident: apply()
+   * threw on this every reconcile pass, tearing down and recreating the
+   * Deployment before the new pod could ever pass its startup probe).
+   */
   async expandInstanceStorage(workspaceId: string, newSize: string): Promise<boolean> {
     const name = this.getResourceName(workspaceId)
     const pvcName = `${name}-workspace`
+
+    try {
+      const current = await this.coreApi.readNamespacedPersistentVolumeClaim(
+        pvcName,
+        this.cfg.namespace,
+      )
+      const currentSize = current.body.spec?.resources?.requests?.storage
+      if (currentSize && parseStorageQuantity(newSize) <= parseStorageQuantity(currentSize)) {
+        return true
+      }
+    } catch (e: any) {
+      if (e.response?.statusCode === 404) return false
+      throw e
+    }
 
     try {
       await this.coreApi.patchNamespacedPersistentVolumeClaim(


### PR DESCRIPTION
## Summary
- `apply()` unconditionally patched a workspace's PVC to the spec's desired storage size on every reconcile pass. Kubernetes forbids shrinking a PVC, so whenever the desired size was below the already-provisioned size, the patch threw — before `writeObserved` could run, so spec drift (`spec_version > observed_version`) never converged.
- The runner kept re-applying (rebuilding the Deployment) on every subsequent tick, killing each pod before it could pass its startup probe — an infinite restart-before-ready loop.
- Found via a production incident: 7 workspaces stuck in this state, one idle since 2026-06-28, all sharing the exact same drift signature (`spec_version` permanently one ahead of `observed_version`, `reported_at` frozen for hours/days despite active pod churn).
- `expandInstanceStorage` now reads the current PVC size first and treats `desired <= current` as a no-op instead of attempting a doomed patch.

## Test plan
- [x] `npx tsc --noEmit` clean in `control-plane` (which type-checks the `internal/k8s-provider` workspace)
- [x] Verified against the live incident: manually corrected `compute_resources.storage` for the 4 affected workspaces to match their live PVC sizes and confirmed they converged and recovered — this fix prevents the underlying failure mode from recurring when storage config drifts below the provisioned PVC again
- [ ] No existing unit tests in `internal/k8s-provider` to extend (package has no test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)