### PR TITLE
fix(mcp-oauth): refresh tokens ahead of expiry instead of at it

### DIFF
--- a/control-plane/src/services/mcp-oauth.test.ts
+++ b/control-plane/src/services/mcp-oauth.test.ts
@@ -9,7 +9,7 @@
  * are out of scope for a unit test.
  */
 import { describe, expect, it } from 'vitest'
-import { shouldDropTokenOnRefreshFailure } from './mcp-oauth'
+import { classifyTokenLife, shouldDropTokenOnRefreshFailure } from './mcp-oauth'
 
 const NOW = new Date('2026-06-10T12:00:00.000Z')
 const ago = (seconds: number) => new Date(NOW.getTime() - seconds * 1000)
@@ -41,5 +41,30 @@ describe('shouldDropTokenOnRefreshFailure', () => {
   it('is exactly at the grace boundary (inclusive)', () => {
     expect(shouldDropTokenOnRefreshFailure(3, ago(600), NOW)).toBe(true)
     expect(shouldDropTokenOnRefreshFailure(3, ago(599), NOW)).toBe(false)
+  })
+})
+
+describe('classifyTokenLife', () => {
+  const MINUTE = 60 * 1000
+
+  it('serves a token with plenty of life as-is', () => {
+    expect(classifyTokenLife(30 * MINUTE)).toBe('fresh')
+  })
+
+  it('flags a token inside the pre-expiry margin for proactive refresh', () => {
+    // google-auth clients treat a token as expired 3m45s before the wire
+    // expiry; the margin must catch it before that.
+    expect(classifyTokenLife(4 * MINUTE)).toBe('refresh-ahead')
+    expect(classifyTokenLife(1)).toBe('refresh-ahead')
+  })
+
+  it('is exactly at the margin boundary (exclusive)', () => {
+    expect(classifyTokenLife(5 * MINUTE + 1)).toBe('fresh')
+    expect(classifyTokenLife(5 * MINUTE)).toBe('refresh-ahead')
+  })
+
+  it('reports a past-expiry token as expired', () => {
+    expect(classifyTokenLife(0)).toBe('expired')
+    expect(classifyTokenLife(-1)).toBe('expired')
   })
 })

