### PR TITLE
fix(web): render approval card for live-streamed execute-wrapped proposes

### DIFF
--- a/web/src/components/chat/tool-renderers/mcp/agent-request.tsx
+++ b/web/src/components/chat/tool-renderers/mcp/agent-request.tsx
@@ -123,21 +123,23 @@ function AgentRequestCardInteractive({ envelope }: { envelope: ProposeEnvelope }
   const workspaceId = useAgentSessionStore((s) => s.workspaceId)
   const isBusy = useAgentSessionStore((s) => s.isBusy)
   const actions = useAgentSessionActions()
-  const seeded: ApiAgentRequest | null =
-    envelope.payload !== undefined && envelope.status !== undefined
-      ? {
-          id: envelope.request_id,
-          workspace_id: workspaceId,
-          user_id: '',
-          kind: envelope.kind,
-          payload: envelope.payload as Record<string, unknown>,
-          status: envelope.status,
-          reject_reason: null,
-          applied_at: null,
-          created_at: new Date().toISOString(),
-          resolved_at: null,
-        }
-      : null
+  // Primitive so it's stable across renders (envelope identity is not) — safe
+  // to use as an effect dep and to gate the fetch-failure fallback below.
+  const hasSeed = envelope.payload !== undefined && envelope.status !== undefined
+  const seeded: ApiAgentRequest | null = hasSeed
+    ? {
+        id: envelope.request_id,
+        workspace_id: workspaceId,
+        user_id: '',
+        kind: envelope.kind,
+        payload: envelope.payload as Record<string, unknown>,
+        status: envelope.status as ApiAgentRequest['status'],
+        reject_reason: null,
+        applied_at: null,
+        created_at: new Date().toISOString(),
+        resolved_at: null,
+      }
+    : null
   const [req, setReq] = useState<ApiAgentRequest | null>(seeded)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
@@ -152,15 +154,21 @@ function AgentRequestCardInteractive({ envelope }: { envelope: ProposeEnvelope }
         if (!cancelled) setReq(r)
       })
       .catch((e: Error) => {
-        if (!cancelled) setLoadError(e.message)
+        // This fetch only refreshes the authoritative status. When the envelope
+        // already carried payload+status (so `seeded` rendered a card), a
+        // transient failure here — e.g. control-plane blips during cluster
+        // instability — must NOT blank the card; keep showing the seed. Only
+        // surface a fatal load error when there was nothing to fall back to.
+        if (!cancelled && !hasSeed) setLoadError(e.message)
       })
     return () => {
       cancelled = true
     }
