### PR TITLE
fix(wecom): keep streams fresh, fall back to markdown, consume acks

### DIFF
--- a/channel-gateway/src/connectors/wecom-sender.test.ts
+++ b/channel-gateway/src/connectors/wecom-sender.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Connector, Route } from '../services/db'
+import { handleRespondAck, wecomSendStream } from './wecom-sender'
+
+const h = vi.hoisted(() => {
+  const ws = { readyState: 1, send: vi.fn() }
+  return { ws, current: ws as { readyState: number; send: ReturnType<typeof vi.fn> } | undefined }
+})
+
+vi.mock('./wecom', () => ({ getSocket: () => h.current }))
+vi.mock('../services/db', () => ({ logEvent: vi.fn(async () => ({})) }))
+
+const connector = { id: 'conn-1', name: 'test-bot' } as Connector
+const route = { id: 'route-1', external_id: 'chat-1' } as Route
+
+function sentFrames(): any[] {
+  return h.ws.send.mock.calls.map((c) => JSON.parse(c[0] as string))
+}
+
+describe('wecomSendStream', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    h.ws.send.mockClear()
+    h.current = h.ws
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keepalive re-flushes the current snapshot while the stream is silent', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'ka-1' },
+      {
+        content: 'Thinking…',
+        finish: false,
+      },
+    )
+    expect(sentFrames()).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(30_000)
+    const frames = sentFrames()
+    expect(frames).toHaveLength(3)
+    // Same stream id, same content, still unfinished.
+    expect(frames[2].body.stream.id).toBe(frames[0].body.stream.id)
+    expect(frames[2].body.stream).toMatchObject({ content: 'Thinking…', finish: false })
+
+    // Cleanup: finish the stream so no timer leaks into other tests.
+    await wecomSendStream(connector, route, { req_id: 'ka-1' }, { content: 'done', finish: true })
+  })
+
+  it('keepalive stays quiet when the scheduler is actively flushing', async () => {
+    await wecomSendStream(connector, route, { req_id: 'ka-2' }, { content: 'a', finish: false })
+    // Scheduler pushes every 25s — always fresher than the keepalive window.
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(25_000)
+      await wecomSendStream(
+        connector,
+        route,
+        { req_id: 'ka-2' },
+        {
+          content: `a${i}`,
+          finish: false,
+        },
+      )
+    }
+    const streamFrames = sentFrames().filter((f) => f.body.msgtype === 'stream')
+    // 1 initial + 4 scheduler flushes, no keepalive extras in between.
+    expect(streamFrames).toHaveLength(5)
+    await wecomSendStream(connector, route, { req_id: 'ka-2' }, { content: 'done', finish: true })
+  })
+
+  it('normal finish sends a finish frame and stops the keepalive', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'fin-1' },
+      {
+        content: 'Thinking…',
+        finish: false,
+      },
+    )
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'fin-1' },
+      {
+        content: 'final answer',
+        finish: true,
+      },
+    )
+    const frames = sentFrames()
+    expect(frames).toHaveLength(2)
+    expect(frames[1].body.stream).toMatchObject({ content: 'final answer', finish: true })
+
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(sentFrames()).toHaveLength(2) // keepalive is gone
+  })
+
+  it('finish with no open stream falls back to a passive markdown reply', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'restart-1' },
+      {
+        content: 'late reply',
+        finish: true,
+      },
+    )
+    const frames = sentFrames()
+    expect(frames).toHaveLength(1)
+    expect(frames[0].body.msgtype).toBe('markdown')
+    expect(frames[0].body.markdown.content).toBe('late reply')
+    expect(frames[0].headers.req_id).toBe('restart-1')
+  })
+
+  it('finish after a rejected frame delivers the reply as markdown too', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'nack-1' },
+      {
+        content: 'Thinking…',
+        finish: false,
+      },
+    )
+    expect(
+      handleRespondAck({ headers: { req_id: 'nack-1' }, errcode: 95001, errmsg: 'stream expired' }),
+    ).toBe(true)
+
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'nack-1' },
+      {
+        content: 'the answer',
+        finish: true,
+      },
+    )
+    const frames = sentFrames()
+    // placeholder + best-effort stream finish + markdown fallback
+    expect(frames).toHaveLength(3)
+    expect(frames[1].body.msgtype).toBe('stream')
+    expect(frames[1].body.stream.finish).toBe(true)
+    expect(frames[2].body.msgtype).toBe('markdown')
+    expect(frames[2].body.markdown.content).toBe('the answer')
+  })
+
+  it('ok acks do not trigger the fallback', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'ok-1' },
+      {
+        content: 'Thinking…',
+        finish: false,
+      },
+    )
+    expect(handleRespondAck({ headers: { req_id: 'ok-1' }, errcode: 0 })).toBe(true)
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'ok-1' },
+      {
+        content: 'done',
+        finish: true,
+      },
+    )
+    const frames = sentFrames()
+    expect(frames).toHaveLength(2)
+    expect(frames[1].body.msgtype).toBe('stream')
+  })
+
+  it('transport failure mid-job marks the stream broken and falls back on finish', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'broken-1' },
+      {
+        content: 'Thinking…',
+        finish: false,
+      },
+    )
+    // WS drops; the next keepalive tick fails and marks the stream broken.
+    h.current = undefined
+    await vi.advanceTimersByTimeAsync(30_000)
+    h.current = h.ws
+
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'broken-1' },
+      {
+        content: 'recovered reply',
+        finish: true,
+      },
+    )
+    const frames = sentFrames()
+    const last = frames[frames.length - 1]
+    expect(last.body.msgtype).toBe('markdown')
+    expect(last.body.markdown.content).toBe('recovered reply')
+  })
+
+  it('drops stream state past max age; a later finish goes out as markdown', async () => {
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'aged-1' },
+      {
+        content: 'Thinking…',
+        finish: false,
+      },
+    )
+    await vi.advanceTimersByTimeAsync(56 * 60_000)
+    h.ws.send.mockClear()
+
+    // State is gone — keepalive stopped ticking.
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(sentFrames()).toHaveLength(0)
+
+    await wecomSendStream(
+      connector,
+      route,
+      { req_id: 'aged-1' },
+      {
+        content: 'very late reply',
+        finish: true,
+      },
+    )
+    const frames = sentFrames()
+    expect(frames).toHaveLength(1)
+    expect(frames[0].body.msgtype).toBe('markdown')
+  })
+
+  it('handleRespondAck ignores acks for unknown req_ids', () => {
+    expect(handleRespondAck({ headers: { req_id: 'nobody' }, errcode: 0 })).toBe(false)
+    expect(handleRespondAck({ errcode: 0 })).toBe(false)
+  })
+})

