### PR TITLE
chore(docker): harden image builds against flaky proxy (retries)

### DIFF
--- a/agents/claude-code/Dockerfile
+++ b/agents/claude-code/Dockerfile
@@ -48,7 +48,7 @@ ARG TARGETARCH
 COPY .npmrc /root/.npmrc
 
 # System packages — slowest layer, changes least
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip openssh-client poppler-utils \
     tmux sudo locales vim-tiny sshpass \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
@@ -57,12 +57,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # gogcli (pinned)
-RUN curl -fsSL https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
+RUN curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
     | tar xz -C /usr/local/bin gog
 
 # gh CLI (latest)
-RUN GH_VER=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name|ltrimstr("v")') \
-    && curl -fsSL https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
+RUN GH_VER=$(curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name|ltrimstr("v")') \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
     | tar xz --strip-components=1 -C /usr/local
 
 # uv (latest) — direct GitHub release; astral.sh install.sh hangs on
@@ -70,7 +70,7 @@ RUN GH_VER=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | j
 # the failure, leaving the image without uv.
 RUN case "$TARGETARCH" in amd64) UV_ARCH=x86_64 ;; arm64) UV_ARCH=aarch64 ;; \
         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; esac \
-    && curl -fsSL https://github.com/astral-sh/uv/releases/latest/download/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/astral-sh/uv/releases/latest/download/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz \
     | tar xz --strip-components=1 -C /usr/local/bin \
         uv-${UV_ARCH}-unknown-linux-gnu/uv uv-${UV_ARCH}-unknown-linux-gnu/uvx
 

--- a/agents/codex/Dockerfile
+++ b/agents/codex/Dockerfile
@@ -52,7 +52,7 @@ ARG TARGETARCH
 COPY .npmrc /root/.npmrc
 
 # System packages — slowest layer, changes least
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip openssh-client poppler-utils \
     tmux sudo locales vim-tiny sshpass \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
@@ -61,12 +61,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # gogcli (pinned)
-RUN curl -fsSL https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
+RUN curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
     | tar xz -C /usr/local/bin gog
 
 # gh CLI (latest)
-RUN GH_VER=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name|ltrimstr("v")') \
-    && curl -fsSL https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
+RUN GH_VER=$(curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name|ltrimstr("v")') \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
     | tar xz --strip-components=1 -C /usr/local
 
 # uv (latest) — direct GitHub release; astral.sh install.sh hangs on
@@ -74,7 +74,7 @@ RUN GH_VER=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | j
 # the failure, leaving the image without uv.
 RUN case "$TARGETARCH" in amd64) UV_ARCH=x86_64 ;; arm64) UV_ARCH=aarch64 ;; \
         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; esac \
-    && curl -fsSL https://github.com/astral-sh/uv/releases/latest/download/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/astral-sh/uv/releases/latest/download/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz \
     | tar xz --strip-components=1 -C /usr/local/bin \
         uv-${UV_ARCH}-unknown-linux-gnu/uv uv-${UV_ARCH}-unknown-linux-gnu/uvx
 

--- a/agents/goose/Dockerfile
+++ b/agents/goose/Dockerfile
@@ -52,7 +52,7 @@ ARG TARGETARCH
 COPY .npmrc /root/.npmrc
 
 # System packages — slowest layer, changes least
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip bzip2 openssh-client poppler-utils \
     tmux sudo locales vim-tiny sshpass \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
@@ -61,13 +61,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # gogcli (pinned)
-RUN curl -fsSL https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
+RUN curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
     | tar xz -C /usr/local/bin gog
 
 # gh CLI (latest) — resolve the version from the releases-page redirect
 # instead of api.github.com, whose anonymous rate limit 403s on shared IPs.
-RUN GH_VER=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/cli/cli/releases/latest | sed 's|.*/tag/v||') \
-    && curl -fsSL https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
+RUN GH_VER=$(curl -fsSLI --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{url_effective}' https://github.com/cli/cli/releases/latest | sed 's|.*/tag/v||') \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
     | tar xz --strip-components=1 -C /usr/local
 
 # uv (latest) — direct GitHub release; astral.sh install.sh hangs on
@@ -75,7 +75,7 @@ RUN GH_VER=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/c
 # the failure, leaving the image without uv.
 RUN case "$TARGETARCH" in amd64) UV_ARCH=x86_64 ;; arm64) UV_ARCH=aarch64 ;; \
         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; esac \
-    && curl -fsSL https://github.com/astral-sh/uv/releases/latest/download/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/astral-sh/uv/releases/latest/download/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz \
     | tar xz --strip-components=1 -C /usr/local/bin \
         uv-${UV_ARCH}-unknown-linux-gnu/uv uv-${UV_ARCH}-unknown-linux-gnu/uvx
 
@@ -94,7 +94,7 @@ RUN case "$TARGETARCH" in amd64) AB_ARCH=x64 ;; arm64) AB_ARCH=arm64 ;; \
 # the AAIF org after the Linux Foundation donation).
 RUN case "$TARGETARCH" in amd64) GOOSE_ARCH=x86_64 ;; arm64) GOOSE_ARCH=aarch64 ;; \
         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; esac \
-    && curl -fsSL https://github.com/block/goose/releases/download/v1.41.0/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.bz2 \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/block/goose/releases/download/v1.41.0/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.bz2 \
     | tar xj -C /usr/local/bin ./goose \
     && chmod +x /usr/local/bin/goose \
     && /usr/local/bin/goose --version

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -111,7 +111,7 @@ COPY .npmrc /root/.npmrc
 # ffmpeg is used by the ASR module to transcode incoming audio (webm/opus, amr, ...)
 # to wav 16k mono before handing off to the configured provider.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg \
+  && apt-get install -y --no-install-recommends -o Acquire::Retries=3 ffmpeg \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Problem

Building behind a mihomo proxy (CN), fetches from `github.com` / `deb.debian.org` intermittently fail and kill the whole layer since nothing retried:

- `apt-get install` → `502 Bad Gateway` on individual `.deb` fetches (hit while installing `ffmpeg` in control-plane; ffmpeg's dep tree pulls dozens of packages, so a single 502 aborts the layer)
- `curl` GitHub downloads → aborts mid-stream (`curl: (18) ... stream 1 was not closed cleanly`), seen on the `uv` download

## Fix

- **curl** GitHub downloads (`uv`, `gogcli`, `gh`, `goose`): add `--retry 3 --retry-delay 2 --retry-all-errors` — retries 5xx **and** connection-reset errors. Applied across codex / claude-code / goose.
- **apt-get install**: add `-o Acquire::Retries=3` so a single-package 502 retries instead of failing the layer. Applied across all agents + control-plane.

No version/behavior change — purely build-time resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)