-  }, [workspaceId, envelope.request_id])
+  }, [workspaceId, envelope.request_id, hasSeed])
 
   async function resolve(decision: 'approved' | 'rejected', rejectReason?: string) {
     setPending(true)
+    setLoadError(null)
     try {
       const updated = await api.resolveAgentRequest(
         workspaceId,
@@ -182,16 +190,15 @@ function AgentRequestCardInteractive({ envelope }: { envelope: ProposeEnvelope }
     }
   }
 
-  if (loadError) {
-    return (
+  // Only a fatal state (no card to show) replaces the whole renderer. A
+  // resolve() failure while a card is already on screen surfaces inline below,
+  // so the user keeps the card and can retry instead of losing it entirely.
+  if (!req) {
+    return loadError ? (
       <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-tiny text-destructive">
         {t('components.chat.toolRenderers.agentRequest.loadFailed')}: {loadError}
       </div>
-    )
-  }
-
-  if (!req) {
-    return (
+    ) : (
       <div className="rounded-md border bg-muted/30 p-3 text-tiny text-muted-foreground">
         {t('components.chat.toolRenderers.agentRequest.loading')}
       </div>
@@ -269,6 +276,12 @@ function AgentRequestCardInteractive({ envelope }: { envelope: ProposeEnvelope }
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {loadError && (
+        <div className="px-3 py-2 border-t border-destructive/20 bg-destructive/5 text-tiny text-destructive">
+          {t('components.chat.toolRenderers.agentRequest.loadFailed')}: {loadError}
         </div>
       )}
 

--- a/web/src/stores/agent-session-store.test.ts
+++ b/web/src/stores/agent-session-store.test.ts
@@ -660,6 +660,53 @@ describe('createAgentSessionStore', () => {
       expect(toolBlock!.type === 'tool' && toolBlock!.tool.input).toEqual({ path: '/a.ts' })
     })
 
+    test('SSE tool_call populates input from start-event args (no completion event)', () => {
+      // The Codex `execute` dispatcher's renderer is chosen by the (name, input)
+      // pair — the approval card only resolves once input reveals the wrapped
+      // {server, tool}. When a tool_call has no separate completion event (only
+      // a tool_result follows), input must be populated on start or the block is
+      // stranded on the generic renderer and the card never appears.
+      const deps = makeDeps({
+        sse: {
+          createAgentChat: vi.fn((_wid, _msg, _sid, handlers: SSEHandlers) => {
+            handlers.onItemStarted?.({
+              item_id: 'tc-1',
+              kind: 'tool_call',
+              role: null,
+              status: 'in_progress',
+              content: [
+                {
+                  type: 'tool_call',
+                  call_id: 'call-1',
+                  name: 'execute',
+                  arguments:
+                    '{"server":"tos-platform","tool":"prompt_update_propose","arguments":{}}',
+                },
+              ],
+            } as UniversalItem)
+            handlers.onItemCompleted?.({
+              item_id: 'tr-1',
+              kind: 'tool_result',
+              role: 'tool',
+              status: 'completed',
+              content: [{ type: 'tool_result', call_id: 'call-1', output: '{}' }],
+            } as UniversalItem)
+          }),
+        },
+      })
+      const { s } = make('ws-1', deps)
+
+      s.sendMessage('update the prompt')
+
+      const assistant = s.messages.find((m) => m.role === 'assistant')!
+      const toolBlock = assistant.blocks.find((b) => b.type === 'tool')!
+      expect(toolBlock.type === 'tool' && toolBlock.tool.input).toEqual({
+        server: 'tos-platform',
+        tool: 'prompt_update_propose',
+        arguments: {},
+      })
+    })
+
     test('SSE tool_result updates existing tool block', () => {
       const deps = makeDeps({
         sse: {

--- a/web/src/stores/agent-session-store.ts
+++ b/web/src/stores/agent-session-store.ts
@@ -408,6 +408,19 @@ export function createAgentSessionStore(
         if (item.kind === 'tool_call') {
           const tc = item.content?.[0]
           if (tc?.type === 'tool_call') {
+            // Populate input from the args carried on the start event rather
+            // than deferring to onItemCompleted. A renderer is chosen by the
+            // (name, input) pair — e.g. the Codex `execute` dispatcher only
+            // resolves to the approval-card renderer once input reveals the
+            // wrapped `{server, tool}`. If a tool_call has no separate
+            // completion event (only a tool_result follows), leaving input
+            // empty here strands the block on the generic renderer forever and
+            // the approval card never appears. Parse defensively; missing/bad
+            // args fall back to {} exactly as before.
+            let input: Record<string, unknown> = {}
+            try {
+              input = JSON.parse(tc.arguments || '{}')
+            } catch {}
             store.setState((s) => ({
               messages: s.messages.map((m) =>
                 m.id === assistantId
@@ -422,7 +435,7 @@ export function createAgentSessionStore(
                             name:
                               tc.name ??
                               transcriptI18n.t('components.chat.toolRenderers.labels.unknown'),
-                            input: {},
+                            input,
                             startedAt: Date.now(),
                             parentToolUseId: item.parent_tool_use_id ?? null,
                           },


### PR DESCRIPTION
## Summary
Follow-up to #103 / #104. A user reported that a builder-mode prompt-update approval card **rendered fine yesterday but stopped rendering again today, same session**. Investigation (control-plane logs + DB) showed the newest `agent_request` she was looking at was **never fetched** by `getAgentRequest` — i.e. the interactive card never mounted — while older requests in the same session (loaded via page reload) fetched and rendered fine.

Root cause is in the **live streaming path**, not the history/reload path (which #103/#104 fixed):

- The renderer for a tool block is chosen by the `(name, input)` pair. The Codex `execute` dispatcher only resolves to the approval-card renderer once `input` reveals the wrapped `{server, tool}` (via `unwrapExecuteDispatchName`).
- `agent-session-store.ts` `onItemStarted` hardcoded `input: {}` and deferred real population to an `onItemCompleted(tool_call)` event. But these `execute` calls emit only a `tool_result` (no separate `tool_call` completion), so `input` stayed `{}` forever — the block was stranded on the generic renderer and the approval card never mounted. On reload the history path (`toChatMessage`) populates input from stored args, which is why it rendered fine there.
- Fix: populate `input` from the start-event args in `onItemStarted` (same defensive `JSON.parse(... || '{}')` as `onItemCompleted`).

Second, a hardening fix in `AgentRequestCardInteractive`: the background `getAgentRequest` call only *refreshes* authoritative status, but a transient failure (control-plane blips during the ongoing cluster instability) set `loadError`, which took render priority and **blanked a card that had already rendered from the seeded envelope**. Now the fatal error state is reserved for when there's genuinely nothing to show (`!req`), and `resolve()` failures surface inline so the card and its retry buttons survive.

## Test plan
- [x] `tsc --noEmit` clean; `biome check` clean on all touched files
- [x] `agent-session-store.test.ts`: added a regression test — a `tool_call` with full args on the start event and **no** completion event (only a `tool_result` follows) now populates `input` immediately. 51/51 pass. (Fails on the pre-fix code, where input stayed `{}`.)
- [x] Verified against the real reproduction: the newest `agent_request` (`cb8f0875…`) had zero `getAgentRequest` fetches in 2h of control-plane logs, confirming its card never mounted; older requests fetched fine via reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)