### PR TITLE
fix(agent-skills): don't wipe hand-added skill dirs in the pre-sweep

### DIFF
--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -3,15 +3,25 @@ import { SkillManager, type Fs, type Shell, type FetchResponse } from './index.t
 
 // ── In-memory DI implementations ──
 
-function createMemFs(): Fs & { files: Map<string, Buffer | string>; dirs: Set<string> } {
+function createMemFs(): Fs & {
+  files: Map<string, Buffer | string>
+  dirs: Set<string>
+  symlinks: Set<string>
+} {
   const files = new Map<string, Buffer | string>()
   const dirs = new Set<string>()
+  // Paths (already present in `dirs`) that are symlinks rather than real dirs.
+  const symlinks = new Set<string>()
 
   return {
     files,
     dirs,
+    symlinks,
     exists(path) {
       return files.has(path) || dirs.has(path)
+    },
+    isSymlink(path) {
+      return symlinks.has(path)
     },
     async mkdir(path) {
       dirs.add(path)
@@ -27,6 +37,7 @@ function createMemFs(): Fs & { files: Map<string, Buffer | string>; dirs: Set<st
     async rm(path) {
       files.delete(path)
       dirs.delete(path)
+      symlinks.delete(path)
     },
     async readdir(path) {
       const prefix = path.endsWith('/') ? path : `${path}/`
@@ -467,6 +478,7 @@ describe('SkillManager', () => {
     test('pre-sweep removes dangling symlinks (localDir gone after restart)', async () => {
       // Symlink present on NFS but its /tmp target is gone (pod restart wiped it).
       fs.dirs.add('/workspace/.claude/skills/orphan')
+      fs.symlinks.add('/workspace/.claude/skills/orphan')
       // /tmp/skill-orphan intentionally missing
 
       const fetchImpl = async (url: string) => {
@@ -476,6 +488,23 @@ describe('SkillManager', () => {
 
       await createManager(fetchImpl).load()
       expect(fs.exists('/workspace/.claude/skills/orphan')).toBe(false)
+    })
+
+    test('pre-sweep preserves hand-added real directories (not symlinks)', async () => {
+      // A user dropped a skill directory straight into skillsDir: a real dir,
+      // no /tmp target, no .managed marker. It must survive both sweeps.
+      fs.dirs.add('/workspace/.claude/skills/hand-added')
+      fs.files.set('/workspace/.claude/skills/hand-added/SKILL.md', 'hand-authored')
+      // /tmp/skill-hand-added intentionally missing
+
+      const fetchImpl = async (url: string) => {
+        if (url.includes('/workspaces/ws-1/skills')) return jsonResponse({ skills: [] })
+        throw new Error(`Unexpected: ${url}`)
+      }
+
+      await createManager(fetchImpl).load()
+      expect(fs.exists('/workspace/.claude/skills/hand-added')).toBe(true)
+      expect(fs.exists('/workspace/.claude/skills/hand-added/SKILL.md')).toBe(true)
     })
 
     test('preserves drafts (present locally, no .managed marker)', async () => {

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -27,6 +27,8 @@ export interface Fetcher {
 /** Filesystem operations used by SkillManager. */
 export interface Fs {
   exists(path: string): boolean
+  /** lstat-based check: true only when the entry itself is a symlink. */
+  isSymlink(path: string): boolean
   mkdir(path: string): Promise<void>
   writeFile(path: string, data: string | Buffer): Promise<void>
   readFile(path: string): Promise<Buffer>
@@ -374,6 +376,10 @@ export class SkillManager {
         if (name.startsWith('.')) continue
         if (RESERVED_SKILL_NAMES.has(name)) continue
         if (this.isEditing(name)) continue
+        // Only symlinks are ours to sweep here: a real directory at destDir is
+        // user-created content (dropped in by hand, never registered), which
+        // the orphan cleanup below also preserves. Deleting it would eat data.
+        if (!this.fs.isSymlink(this.destDir(name))) continue
         if (this.fs.exists(this.localDir(name))) continue
         try {
           await this.fs.rm(this.destDir(name))

--- a/internal/agent-skills/src/node.ts
+++ b/internal/agent-skills/src/node.ts
@@ -3,7 +3,7 @@
  * Import this in agent code; never in tests.
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, lstatSync } from 'node:fs'
 import { mkdir, writeFile, readFile, rm, readdir, rename } from 'node:fs/promises'
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
@@ -13,6 +13,13 @@ const execFile = promisify(execFileCb)
 
 export const nodeFs: Fs = {
   exists: existsSync,
+  isSymlink: (path) => {
+    try {
+      return lstatSync(path).isSymbolicLink()
+    } catch {
+      return false
+    }
+  },
   mkdir: (path) => mkdir(path, { recursive: true }).then(() => {}),
   writeFile: (path, data) => writeFile(path, data),
   readFile: (path) => readFile(path),


### PR DESCRIPTION
## Summary

`SkillManager.load()`'s dangling-symlink pre-sweep removed any skillsDir entry whose `localBase` target was missing, without checking that the entry was actually a symlink. A real directory a user dropped into skillsDir by hand has no `localBase` target, so it was deleted on every skill reload — even though the later orphan cleanup deliberately preserves unmanaged entries.

Note the `.managed` marker can't be the guard here: it lives on tmpfs, so after a pod restart dangling symlinks have no marker either and the sweep would stop cleaning them. The entry's own type is the right signal.

## Changes

- Add `Fs.isSymlink(path)` (lstat-based) to the DI interface; implement in `nodeFs` and the test mem-fs
- Gate the pre-sweep on it: only genuine symlinks are swept, real directories survive
- New test: hand-added real directory (no tmpfs target, no `.managed` marker) survives `load()`; existing dangling-symlink test updated to mark its entry as a symlink

## Testing

- `internal/agent-skills`: `vitest run` — 31 passed
- `npx tsc --noEmit` clean in `agents/claude-code` and `agents/codex` (the two `nodeFs` consumers)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)