### PR TITLE
fix(ui-sdk): unwrap Codex execute dispatcher's result envelope in getMcpText

### DIFF
--- a/internal/ui-sdk/src/tool-renderers/types.ts
+++ b/internal/ui-sdk/src/tool-renderers/types.ts
@@ -42,9 +42,11 @@ export function truncate(s: string, max = 120): string {
 
 /**
  * Extract text from MCP tool result.
- * Handles both formats:
- *  - CC MCP:    [{"type":"text","text":"..."}]
- *  - Codex MCP: {"content":[{"type":"text","text":"..."}]}
+ * Handles:
+ *  - CC MCP:      [{"type":"text","text":"..."}]
+ *  - Codex MCP:   {"content":[{"type":"text","text":"..."}]}
+ *  - Codex `execute(server, tool, arguments)` dispatcher: wraps the real
+ *    CallToolResult one level deeper, as {"result":{"content":[...]},"error":null}
  */
 export function getMcpText(result: string | object | undefined): string | null {
   const parsed = safeParseResult<unknown>(result)
@@ -56,9 +58,16 @@ export function getMcpText(result: string | object | undefined): string | null {
       return (first as { text: string }).text
     return null
   }
+  if (typeof parsed !== 'object') return null
+  const container =
+    'content' in parsed
+      ? parsed
+      : 'result' in parsed && typeof (parsed as { result: unknown }).result === 'object'
+        ? (parsed as { result: object }).result
+        : parsed
   // Wrapped: {"content":[{"type":"text","text":"..."}]}
-  if (typeof parsed === 'object' && 'content' in parsed) {
-    const content = (parsed as { content: unknown }).content
+  if (container && typeof container === 'object' && 'content' in container) {
+    const content = (container as { content: unknown }).content
     if (
       Array.isArray(content) &&
       content[0] &&


### PR DESCRIPTION
## Summary
- Follow-up to #103. That PR fixed renderer *selection* for tool calls routed through Codex's `execute(server, tool, arguments)` dispatcher, but missed that the dispatcher also wraps the *result* one level deeper: `{"result":{"content":[...]},"error":null}` instead of the direct `{"content":[...]}` shape.
- `getMcpText` only recognized the direct array/`{content:[...]}` shapes, so `*_propose` approval cards (and any other MCP renderer using `getMcpText`) now resolved to the correct renderer but still couldn't extract the envelope/text — rendering nothing.
- `getMcpText` now unwraps the `{result, error}` container before looking for `content`, while still handling the two pre-existing shapes unchanged.

## Test plan
- [x] `tsc --noEmit` clean in `internal/ui-sdk` and `web`
- [x] Verified against a real captured `execute`-wrapped result payload from a reproduction session (`workspace_schedule_propose`) — correctly extracts the inner envelope JSON; direct array and direct `{content:[...]}` shapes still parse unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)