### PR TITLE
fix(web): format model error line and i18n load-failure message

### DIFF
--- a/web/src/components/workspace/ModelFields.tsx
+++ b/web/src/components/workspace/ModelFields.tsx
@@ -165,9 +165,7 @@ export function ModelFields({
             />
           )}
         </div>
-        {modelsError && (
-          <p className="text-xs text-destructive">{modelsError}</p>
-        )}
+        {modelsError && <p className="text-xs text-destructive">{modelsError}</p>}
         {providerId && <TestResult state={test.state} detail={test.detail} />}
       </div>
 

--- a/web/src/components/workspace/agent-config/ModelPicker.tsx
+++ b/web/src/components/workspace/agent-config/ModelPicker.tsx
@@ -250,6 +250,7 @@ export function TestResult({ state, detail }: { state: TestState; detail: string
 // ── Hook: fetch models for a provider ──
 
 export function useProviderModels(providerId: string) {
+  const { t } = useTranslation()
   const [models, setModels] = useState<{ id: string; name: string }[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -270,10 +271,10 @@ export function useProviderModels(providerId: string) {
       })
       .catch(() => {
         setModels([])
-        setError('Failed to load models')
+        setError(t('components.modelFields.errors.loadModelsFailed'))
       })
       .finally(() => setLoading(false))
-  }, [providerId])
+  }, [providerId, t])
 
   return { models, loading, error }
 }

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1157,6 +1157,9 @@
       },
       "empty": {
         "noProviders": "No providers found."
+      },
+      "errors": {
+        "loadModelsFailed": "Failed to load models"
       }
     },
     "agentConfigFieldHint": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1182,6 +1182,9 @@
       },
       "empty": {
         "noProviders": "未找到 API 供应商。"
+      },
+      "errors": {
+        "loadModelsFailed": "加载模型列表失败"
       }
     },
     "agentConfigFieldHint": {


### PR DESCRIPTION
Follow-up to #101.

## What

- **Format**: collapse the `modelsError` conditional in `ModelFields.tsx` to a single line — this is the `biome check` failure that CI flagged on #101 (merged without it).
- **i18n**: replace the hardcoded English `'Failed to load models'` fallback in `useProviderModels` with a translated key `components.modelFields.errors.loadModelsFailed`, added to both `en-US` and `zh-CN`.

## Verified

- `npx tsc --noEmit` passes
- `biome check` on changed files → exit 0 (only pre-existing exhaustive-deps warnings in `ModelFields.tsx`, unrelated)
- Both locale JSON files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)