### PR TITLE
fix(workspaces): make Restart actually replace the pod

### DIFF
--- a/control-plane/src/routes/workspaces/lifecycle.ts
+++ b/control-plane/src/routes/workspaces/lifecycle.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import type { AppEnv } from '../../lib/types'
 import { resetAllSessionsIdle } from '../../services/db/sessions'
 import { getWorkspace, updateWorkspace } from '../../services/db/workspaces'
-import { setDesiredPhase } from '../../services/placement'
+import { bumpWorkspaceSpec, setDesiredPhase } from '../../services/placement'
 import { reconcileWorkspacePod, startWorkspaceInstance } from '../../services/workspace-reconcile'
 import { canManage, interruptAllSessions } from './_shared'
 
@@ -115,6 +115,64 @@ lifecycle.openapi(stopRoute, async (c) => {
     await updateWorkspace(id, { status: 'stopped' })
     return c.json({ success: true }, 200)
   } catch (e: any) {
+    return c.json({ error: e.message }, 500)
+  }
+})
+
+// ── POST /:id/restart ──────────────────────────────────────────────────────
+const restartRoute = createRoute({
+  method: 'post',
+  path: '/{id}/restart',
+  tags: ['workspaces'],
+  summary: 'Restart a workspace — replace its pod, preserving state',
+  description:
+    "Recreates the workspace's pod (clearing in-pod ephemeral/agent state such " +
+    'as a stuck agent process) while keeping desired_phase=running, the PVC, ' +
+    'and persisted session history. Replaces the racy client-side stop+start: ' +
+    'bumps the placement spec so the env-runner rebuilds the Deployment in one ' +
+    'converge, so the pod is always actually replaced (a fast stop+start could ' +
+    'leave the old pod running because the stopped window was never observed).',
+  security: [{ bearerAuth: [] }],
+  request: { params: WorkspaceIdParam },
+  responses: {
+    200: {
+      description: 'Restart initiated',
+      content: { 'application/json': { schema: SuccessSchema } },
+    },
+    404: {
+      description: 'Workspace not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+    500: {
+      description: 'Internal error',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+lifecycle.openapi(restartRoute, async (c) => {
+  const currentUser = c.get('user')
+  const { id } = c.req.valid('param')
+  const workspace = await getWorkspace(id)
+  if (!workspace || !canManage(workspace, currentUser)) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+
+  try {
+    console.log(`[Restart] Request workspace=${id}`)
+    await interruptAllSessions(workspace, 'Restart')
+    // Force a pod replacement via the placement system rather than a client-side
+    // stop→start: bumping spec_version makes the env-runner re-apply (rebuild the
+    // Deployment → new pod) on its next converge. desired_phase stays 'running'
+    // throughout, so — unlike stop+start — there is no stopped window to race
+    // away, and the pod is reliably recreated. PVC + session history persist.
+    await bumpWorkspaceSpec(id)
+    await setDesiredPhase(id, 'running')
+    await resetAllSessionsIdle(id)
+    await updateWorkspace(id, { status: 'starting' })
+    return c.json({ success: true }, 200)
+  } catch (e: any) {
+    console.error('[Restart] Failed:', e)
     return c.json({ error: e.message }, 500)
   }
 })

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -72,10 +72,11 @@ export function useRestartWorkspace() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (id: string) => {
-      await api.stopWorkspace(id)
-      return api.startWorkspace(id)
-    },
+    // Single server-side restart (pod rebuild via the placement system). The old
+    // stop-then-start raced: the two desired-phase writes landed back-to-back so
+    // the env-runner never observed a durable "stopped", left the Deployment at
+    // one replica, and the same pod (with its stale in-pod agent state) survived.
+    mutationFn: (id: string) => api.restartWorkspace(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['workspaces'] })
     },

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -279,6 +279,12 @@ class ApiClient {
     })
   }
 
+  async restartWorkspace(id: string): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>(`/workspaces/${id}/restart`, {
+      method: 'POST',
+    })
+  }
+
   async deleteWorkspace(id: string): Promise<{ success: boolean }> {
     return this.request<{ success: boolean }>(`/workspaces/${id}`, {
       method: 'DELETE',


### PR DESCRIPTION
## Summary
A user reported that a workspace stuck on persistent `Internal error` did **not** recover after clicking the UI **Restart** button. Investigation showed the pod was never actually recreated (pod age 25h, 0 restarts, warm `agentInit=0.0s`).

Root cause: the UI Restart (`useRestartWorkspace`) called `stopWorkspace()` then `startWorkspace()` back to back. After the P1 control inversion, both are **async desired-phase writes** converged by the env-runner — cp no longer mutates k8s directly. The two writes (`stopped`, then immediately `running`) landed within one reconcile window, so the runner never observed a durable `stopped` state, left the Deployment at 1 replica, and the **same pod survived**. Any in-pod ephemeral agent state — e.g. a codex bridge whose child died mid-turn and now instant-fails every prompt — was therefore never cleared, so "restart" didn't fix the exact thing users reach for it to fix. (Verified separately: a real pod delete recovers the session cleanly by cold-loading from the persisted rollout.)

## Change
- Add `POST /workspaces/:id/restart`: forces a pod replacement through the placement system by bumping `spec_version` (env-runner re-applies → `rebuildInstance` → new pod) while keeping `desired_phase=running`. No stopped window to race away; PVC + persisted session history preserved.
- `api.restartWorkspace()` + point `useRestartWorkspace` at the single server-side restart instead of stop+start.

This reuses the exact convergence path already used by rebuild/resize/template-drift (`bumpWorkspaceSpec` → reconcile `spec_version > observed_version` → `provider.apply` → `rebuildInstance`), so no new k8s-mutation surface or schema change.

## Test plan
- [x] `tsc --noEmit` clean in control-plane and web; `biome check` clean on touched files
- [x] Mechanism validated in prod: deleting the stuck pod recreated it and the affected session cold-loaded from its rollout and resumed streaming normally (same underlying `rebuildInstance` path this route triggers)
- [ ] Post-deploy: click Restart on a running workspace → confirm a new pod is created (pod age resets) and the session resumes from history

🤖 Generated with [Claude Code](https://claude.com/claude-code)