--- a/channel-gateway/src/connectors/wecom-sender.ts
+++ b/channel-gateway/src/connectors/wecom-sender.ts
@@ -1,5 +1,6 @@
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 import WebSocket from 'ws'
+import * as db from '../services/db'
 import type { Connector, Route } from '../services/db'
 import { getSocket } from './wecom'
 
@@ -19,14 +20,16 @@ export async function wecomSend(
 
   if (reqId) {
     // Passive reply using the original req_id (1-hour window, single use)
-    ws.send(JSON.stringify({
-      cmd: 'aibot_respond_msg',
-      headers: { req_id: reqId },
-      body: {
-        msgtype: 'markdown',
-        markdown: { content: text },
-      },
-    }))
+    ws.send(
+      JSON.stringify({
+        cmd: 'aibot_respond_msg',
+        headers: { req_id: reqId },
+        body: {
+          msgtype: 'markdown',
+          markdown: { content: text },
+        },
+      }),
+    )
   } else {
     // No req_id available — this would need aibot_subscribe proactive push
     // For now, log a warning
@@ -45,14 +48,36 @@ export async function wecomSend(
 // as "true typewriter" anyway.
 const STREAM_FLUSH_INTERVAL_MS = 2500
 
+// WeCom expires a stream after a freshness window of minutes; frames sent
+// after expiry are silently dropped. While a stream is open, re-flush the
+// current snapshot on this cadence — independent of scheduler pushes — so a
+// long-running job (tool-heavy turns with no visible text) keeps its stream
+// alive until the finish frame. 2 frames/min is well inside the quota above.
+const KEEPALIVE_INTERVAL_MS = 30_000
+
+// The passive-reply req_id itself expires after 1 hour; past that neither
+// stream frames nor markdown replies can be delivered. Stop keepalive and
+// drop the stream state a bit before the hard deadline — a finish arriving
+// later takes the no-state markdown fallback (a last-ditch attempt).
+const STREAM_MAX_AGE_MS = 55 * 60_000
+
 interface StreamState {
   connectorId: string
   connectorName: string
+  routeId: string
   reqId: string
   streamId: string
   content: string
+  openedAt: number
   lastFlushAt: number
   timer: NodeJS.Timeout | null
+  keepalive: NodeJS.Timeout | null
+  framesSent: number
+  acksOk: number
+  acksErr: number
+  lastErr: { errcode: number; errmsg: string } | null
+  /** Set when a flush failed at the transport level (WS down mid-job). */
+  broken: boolean
 }
 
 const streams = new Map<string, StreamState>()
@@ -64,28 +89,104 @@ function newStreamId(): string {
   return `stream_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`
 }
 
+function clearStream(state: StreamState) {
+  if (state.timer) clearTimeout(state.timer)
+  if (state.keepalive) clearInterval(state.keepalive)
+  state.timer = null
+  state.keepalive = null
+  streams.delete(state.reqId)
+}
+
 function flushFrame(state: StreamState, finish: boolean) {
   const ws = getSocket(state.connectorId)
   if (!ws || ws.readyState !== WebSocket.OPEN) {
     throw new Error(`Connector ${state.connectorName}: WebSocket not connected`)
   }
-  ws.send(JSON.stringify({
-    cmd: 'aibot_respond_msg',
-    headers: { req_id: state.reqId },
-    body: {
-      msgtype: 'stream',
-      stream: {
-        id: state.streamId,
-        content: state.content,
-        finish,
+  ws.send(
+    JSON.stringify({
+      cmd: 'aibot_respond_msg',
+      headers: { req_id: state.reqId },
+      body: {
+        msgtype: 'stream',
+        stream: {
+          id: state.streamId,
+          content: state.content,
+          finish,
+        },
       },
-    },
-  }))
+    }),
+  )
+  state.framesSent++
   state.lastFlushAt = Date.now()
   if (state.timer) {
     clearTimeout(state.timer)
     state.timer = null
   }
+}
+
+function startKeepalive(state: StreamState) {
+  state.keepalive = setInterval(() => {
+    if (streams.get(state.reqId) !== state) {
+      // Superseded or finished elsewhere — stop ticking.
+      clearInterval(state.keepalive!)
+      return
+    }
+    if (Date.now() - state.openedAt > STREAM_MAX_AGE_MS) {
+      console.warn(
+        `[WeCom] ${state.connectorName}: stream req=${state.reqId} exceeded max age, dropping state`,
+      )
+      clearStream(state)
+      return
+    }
+    // Only fill silence: a recent scheduler-driven flush already refreshed it.
+    if (Date.now() - state.lastFlushAt < KEEPALIVE_INTERVAL_MS - 1000) return
+    try {
+      flushFrame(state, false)
+    } catch (e) {
+      state.broken = true
+      console.warn(
+        `[WeCom] ${state.connectorName}: keepalive flush failed for req=${state.reqId}:`,
+        e instanceof Error ? e.message : e,
+      )
+    }
+  }, KEEPALIVE_INTERVAL_MS)
+  // Don't hold the process open for keepalives.
+  state.keepalive.unref?.()
+}
+
+/**
+ * Consume a WebSocket response frame for an `aibot_respond_msg` we sent.
+ * WeCom acks every respond with `{headers:{req_id}, errcode, errmsg}`; before
+ * this existed `ws.send` was treated as delivery, so expired-stream drops were
+ * recorded as success. Returns true when the ack matched an open stream.
+ */
+export function handleRespondAck(frame: {
+  headers?: { req_id?: string }
+  errcode?: number
+  errmsg?: string
+}): boolean {
+  const reqId = frame.headers?.req_id
+  if (!reqId) return false
+  const state = streams.get(reqId)
+  if (!state) return false
+  if (frame.errcode === 0) {
+    state.acksOk++
+    return true
+  }
+  state.acksErr++
+  state.lastErr = { errcode: frame.errcode ?? -1, errmsg: frame.errmsg ?? '' }
+  console.error(
+    `[WeCom] ${state.connectorName}: stream frame rejected errcode=${frame.errcode} errmsg=${frame.errmsg} req=${reqId}`,
+  )
+  db.logEvent({
+    route_id: state.routeId,
+    connector_id: state.connectorId,
+    event_type: 'send',
+    payload: { stream: true, req_id: reqId, errcode: frame.errcode },
+    status: 'error',
+    error: frame.errmsg || `errcode=${frame.errcode}`,
+  }).catch(() => {})
+  return true
 }
 
 export async function wecomSendStream(
@@ -102,31 +203,70 @@ export async function wecomSendStream(
   }
 
   let state = streams.get(reqId)
-  if (!state) {
-    state = {
-      connectorId: connector.id,
-      connectorName: connector.name,
-      reqId,
-      streamId: newStreamId(),
-      content: '',
-      lastFlushAt: 0,
-      timer: null,
-    }
-    streams.set(reqId, state)
-  }
-
-  // Scheduler sends cumulative snapshots; replace, never append.
-  state.content = chunk.content
 
   if (chunk.finish) {
+    // No open stream to finish — the gateway restarted mid-job or the stream
+    // aged out. A finish-only frame on a fresh stream id may not render, and
+    // if the old stream expired it would be silently dropped; deliver the
+    // reply as a plain passive markdown message instead.
+    if (!state) {
+      console.warn(
+        `[WeCom] ${connector.name}: finish with no open stream req=${reqId}, sending as markdown`,
+      )
+      await wecomSend(connector, route, chunk.content, replyTo)
+      return
+    }
+    state.content = chunk.content
+    // Frames were rejected or the transport dropped mid-job: assume the
+    // stream is dead. Still fire the finish frame (closes the bubble if the
+    // stream is somehow alive), then deliver the content as a fresh markdown
+    // message so the reply is not lost.
+    if (state.broken || state.acksErr > 0) {
+      console.warn(
+        `[WeCom] ${connector.name}: stream req=${reqId} looks dead (broken=${state.broken} ackErrs=${state.acksErr} lastErr=${JSON.stringify(state.lastErr)}), falling back to markdown`,
+      )
+      try {
+        flushFrame(state, true)
+      } catch {
+        // Best-effort — the markdown fallback below is the real delivery.
+      }
+      clearStream(state)
+      await wecomSend(connector, route, chunk.content, replyTo)
+      return
+    }
     // Final frame must always be sent, regardless of throttle.
     try {
       flushFrame(state, true)
     } finally {
-      streams.delete(reqId)
+      clearStream(state)
     }
     return
   }
+
+  if (!state) {
+    state = {
+      connectorId: connector.id,
+      connectorName: connector.name,
+      routeId: route.id,
+      reqId,
+      streamId: newStreamId(),
+      content: '',
+      openedAt: Date.now(),
+      lastFlushAt: 0,
+      timer: null,
+      keepalive: null,
+      framesSent: 0,
+      acksOk: 0,
+      acksErr: 0,
+      lastErr: null,
+      broken: false,
+    }
+    streams.set(reqId, state)
+    startKeepalive(state)
+  }
+
+  // Scheduler sends cumulative snapshots; replace, never append.
+  state.content = chunk.content
 
   // Non-final: throttle. If we haven't flushed in INTERVAL, flush now;
   // otherwise schedule a trailing flush so the latest content lands.

--- a/channel-gateway/src/connectors/wecom.ts
+++ b/channel-gateway/src/connectors/wecom.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import WebSocket from 'ws'
 import { NapClient } from '../../../internal/client/src/index'
 import * as db from '../services/db'
-import { wecomSend, wecomSendStream } from './wecom-sender'
+import { handleRespondAck, wecomSend, wecomSendStream } from './wecom-sender'
 
 const NAP_API_URL = process.env.NAP_API_URL || 'http://localhost:3000'
 const WS_URL = 'wss://openws.work.weixin.qq.com'
@@ -177,6 +177,20 @@ export async function startOne(connectorId: string) {
           if (pending.kind === 'initial') {
             console.log(`[WeCom] ${connector.name}: subscribed successfully`)
           }
+        }
+        return
+      }
+
+      // Acks for `aibot_respond_msg` share the inbound req_id and carry no
+      // cmd field. Route them to the sender so rejected/dropped frames mark
+      // the stream dead (triggering the markdown fallback on finish) instead
+      // of being fire-and-forget "successes".
+      if (!frame.cmd && reqId && typeof frame.errcode === 'number') {
+        const consumed = handleRespondAck(frame)
+        if (!consumed && frame.errcode !== 0) {
+          console.error(
+            `[WeCom] ${connector.name}: send rejected errcode=${frame.errcode} errmsg=${frame.errmsg} req=${reqId}`,
+          )
         }
         return
       }


### PR DESCRIPTION
## Summary

Long-running jobs (e.g. a 16-minute tool-heavy turn) reliably lost their WeCom reply: the connector claims the bubble with a `Thinking…` stream placeholder, WeCom expires the stream after a freshness window of minutes, and every later frame — including the finish — was silently discarded while fire-and-forget `ws.send` recorded the send as success.

Implements all three parts proposed in the issue.

## Changes (`channel-gateway`)

**Keepalive** — while a stream is open, `wecom-sender` re-flushes the current cumulative snapshot every 30s, but only when the scheduler has been silent (an active streaming route's own flushes count as freshness). 2 frames/min sits well inside the 30/min·1000/hour session quota. Stream state is dropped shortly before the 1-hour passive-reply hard deadline so keepalive timers can't leak on jobs that never send a finish.

**Expiry fallback** — a `finish` that arrives:
- with **no open stream** (gateway restarted mid-job, or state aged out), or
- on a stream **marked dead** (a frame was rejected, or a keepalive flush failed at the transport level)

is delivered as a fresh passive markdown message (`aibot_respond_msg` + markdown) instead of a stream-finish frame that would be silently dropped. In the marked-dead case the finish frame is still fired best-effort first, to close the bubble if the stream happens to be alive.

**Ack handling** — WeCom acks every `aibot_respond_msg` with `{headers:{req_id}, errcode, errmsg}` and no `cmd`. The connector's `onmessage` now routes those to `handleRespondAck`: rejected frames mark the stream dead (feeding the fallback above) and land in the connector event log as `send`/`error` events. Non-stream send rejections get logged too.

## Testing

- New `wecom-sender.test.ts` (9 cases, fake timers + mocked socket): keepalive fires on silence / stays quiet under active streaming, normal finish stops keepalive, no-state finish → markdown, nacked stream → best-effort finish + markdown, ok acks don't trigger fallback, transport failure mid-job → fallback, max-age state drop → later finish as markdown, unknown-req_id acks ignored
- `channel-gateway`: `vitest run` 21 passed, `npx tsc --noEmit` clean, biome clean

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)