### PR TITLE
chore(codex): bump codex-acp to 1.1.2 (codex 0.144, gpt-5.6)

### DIFF
--- a/agents/codex/Dockerfile
+++ b/agents/codex/Dockerfile
@@ -89,7 +89,7 @@ RUN case "$TARGETARCH" in amd64) AB_ARCH=x64 ;; arm64) AB_ARCH=arm64 ;; \
 
 # Install codex-acp globally (pre-install to avoid npx cold start).
 # Upstream rewrite: github.com/agentclientprotocol/codex-acp — a TypeScript ACP
-# server that drives codex over its app-server JSON-RPC protocol (codex 0.142+)
+# server that drives codex over its app-server JSON-RPC protocol (codex 0.144+)
 # and bundles the codex binary through @openai/codex (per-arch native dep, npm
 # resolves the host arch — no TARGETARCH switch needed, no glibc constraint).
 # Replaces the previous Rust-based codex-acp fork: its collab-subagent and
@@ -97,7 +97,7 @@ RUN case "$TARGETARCH" in amd64) AB_ARCH=x64 ;; arm64) AB_ARCH=arm64 ;; \
 # ItemStarted/ItemCompleted lifecycle (collabAgentToolCall / imageGeneration
 # items), so they no longer need to be carried here. bin name `codex-acp`
 # and no-arg stdio-server invocation match the bridge's BRIDGE_OPTS.
-RUN npm install -g --registry=https://registry.npmjs.org @agentclientprotocol/codex-acp@1.0.2
+RUN npm install -g --registry=https://registry.npmjs.org @agentclientprotocol/codex-acp@1.1.2
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Bump the pinned `@agentclientprotocol/codex-acp` in `agents/codex/Dockerfile` from `1.0.2` to `1.1.2`.

## Why

`codex-acp` 1.1.2 bundles `@openai/codex ^0.144.0`. **gpt-5.6** (GA 2026-07-09) requires the codex CLI to be `>= 0.144.0` — the previous pin (`1.0.2` → codex `0.142.4`) does not expose the model at all, regardless of plan/provider.

## Scope

One-line pin change (plus a comment refresh `0.142+` → `0.144+`). No model allow-list to touch — the model name flows through provider/agent_settings dynamically; usage sweeping reads whatever model is in the session meta.

Incremental changes 1.0.2 → 1.1.2 (all non-breaking, codex patch/minor + ACP SDK upgrades):
- 1.1.0 — codex 0.142.5, ACP SDK v1.1, message IDs, goal tracking, Fast-mode boolean config
- 1.1.1 — codex 0.143.0, ACP SDK 1.2.1, MCP elicitation, agent message phases exposed
- 1.1.2 — codex 0.144.0

## Rollout

After merge: in-smtx bumps the submodule pin, then rolls out the codex agent image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)