### PR TITLE
feat(web): offer goose in the workspace agent-type picker

### DIFF
--- a/internal/ui-sdk/src/tool-renderers/registry.ts
+++ b/internal/ui-sdk/src/tool-renderers/registry.ts
@@ -150,7 +150,6 @@ const agentFallbacks: Record<string, ToolRendererDef> = {
   // so the codex fallback renders them well; other builtins fall through to
   // the default renderer until dedicated goose renderers land.
   goose: codexFallback,
-  'goose-dev': codexFallback,
 }
 
 // ── Public API ──

--- a/web/src/components/workspace/AgentSettingsEditor.tsx
+++ b/web/src/components/workspace/AgentSettingsEditor.tsx
@@ -10,7 +10,7 @@ interface AgentSettingsEditorProps {
 /**
  * Settings dialect per agent core. Explicit switch (not key concatenation) so
  * unknown/dev agent types degrade to no hint instead of leaking a raw i18n
- * key — `goose-dev` is the canary alias of `goose`.
+ * key.
  */
 type SettingsKind = 'claude-code' | 'codex' | 'goose'
 
@@ -21,7 +21,6 @@ function settingsKind(agentType?: string): SettingsKind | null {
     case 'codex':
       return 'codex'
     case 'goose':
-    case 'goose-dev':
       return 'goose'
     default:
       return null

--- a/web/src/components/workspace/ConfigFormFields.tsx
+++ b/web/src/components/workspace/ConfigFormFields.tsx
@@ -66,7 +66,6 @@ function defaultAgentSettings(agentType: string): string {
     // Goose settings are YAML — an empty string means "no extra settings"
     // (a JSON `{}` would be skipped agent-side but reads as the wrong dialect).
     case 'goose':
-    case 'goose-dev':
       return ''
     default:
       return JSON.stringify(AGENT_SETTINGS_DEFAULTS[agentType] ?? {}, null, 2)

--- a/web/src/components/workspace/ModelFields.tsx
+++ b/web/src/components/workspace/ModelFields.tsx
@@ -22,12 +22,15 @@ import {
 const AGENT_TYPES = [
   { value: 'claude-code', label: 'Claude Code' },
   { value: 'codex', label: 'Codex' },
+  { value: 'goose', label: 'Goose' },
 ]
 
 /** Provider types each agent supports — omit to allow all. */
 const AGENT_PROVIDER_TYPES: Record<string, string[] | null> = {
   'claude-code': ['anthropic', 'anthropic-oauth', 'claude-code-oauth'],
   codex: ['openai'],
+  // Dev scope: OpenAI-compatible chat-completions endpoints only.
+  goose: ['openai'],
 }
 
 // Compose a one-line attribution for non-owned providers so the workspace

--- a/web/src/docs/inline-help/agent-config-docs.ts
+++ b/web/src/docs/inline-help/agent-config-docs.ts
@@ -7,9 +7,7 @@ function getSettingsDoc(agentType: string): string {
   switch (agentType) {
     case 'codex':
       return loadDoc('agent-config-settings-codex')
-    // `goose-dev` is the canary alias of `goose` (dev-image rollout pattern).
     case 'goose':
-    case 'goose-dev':
       return loadDoc('agent-config-settings-goose')
     default:
       return loadDoc('agent-config-settings-claude-code')


### PR DESCRIPTION
## Summary

- `ModelFields`: `goose` joins the agent-type dropdown, gated to OpenAI-compatible providers (same scope as the agent's provider env support).
- Retire the `goose-dev` canary alias entries (settings dialect switch, inline docs, YAML default, tool-renderer fallback) — scaffolding from the dev-image test rollout in #114; exact names only now.

## Testing

- `tsc --noEmit` green on web; biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)