### PR TITLE
fix(web): filter workspace file search client-side instead of dufs ?q=

### DIFF
--- a/web/src/components/workspace/WorkspaceFilesPanel.tsx
+++ b/web/src/components/workspace/WorkspaceFilesPanel.tsx
@@ -181,16 +181,14 @@ export function WorkspaceFilesPanel({
 
   const qc = useQueryClient()
   const listingQueryKey = useMemo(
-    () => ['workspace-files', workspaceId, drive, currentPath, searchQuery || ''] as const,
-    [workspaceId, drive, currentPath, searchQuery],
+    () => ['workspace-files', workspaceId, drive, currentPath] as const,
+    [workspaceId, drive, currentPath],
   )
   const isAfsRoot = drive === 'afs' && currentPath === '/'
   const listingQuery = useQuery<{ entries: DufsEntry[] }>({
     queryKey: listingQueryKey,
     queryFn: async () => {
-      const resp = await fetch(
-        dirListUrl(workspaceId, currentPath, searchQuery || undefined, drive),
-      )
+      const resp = await fetch(dirListUrl(workspaceId, currentPath, undefined, drive))
       if (!resp.ok) {
         throw new Error(t('components.workspaceFiles.errors.listFailed', { status: resp.status }))
       }
@@ -198,7 +196,16 @@ export function WorkspaceFilesPanel({
     },
     enabled: !isAfsRoot,
   })
-  const entries: DufsEntry[] = listingQuery.data?.entries ?? []
+  // Search filters the already-fetched listing client-side. Passing `q`
+  // through puts dufs into a recursive walk of the entire subtree — two
+  // stats per entry, 100s+ on large workspaces over NFS — so the panel
+  // deliberately scopes search to the current folder.
+  const allEntries: DufsEntry[] = listingQuery.data?.entries ?? []
+  const entries: DufsEntry[] = useMemo(() => {
+    if (!searchQuery) return allEntries
+    const q = searchQuery.toLowerCase()
+    return allEntries.filter((e) => e.name.toLowerCase().includes(q))
+  }, [allEntries, searchQuery])
   const isLoading = listingQuery.isLoading && !isAfsRoot
   const listingError = listingQuery.error
     ? listingQuery.error instanceof Error
@@ -429,7 +436,7 @@ export function WorkspaceFilesPanel({
 
   const handleSearch = (query: string) => {
     setSearchQuery(query)
-    // Listing query is keyed on searchQuery, so it refetches automatically.
+    // Filtering happens client-side over the current listing — no refetch.
   }
 
   const openFile = (entry: DufsEntry) => {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1555,7 +1555,7 @@
         "copiedPath": "Path copied!"
       },
       "placeholders": {
-        "search": "Search files..."
+        "search": "Filter this folder..."
       },
       "states": {
         "dropToUpload": "Drop files to upload",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1580,7 +1580,7 @@
         "copiedPath": "路径已复制"
       },
       "placeholders": {
-        "search": "搜索文件..."
+        "search": "筛选当前目录..."
       },
       "states": {
         "dropToUpload": "拖拽文件到这里以上传",


### PR DESCRIPTION
## Summary

The files panel proxied its search box straight to dufs's `?q=`, which recursively walks the **entire** subtree with two stats per entry — 100s+ on large (~93k-entry) workspaces over NFS — and refired on every keystroke (no debounce).

This implements option 1 from the issue: search now filters the already-fetched current-directory listing client-side. Zero extra requests, instant results, and debounce becomes moot since typing no longer triggers network calls.

## Changes

- `WorkspaceFilesPanel`: drop `searchQuery` from the listing query key / request; filter entries by case-insensitive name substring in a `useMemo`
- Placeholder reworded to "Filter this folder…" / "筛选当前目录…" to match the narrower scope

## Not changed

- `FileMention` (@-mention picker) keeps the recursive backend search — it needs deeply nested paths and already debounces at 150ms. If that path still hurts, option 2 from the issue (dufs `--hidden` pruning of agent-internal dirs) is the follow-up.
- The cp `q` param stays for FileMention and API compat.

## Testing

- `web`: `npx tsc --noEmit` clean

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)