### PR TITLE
fix(ui-sdk): resolve tool renderer through Codex execute dispatcher

### DIFF
--- a/internal/ui-sdk/src/components/ToolCallBlock.tsx
+++ b/internal/ui-sdk/src/components/ToolCallBlock.tsx
@@ -4,7 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { useLazyToolRenderers } from '../lazy'
 import { getToolRenderersVersion, subscribeToolRenderers } from '../tool-renderers/plugin-registry'
 import { DefaultInput, DefaultResult } from '../tool-renderers/defaults'
-import { getToolDisplayName, resolveRenderer } from '../tool-renderers/registry'
+import {
+  getToolDisplayName,
+  resolveRenderer,
+  unwrapExecuteDispatchName,
+} from '../tool-renderers/registry'
 import { jsonPreview } from '../tool-renderers/types'
 import type { ToolCall } from '../types'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
@@ -43,11 +47,12 @@ function ToolCallBlockImpl({ tool }: { tool: ToolCall }) {
   // default to the real renderer the moment it lands.
   useSyncExternalStore(subscribeToolRenderers, getToolRenderersVersion)
   useSyncExternalStore(lazy?.subscribe ?? NOOP_SUBSCRIBE, lazy?.getVersion ?? ZERO)
-  const renderer = resolveRenderer(tool.name, agentType)
+  const effectiveName = unwrapExecuteDispatchName(tool.name, tool.input)
+  const renderer = resolveRenderer(tool, agentType)
   // No synchronous renderer yet — if a host-provided lazy source owns this tool,
   // show a skeleton and kick off the bundle load; the subscriptions above
   // re-render once it registers.
-  const lazyPluginId = renderer ? null : (lazy?.getPluginId(getToolDisplayName(tool.name)) ?? null)
+  const lazyPluginId = renderer ? null : (lazy?.getPluginId(getToolDisplayName(effectiveName)) ?? null)
   useEffect(() => {
     if (lazyPluginId && lazy) lazy.load(lazyPluginId).catch(() => {})
   }, [lazyPluginId, lazy])
@@ -76,9 +81,9 @@ function ToolCallBlockImpl({ tool }: { tool: ToolCall }) {
             )}
             <span
               className="shrink-0 truncate font-mono text-xs text-foreground/80"
-              title={getToolDisplayName(tool.name)}
+              title={getToolDisplayName(effectiveName)}
             >
-              {getToolDisplayName(tool.name)}
+              {getToolDisplayName(effectiveName)}
             </span>
             {preview && (
               <span

--- a/internal/ui-sdk/src/tool-renderers/registry.ts
+++ b/internal/ui-sdk/src/tool-renderers/registry.ts
@@ -145,14 +145,29 @@ export function getToolDisplayName(name: string | null | undefined): string {
 }
 
 /**
+ * Codex dispatches MCP calls as a literal `execute` tool_call carrying the
+ * real target at `input.tool` (paired with `input.server` / `input.arguments`
+ * — the same shape `unwrapMcpInput` unwraps for renderer input access).
+ * Renderer lookup needs the real tool name, not the `execute` wrapper name.
+ */
+export function unwrapExecuteDispatchName(name: string, input: unknown): string {
+  if (name !== 'execute' || typeof input !== 'object' || input === null) return name
+  const record = input as Record<string, unknown>
+  return typeof record.tool === 'string' && record.server ? record.tool : name
+}
+
+/**
  * Resolve the best renderer for a tool call.
  * 1. Built-in exact tool-name match (after stripping prefixes)
  * 2. Plugin-registered renderer (window.tos.registerToolRenderer)
  * 3. Agent-type fallback
  * 4. null (caller uses DefaultInput/DefaultResult)
  */
-export function resolveRenderer(toolName: string, agentType: string): ToolRendererDef | null {
-  const displayName = getToolDisplayName(toolName)
+export function resolveRenderer(
+  tool: { name: string; input?: unknown },
+  agentType: string,
+): ToolRendererDef | null {
+  const displayName = getToolDisplayName(unwrapExecuteDispatchName(tool.name, tool.input))
   return (
     toolRenderers[displayName] ??
     getPluginToolRenderer(displayName) ??


### PR DESCRIPTION
## Summary
- Codex agent sessions route MCP calls through a literal `execute` tool_call, with the real target tool nested at `input.tool` / `input.server` / `input.arguments` — the same wrapper shape `unwrapMcpInput` already unwraps for renderer *input* access.
- `resolveRenderer` only matched the literal tool-call name, so any `*_propose` tool (e.g. builder-mode prompt-library update) invoked this way never matched the approval-card allow-list and silently fell back to the default renderer — no Approve/Reject card, even though the backend created a valid pending `agent_requests` row.
- Added `unwrapExecuteDispatchName` in `registry.ts` and threaded the resolved name through `ToolCallBlock` for renderer lookup, lazy-plugin lookup, and the displayed tool title (so the card/label shows the real tool name instead of `execute`).

## Test plan
- [x] `tsc --noEmit` clean in `internal/ui-sdk` and `web`
- [x] Verified `unwrapExecuteDispatchName` against a real captured `execute` dispatcher payload (`{server, tool: "prompt_update_propose", arguments}`) — correctly resolves to `prompt_update_propose`; direct (non-wrapped) tool calls and unrelated tool names pass through unchanged
- [ ] Manual end-to-end verification in a live Codex-routed session (not exercised — no local repro environment for this agent runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)