--- a/control-plane/src/services/mcp-oauth.ts
+++ b/control-plane/src/services/mcp-oauth.ts
@@ -38,6 +38,25 @@ interface OAuthToken {
 // it; refreshing every ~30min is cheap and avoids stale-token 401s.
 const DEFAULT_TOKEN_TTL_SECONDS = 1800
 
+// How long before expiry we start refreshing proactively. Must exceed
+// google-auth's REFRESH_THRESHOLD (3m45s): clients built on it treat a token
+// as already expired that far ahead of the wire expiry, so anything we serve
+// must have more life left than that.
+const REFRESH_MARGIN_MS = 5 * 60 * 1000
+
+/**
+ * Classify a stored token by remaining life. OAuth-proxy MCP servers mint
+ * their access token together with the upstream provider token, and
+ * google-auth style clients refuse a token in its final 3m45s — serving a
+ * nearly-expired token makes every downstream call fail until it rotates.
+ * `refresh-ahead` marks the window where the token still works but must be
+ * refreshed rather than served as-is.
+ */
+export function classifyTokenLife(msLeft: number): 'fresh' | 'refresh-ahead' | 'expired' {
+  if (msLeft <= 0) return 'expired'
+  return msLeft > REFRESH_MARGIN_MS ? 'fresh' : 'refresh-ahead'
+}
+
 // In-memory store for pending PKCE flows (keyed by state)
 interface PendingAuth {
   user_id: string
@@ -458,22 +477,24 @@ export async function getValidAccessToken(
   // Effective expiry: use stored expires_at, else fall back to updated_at + TTL.
   // Older rows predating the fallback default may have NULL expires_at; treat
   // those as expired once they're past the fallback window so refresh kicks in.
-  if (!forceRefresh) {
-    const effectiveExpiresAt =
-      token.expires_at ??
-      new Date(new Date(token.updated_at).getTime() + DEFAULT_TOKEN_TTL_SECONDS * 1000)
-    if (effectiveExpiresAt > new Date()) {
-      return token.access_token
-    }
+  const effectiveExpiresAt =
+    token.expires_at ??
+    new Date(new Date(token.updated_at).getTime() + DEFAULT_TOKEN_TTL_SECONDS * 1000)
+  const msLeft = effectiveExpiresAt.getTime() - Date.now()
+  const life = classifyTokenLife(msLeft)
+
+  if (!forceRefresh && life === 'fresh') {
+    return token.access_token
   }
+  const stillValid = life !== 'expired'
 
   // Try refresh
-  if (!token.refresh_token) return null
+  if (!token.refresh_token) return stillValid ? token.access_token : null
   const { rows: clientRows } = await pool.query(
     'SELECT server_origin, metadata, client_id, client_secret FROM mcp_oauth_clients WHERE server_origin = $1',
     [serverOrigin],
   )
-  if (clientRows.length === 0) return null
+  if (clientRows.length === 0) return stillValid ? token.access_token : null
   const client = clientRows[0] as OAuthClient
 
   try {
@@ -481,6 +502,16 @@ export async function getValidAccessToken(
     await upsertToken(userId, serverOrigin, refreshed)
     return refreshed.access_token
   } catch (e) {
+    // A proactive (within-margin) refresh failure is not fatal while the
+    // current token is still valid: serve it and let a later request retry.
+    // forceRefresh callers are excluded — they hold proof the token is bad.
+    if (stillValid && !forceRefresh) {
+      console.warn(
+        `[mcp-oauth] proactive refresh failed for ${serverOrigin}; serving still-valid token (${Math.round(msLeft / 1000)}s left):`,
+        e instanceof Error ? e.message : e,
+      )
+      return token.access_token
+    }
     if (e instanceof McpRefreshError && e.permanent) {
       // A "permanent" OAuth code may actually be an upstream transient (a TLS
       // blip while the broker refreshes the provider token, reported back as


### PR DESCRIPTION
## Problem

`getValidAccessToken` served the stored MCP OAuth access token until the very second of `expires_at` and only refreshed after expiry.

OAuth-proxy MCP servers (e.g. FastMCP `OAuthProxy` fronting Google) mint their MCP access token together with the upstream provider token, so both expire at the same moment. On the server side, google-auth treats credentials as expired **3m45s before** the wire expiry (`REFRESH_THRESHOLD`) and attempts a refresh then. The result: every tool call landing in the final ~4 minutes of a token's life fails with an unrecoverable auth error (`RefreshError` → "Please sign in via your MCP client's OAuth 2.1 flow"), until cp finally rotates the token after expiry.

For long-running agent sessions doing continuous MCP tool calls this is a guaranteed multi-minute outage every token lifetime (observed in production: failure window opening at exactly `expiry − 3m45s` and closing at cp's post-expiry refresh). Agents interpret it as a dead connection and ask the user to manually reconnect the MCP server — which is never actually necessary.

## Fix

Classify token life via a new pure helper `classifyTokenLife(msLeft)` with a 5-minute pre-expiry margin (> 3m45s):

- **fresh** (> 5 min left): serve as-is, unchanged behavior.
- **refresh-ahead** (≤ 5 min left, not expired): refresh proactively. If the opportunistic refresh fails, serve the still-valid token instead of failing the request — a later request retries. `forceRefresh` callers are excluded from this fallback since they hold proof (an upstream 401) that the token is bad.
- **expired**: existing behavior, including the permanent-failure grace window and token-drop logic.

Tokens without a `refresh_token` (or without a registered client) are likewise served until real expiry rather than being dropped at the margin.

## Testing

- `VITEST_UNIT=1 vitest run src/services/mcp-oauth.test.ts` — 10/10 pass (4 new cases covering the margin boundary and expiry classification).
- `tsc --noEmit` introduces no new errors in the touched files.
- `biome check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)