### PR TITLE
fix(schedules): reject cron steps that exceed a field's range

### DIFF
--- a/control-plane/src/lib/schedule-cron.test.ts
+++ b/control-plane/src/lib/schedule-cron.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ScheduleCreateBodySchema,
+  ScheduleUpdateBodySchema,
+  hasOutOfRangeCronStep,
+} from '../../../internal/types/api'
+
+// cron-parser silently collapses a step larger than a field's range instead
+// of erroring — e.g. "0/120" in the minute field only ever matches minute 0,
+// turning "every 120 minutes" into "every hour" with no error. Both the web
+// preview and pg-boss (real schedule execution) run on that same library, so
+// this has to be rejected before it reaches either.
+describe('hasOutOfRangeCronStep', () => {
+  it('flags a minute step beyond 59 (the reported bug)', () => {
+    expect(hasOutOfRangeCronStep('0/120 * * * *')).toBe(true)
+  })
+
+  it('flags an hour step beyond 23', () => {
+    expect(hasOutOfRangeCronStep('0 0/25 * * *')).toBe(true)
+  })
+
+  it('flags a day-of-month step beyond 31', () => {
+    expect(hasOutOfRangeCronStep('0 9 1/40 * *')).toBe(true)
+  })
+
+  it('flags a month step beyond 12', () => {
+    expect(hasOutOfRangeCronStep('0 9 1 1/15 *')).toBe(true)
+  })
+
+  it('flags a day-of-week step beyond 7', () => {
+    expect(hasOutOfRangeCronStep('0 9 * * 1/10')).toBe(true)
+  })
+
+  it('allows an in-range minute step', () => {
+    expect(hasOutOfRangeCronStep('*/30 * * * *')).toBe(false)
+  })
+
+  it('allows the hour-field equivalent of "every 120 minutes"', () => {
+    expect(hasOutOfRangeCronStep('0 */2 * * *')).toBe(false)
+  })
+
+  it('allows plain fixed-time expressions with no step syntax', () => {
+    expect(hasOutOfRangeCronStep('0 9 * * *')).toBe(false)
+  })
+
+  it('does not throw on a malformed expression — returns false so existing invalid-expression handling still applies', () => {
+    expect(hasOutOfRangeCronStep('not a cron')).toBe(false)
+    expect(hasOutOfRangeCronStep('')).toBe(false)
+  })
+})
+
+describe('ScheduleCreateBodySchema cron step validation', () => {
+  const base = { name: 'test', prompt: 'hi' }
+
+  it('rejects a cron with an out-of-range step', () => {
+    const result = ScheduleCreateBodySchema.safeParse({ ...base, cron: '0/120 * * * *' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a cron with a valid step', () => {
+    const result = ScheduleCreateBodySchema.safeParse({ ...base, cron: '0 */2 * * *' })
+    expect(result.success).toBe(true)
+  })
+
+  it('still rejects when both cron and run_at are set, independent of step validity', () => {
+    const result = ScheduleCreateBodySchema.safeParse({
+      ...base,
+      cron: '0 9 * * *',
+      run_at: '2099-01-01T00:00:00.000Z',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ScheduleUpdateBodySchema cron step validation', () => {
+  it('rejects a cron with an out-of-range step', () => {
+    const result = ScheduleUpdateBodySchema.safeParse({ cron: '0/120 * * * *' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a partial update without touching cron', () => {
+    const result = ScheduleUpdateBodySchema.safeParse({ enabled: false })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts clearing cron to null (switching to a one-time schedule)', () => {
+    const result = ScheduleUpdateBodySchema.safeParse({
+      cron: null,
+      run_at: '2099-01-01T00:00:00.000Z',
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -1318,6 +1318,25 @@ export const ApiScheduleSchema = z.object({
 
 export type ApiSchedule = z.infer<typeof ApiScheduleSchema>
 
+// Per-field max value for a standard 5-field cron expression (minute, hour,
+// day-of-month, month, day-of-week). The `cron-parser` lib both the web
+// preview and pg-boss (server-side execution) run on doesn't reject a step
+// larger than a field's range — e.g. "0/120" in the minute field silently
+// walks 0,120,240,... within 0-59 and only ever matches minute 0, collapsing
+// "every 120 minutes" into "every hour" with no error, no matter which side
+// parses it. Reject that shape up front instead of letting it silently fire
+// at the wrong interval.
+const CRON_FIELD_MAX = [59, 23, 31, 12, 7]
+
+export function hasOutOfRangeCronStep(cron: string): boolean {
+  const parts = cron.trim().split(/\s+/)
+  if (parts.length !== 5) return false
+  return parts.some((field, i) => {
+    const step = field.match(/\/(\d+)$/)
+    return step ? Number(step[1]) > CRON_FIELD_MAX[i] : false
+  })
+}
+
 export const ScheduleCreateBodySchema = z
   .object({
     name: z.string().min(1),
@@ -1332,6 +1351,10 @@ export const ScheduleCreateBodySchema = z
   })
   .refine((v) => !!v.cron !== !!v.run_at, {
     message: 'Provide exactly one of cron or run_at',
+    path: ['cron'],
+  })
+  .refine((v) => !v.cron || !hasOutOfRangeCronStep(v.cron), {
+    message: 'cron step exceeds a field\'s valid range (e.g. minute step > 59)',
     path: ['cron'],
   })
 
@@ -1349,6 +1372,10 @@ export const ScheduleUpdateBodySchema = z
     enabled: z.boolean(),
   })
   .partial()
+  .refine((v) => !v.cron || !hasOutOfRangeCronStep(v.cron), {
+    message: 'cron step exceeds a field\'s valid range (e.g. minute step > 59)',
+    path: ['cron'],
+  })
 
 // ─── Chat ───────────────────────────────────────────────────────────
 

--- a/web/src/components/ui/cron-editor.tsx
+++ b/web/src/components/ui/cron-editor.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { describeCron } from "@/lib/cron-describe";
+import { hasOutOfRangeCronStep } from "@neutree-ai/types";
 import { CronExpressionParser } from "cron-parser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -386,8 +387,15 @@ export function CronEditor({
       ? "custom"
       : parsed.period;
 
-  const description = useMemo(() => describeCron(value, i18n.language), [value, i18n.language]);
-  const nextFires = useMemo(() => computeNextFires(value, timezone, 3), [value, timezone]);
+  const outOfRangeStep = useMemo(() => hasOutOfRangeCronStep(value), [value]);
+  const description = useMemo(
+    () => (outOfRangeStep ? null : describeCron(value, i18n.language)),
+    [value, i18n.language, outOfRangeStep],
+  );
+  const nextFires = useMemo(
+    () => (outOfRangeStep ? null : computeNextFires(value, timezone, 3)),
+    [value, timezone, outOfRangeStep],
+  );
 
   return (
     <div className="space-y-3">
@@ -549,13 +557,17 @@ export function CronEditor({
       {/* Preview — natural-language description + next fires. Raw cron is
           intentionally absent from the preview: it only appears in the
           custom-mode input box where the user is typing it directly. */}
-      {(description || nextFires) && (
+      {(description || nextFires || outOfRangeStep) && (
         <div className="space-y-1 rounded-md border border-foreground/[0.08] bg-foreground/[0.02] px-2.5 py-2">
           {description ? (
             <div className="text-xs text-foreground">{description}</div>
           ) : (
             <div className="text-xs text-destructive">
-              {t("components.cronEditor.hints.invalid")}
+              {t(
+                outOfRangeStep
+                  ? "components.cronEditor.hints.outOfRangeStep"
+                  : "components.cronEditor.hints.invalid",
+              )}
             </div>
           )}
           {nextFires && nextFires.length > 0 && (

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1773,7 +1773,8 @@
       },
       "hints": {
         "standard": "Standard 5-field cron: minute hour day month weekday",
-        "invalid": "Invalid expression"
+        "invalid": "Invalid expression",
+        "outOfRangeStep": "Step exceeds this field's valid range — the actual interval will be truncated and won't fire as intended"
       }
     },
     "dialog": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1798,7 +1798,8 @@
       },
       "hints": {
         "standard": "标准 5 段 cron：分钟 小时 日 月 星期",
-        "invalid": "表达式无效"
+        "invalid": "表达式无效",
+        "outOfRangeStep": "步长超出该字段取值范围，实际触发间隔会被截断，不会按预期生效"
       }
     },
     "dialog": {


### PR DESCRIPTION
## Summary
- Reported via Forum: a custom schedule cron of `0/120 * * * *` ("every 120 minutes") actually fires every 60 minutes — both in the UI's next-run preview and in real task execution.
- Root cause: `cron-parser` doesn't validate that a step value fits within a field's range. The minute field only spans 0-59, so `0/120` walks `0, 120, 240, ...` and only ever matches `0`, collapsing the interval to hourly with no error thrown. `pg-boss` (server-side schedule execution) depends on the same `cron-parser` version, so this isn't a cosmetic preview bug — real scheduled tasks misfire at the wrong cadence.
- Added `hasOutOfRangeCronStep` in `internal/types/api.ts` (shared by web and control-plane) and wired it into:
  - `ScheduleCreateBodySchema` / `ScheduleUpdateBodySchema` `.refine()` — server-side rejection on create/update, both already validated automatically via `@hono/zod-openapi`.
  - The custom cron input in `web/src/components/ui/cron-editor.tsx` — shows a specific "step exceeds this field's range" warning instead of a preview that silently shows the (wrong) collapsed schedule.
- The structured "every N [minute/hour/day]" UI already clamped its step to each unit's max, so it was never reachable from there — only the free-text custom cron box.

## Test plan
- [x] `tsc --noEmit` clean in `web` and `control-plane`
- [x] `biome check` clean on touched files
- [x] Verified `hasOutOfRangeCronStep` against the reported case (`0/120 * * * *` → true), valid equivalents (`*/30 * * * *`, `0 */2 * * *` → false), an hour-field case (`0 0/25 * * *` → true), and a malformed string (does not throw, returns false so existing invalid-expression handling still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)