### PR TITLE
fix(env-runner-k8s): make it buildable, and actually deploy it in self-host

### DIFF
--- a/env-runner-k8s/Dockerfile
+++ b/env-runner-k8s/Dockerfile
@@ -17,7 +17,7 @@ COPY env-runner-k8s/src ./src
 # them into dist/index.js, so the runtime stage doesn't need them.
 # @kubernetes/client-node and multiplex stay external.
 COPY internal/env-runner-core /app/internal/env-runner-core
-COPY internal/k8s-provider/package.json internal/k8s-provider/index.ts /app/internal/k8s-provider/
+COPY internal/k8s-provider /app/internal/k8s-provider
 COPY internal/env-tunnel /app/internal/env-tunnel
 COPY internal/types /app/internal/types
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -480,6 +480,11 @@ apply_manifests() {
   kapply -f "$RENDERED_DIR/channel-gateway.yaml"
   kapply -f "$RENDERED_DIR/scheduler.yaml"
   kapply -f "$RENDERED_DIR/skills-content-service.yaml"
+  # env-runner-k8s owns every workspace mutation since the P1 control inversion:
+  # control-plane only writes desired state to workspace_placements, the runner
+  # reconciles it into Deployments. Without it, workspaces never start. Apply it
+  # before control-plane so the runner is watching before placements are written.
+  kapply -f "$RENDERED_DIR/env-runner-k8s.yaml"
   kapply -f "$RENDERED_DIR/control-plane.yaml"
   if [ "$SANDBOX_ENABLED" = "true" ]; then
     kapply -f "$RENDERED_DIR/sandbox-service.yaml"
@@ -527,7 +532,7 @@ apply_manifests() {
   [ "$BROWSER_ENABLED" = true ] && browser_dep="nap-browser"
 
   log "Waiting for deployments to be ready ..."
-  for dep in nap-cp nap-cg nap-scheduler nap-skills $sandbox_dep $browser_dep afs-controller nap-office-converter; do
+  for dep in nap-cp nap-cg nap-scheduler nap-skills nap-env-runner-k8s $sandbox_dep $browser_dep afs-controller nap-office-converter; do
     kubectl -n "${NAMESPACE}" rollout status "deployment/$dep" --timeout=180s || {
       warn "$dep not ready within 180s"
     }
@@ -539,13 +544,13 @@ apply_manifests() {
   # on fresh installs (pods were just created). Excluded: nap-pg (operator-
   # managed via CNPG).
   log "Refreshing :latest-tag deployments to pick up new image digests ..."
-  for dep in nap-cp nap-cg nap-scheduler nap-skills afs-controller $sandbox_dep $browser_dep nap-office-converter; do
+  for dep in nap-cp nap-cg nap-scheduler nap-skills nap-env-runner-k8s afs-controller $sandbox_dep $browser_dep nap-office-converter; do
     kubectl -n "${NAMESPACE}" rollout restart "deployment/$dep" >/dev/null 2>&1 || true
   done
   if [ "$SANDBOX_ENABLED" = "true" ]; then
     kubectl -n "${NAMESPACE}" rollout restart daemonset/sandbox-image-warmer >/dev/null 2>&1 || true
   fi
-  for dep in nap-cp nap-cg nap-scheduler nap-skills afs-controller $sandbox_dep $browser_dep nap-office-converter; do
+  for dep in nap-cp nap-cg nap-scheduler nap-skills nap-env-runner-k8s afs-controller $sandbox_dep $browser_dep nap-office-converter; do
     kubectl -n "${NAMESPACE}" rollout status "deployment/$dep" --timeout=180s || {
       warn "$dep restart not ready within 180s"
     }


### PR DESCRIPTION
`env-runner-k8s` is mandatory since the P1 control inversion, but it is currently **neither buildable nor deployed**. Two independent bugs, both of which block any self-hosted release cut from `main`.

## 1. The image cannot be built

`env-runner-k8s/Dockerfile`'s build stage copied only `k8s-provider/package.json` and `k8s-provider/index.ts`. Once *"refactor: carve workspace-runtime seams"* split that package into `config.ts` / `provider.ts` / `workspace-spec.ts`, `index.ts` re-exported files that were never copied:

```
✘ [ERROR] Could not resolve "./config"
    ../internal/k8s-provider/index.ts:13:69
✘ [ERROR] Could not resolve "./provider"
✘ [ERROR] Could not resolve "./workspace-spec"
3 errors
```

`npm run build` dies, so the image has been unbuildable since that refactor. Fixed by copying the directory whole — matching `env-runner-core` / `env-tunnel` / `types` in the same file, and control-plane's `COPY internal/k8s-provider /internal/k8s-provider`.

## 2. The manifest is rendered but never applied

`self-host/manifests/env-runner-k8s.yaml` was added to the shared manifests, but `install.sh`'s apply sequence is a **per-file list**, not a glob over `rendered/`. `render_manifests` *does* glob, so the manifest is rendered and then silently never applied. The install reports success.

Since the P1 control inversion, control-plane no longer mutates Kubernetes directly — `k8s.ts`:

> The mutation wrappers (create/start/stop/restart/rebuild/resize/expand) were removed in the P1 control inversion — those actions now go through `workspace_placements` and the env-runner.

This covers the built-in environment too ("today's only environment"), not just remote/BYOI ones.

**Impact on a self-hosted install from current `main`:**
- Newly created workspaces never come up (`workspace_placements` gets `spec_version=1, observed_version=0`; nothing reconciles it).
- Existing workspaces keep running (`121_byoi_p1_cutover` backfills placements with `observed_version = spec_version`), but every start/stop/restart/rebuild/resize is **silently dropped** — `POST /workspaces/{id}/restart` bumps the spec and returns `200` regardless.

Nothing errors at install time, which is what makes it nasty.

Fixed by applying `env-runner-k8s.yaml` before `control-plane.yaml` (so the runner is watching before placements are written) and adding `nap-env-runner-k8s` to the readiness-wait and rollout-restart/status lists.

## Test

Both bugs were reproduced and the fixes verified end-to-end on the equivalent downstream offline installer (same shared manifest, same per-file apply list), on **amd64 and arm64**, installing from the packaged tarball rather than a source tree.

**Bug 1** — `env-runner-k8s` failed to build identically on both arches before the fix; builds and pushes cleanly on both after.

**Bug 2** — after the fix the runner is deployed, and the lifecycle path actually reconciles. The decisive check is that `POST /workspaces/{id}/restart` returns `200` whether or not the runner exists, so success is `observed_version` catching up to the bumped `spec_version` **and** the pod being replaced:

| | migration high-water | env-runner | restart → converge | workspace pod |
|---|---|---|---|---|
| amd64 | 123 | 1/1 Running | `spec 1→2`, `observed→2` in ~9s | `…-fx6fn` → `…-pwtj2` ✅ |
| arm64 | 123 | 1/1 Running | `spec 1→2`, `observed→2` in ~12s | `…-zs2cb` → `…-cm9jz` ✅ |

Both reached `observed_phase=starting` and a fresh Deployment-managed pod, i.e. the runner picked the placement up and re-applied it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)