### PR TITLE
feat: add openai-chat provider type for Chat Completions endpoints

### DIFF
--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -82,6 +82,13 @@ function isAnthropicType(pt: string): boolean {
   return pt === 'anthropic' || pt === 'anthropic-oauth' || pt === 'claude-code-oauth'
 }
 
+// Both OpenAI-family types list models the same way (GET /v1/models); they
+// differ only in the chat wire protocol used at runtime and by the test probe:
+// `openai` = Responses API (Codex), `openai-chat` = Chat Completions (goose).
+function isOpenAIType(pt: string): boolean {
+  return pt === 'openai' || pt === 'openai-chat'
+}
+
 // ── GET / ──────────────────────────────────────────────────────────────────
 const listRoute = createRoute({
   method: 'get',
@@ -295,7 +302,7 @@ providers.openapi(listModelsRoute, async (c) => {
       return c.json({ models }, 200)
     }
 
-    if (provider.provider_type === 'openai') {
+    if (isOpenAIType(provider.provider_type)) {
       const baseUrl = (provider.base_url || 'https://api.openai.com').replace(/\/+$/, '')
       const res = await fetch(`${baseUrl}/v1/models`, {
         headers: { Authorization: `Bearer ${provider.api_key}` },
@@ -381,35 +388,44 @@ providers.openapi(testRoute, async (c) => {
           messages: [{ role: 'user', content: 'hi' }],
         }),
       })
-    } else if (effective.provider_type === 'openai') {
+    } else if (isOpenAIType(effective.provider_type)) {
       const baseUrl = (effective.base_url || 'https://api.openai.com').replace(/\/+$/, '')
       const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${effective.api_key}`,
       }
+      const probeChat = () =>
+        fetch(`${baseUrl}/v1/chat/completions`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            model,
+            max_tokens: 1,
+            messages: [{ role: 'user', content: 'hi' }],
+          }),
+        })
 
-      res = await fetch(`${baseUrl}/v1/responses`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          model,
-          input: 'hi',
-          max_output_tokens: 1,
-        }),
-      })
+      if (effective.provider_type === 'openai-chat') {
+        // Chat Completions only — probe the endpoint goose actually uses.
+        res = await probeChat()
+      } else {
+        // `openai` = Responses API; fall back to Chat Completions for gateways
+        // that don't implement /v1/responses.
+        res = await fetch(`${baseUrl}/v1/responses`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            model,
+            input: 'hi',
+            max_output_tokens: 1,
+          }),
+        })
 
-      if (!res.ok) {
-        const text = await res.text().catch(() => '')
-        if (text.includes('Unsupported') || res.status === 404) {
-          res = await fetch(`${baseUrl}/v1/chat/completions`, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({
-              model,
-              max_tokens: 1,
-              messages: [{ role: 'user', content: 'hi' }],
-            }),
-          })
+        if (!res.ok) {
+          const text = await res.text().catch(() => '')
+          if (text.includes('Unsupported') || res.status === 404) {
+            res = await probeChat()
+          }
         }
       }
     } else {

--- a/web/src/components/dialogs/ProviderFormFields.tsx
+++ b/web/src/components/dialogs/ProviderFormFields.tsx
@@ -66,6 +66,11 @@ const PROVIDER_TYPES: Array<{ value: string; labelKey: string; descKey: string }
     labelKey: 'components.createProvider.types.openai.label',
     descKey: 'components.createProvider.types.openai.desc',
   },
+  {
+    value: 'openai-chat',
+    labelKey: 'components.createProvider.types.openaiChat.label',
+    descKey: 'components.createProvider.types.openaiChat.desc',
+  },
 ]
 
 export function ProviderFormFields({ form, setForm, errors, isEditing }: ProviderFormFieldsProps) {

--- a/web/src/components/workspace/ModelFields.tsx
+++ b/web/src/components/workspace/ModelFields.tsx
@@ -28,9 +28,10 @@ const AGENT_TYPES = [
 /** Provider types each agent supports — omit to allow all. */
 const AGENT_PROVIDER_TYPES: Record<string, string[] | null> = {
   'claude-code': ['anthropic', 'anthropic-oauth', 'claude-code-oauth'],
+  // Codex speaks the OpenAI Responses API (wire_api = "responses").
   codex: ['openai'],
-  // Dev scope: OpenAI-compatible chat-completions endpoints only.
-  goose: ['openai'],
+  // Goose speaks the OpenAI Chat Completions API only.
+  goose: ['openai-chat'],
 }
 
 // Compose a one-line attribution for non-owned providers so the workspace

--- a/web/src/docs/inline-help/_load.ts
+++ b/web/src/docs/inline-help/_load.ts
@@ -39,6 +39,7 @@ type InlineDocName =
   | 'provider-anthropic-oauth'
   | 'provider-claude-code-oauth'
   | 'provider-openai'
+  | 'provider-openai-chat'
   | 'route-overview'
   | 'route-slack'
   | 'route-webhook'

--- a/web/src/docs/inline-help/en-US/provider-openai-chat.md
+++ b/web/src/docs/inline-help/en-US/provider-openai-chat.md
@@ -1,11 +1,11 @@
-Connects to the official OpenAI API, Azure OpenAI, or any gateway that implements the OpenAI **Responses API**.
+Connects to the official OpenAI API, Azure OpenAI, or any gateway that implements the OpenAI **Chat Completions API** — the widely supported OpenAI protocol offered by most gateways.
 
 - **Base URL**: `https://api.openai.com` or the endpoint of a compatible service
 - **API Key**: the key for that service
 
 ## Requirements
 
-- The endpoint must implement the **Responses API** (`/v1/responses`) — services that only offer Chat Completions (`/v1/chat/completions`) do **not** work with this type; use **OpenAI Chat Completions** for those
+- The endpoint must implement the **Chat Completions API** (`/v1/chat/completions`) — for endpoints that implement the newer Responses API (`/v1/responses`), use **OpenAI Responses** instead
 
 ## Notes
 

--- a/web/src/docs/inline-help/en-US/provider-openai-chat.md
+++ b/web/src/docs/inline-help/en-US/provider-openai-chat.md
@@ -7,10 +7,6 @@ Connects to the official OpenAI API, Azure OpenAI, or any gateway that implement
 
 - The endpoint must implement the **Chat Completions API** (`/v1/chat/completions`) — for endpoints that implement the newer Responses API (`/v1/responses`), use **OpenAI Responses** instead
 
-## Notes
-
-- OpenRouter free models require the `:free` suffix on the model name, such as `stepfun/step-3.5-flash:free`
-
 ## Visibility
 
 - **Private**: visible only to yourself

--- a/web/src/docs/inline-help/en-US/provider-openai.md
+++ b/web/src/docs/inline-help/en-US/provider-openai.md
@@ -7,10 +7,6 @@ Connects to the official OpenAI API, Azure OpenAI, or any gateway that implement
 
 - The endpoint must implement the **Responses API** (`/v1/responses`) — services that only offer Chat Completions (`/v1/chat/completions`) do **not** work with this type; use **OpenAI Chat Completions** for those
 
-## Notes
-
-- OpenRouter free models require the `:free` suffix on the model name, such as `stepfun/step-3.5-flash:free`
-
 ## Visibility
 
 - **Private**: visible only to yourself

--- a/web/src/docs/inline-help/provider-docs.ts
+++ b/web/src/docs/inline-help/provider-docs.ts
@@ -1,12 +1,19 @@
 import { i18n } from '@/lib/i18n'
 import { loadDoc } from './_load'
 
-type ProviderDocKey = 'openai' | 'anthropic' | 'claude-code-oauth' | 'anthropic-oauth'
+type ProviderDocKey =
+  | 'openai'
+  | 'openai-chat'
+  | 'anthropic'
+  | 'claude-code-oauth'
+  | 'anthropic-oauth'
 
 export function getProviderDoc(type: string): string {
   switch (type as ProviderDocKey) {
     case 'openai':
       return loadDoc('provider-openai')
+    case 'openai-chat':
+      return loadDoc('provider-openai-chat')
     case 'anthropic':
       return loadDoc('provider-anthropic')
     case 'claude-code-oauth':

--- a/web/src/docs/inline-help/zh-CN/provider-openai-chat.md
+++ b/web/src/docs/inline-help/zh-CN/provider-openai-chat.md
@@ -7,10 +7,6 @@
 
 - 服务端必须实现 **Chat Completions API**（`/v1/chat/completions`）—— 若服务端实现的是更新的 Responses API（`/v1/responses`），请改用 **OpenAI Responses**
 
-## 注意事项
-
-- OpenRouter 免费模型需在模型名后加 `:free` 后缀，如 `stepfun/step-3.5-flash:free`
-
 ## Visibility
 
 - **Private**: 仅自己可见

--- a/web/src/docs/inline-help/zh-CN/provider-openai-chat.md
+++ b/web/src/docs/inline-help/zh-CN/provider-openai-chat.md
@@ -1,11 +1,11 @@
-接入 OpenAI 官方 API、Azure OpenAI，或任意实现了 OpenAI **Responses API** 的网关。
+接入 OpenAI 官方 API、Azure OpenAI，或任意实现了 OpenAI **Chat Completions API** 的网关 —— 这是大多数网关都支持的通用 OpenAI 协议。
 
 - **Base URL**: `https://api.openai.com` 或兼容服务的端点
 - **API Key**: 对应服务的 API Key
 
 ## 要求
 
-- 服务端必须实现 **Responses API**（`/v1/responses`）—— 只提供 Chat Completions（`/v1/chat/completions`）的服务**不能用**此类型，请改用 **OpenAI Chat Completions**
+- 服务端必须实现 **Chat Completions API**（`/v1/chat/completions`）—— 若服务端实现的是更新的 Responses API（`/v1/responses`），请改用 **OpenAI Responses**
 
 ## 注意事项
 

--- a/web/src/docs/inline-help/zh-CN/provider-openai.md
+++ b/web/src/docs/inline-help/zh-CN/provider-openai.md
@@ -7,10 +7,6 @@
 
 - 服务端必须实现 **Responses API**（`/v1/responses`）—— 只提供 Chat Completions（`/v1/chat/completions`）的服务**不能用**此类型，请改用 **OpenAI Chat Completions**
 
-## 注意事项
-
-- OpenRouter 免费模型需在模型名后加 `:free` 后缀，如 `stepfun/step-3.5-flash:free`
-
 ## Visibility
 
 - **Private**: 仅自己可见

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2017,8 +2017,12 @@
           "desc": "Personal Claude Pro / Team subscription — token via claude setup-token"
         },
         "openai": {
-          "label": "OpenAI compatible",
-          "desc": "For Codex — endpoint must support the OpenAI Responses API"
+          "label": "OpenAI Responses",
+          "desc": "Endpoint must support the OpenAI Responses API (/v1/responses)"
+        },
+        "openaiChat": {
+          "label": "OpenAI Chat Completions",
+          "desc": "Endpoint must support the OpenAI Chat Completions API (/v1/chat/completions)"
         }
       },
       "actions": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2042,8 +2042,12 @@
           "desc": "个人 Claude Pro / Team 订阅 —— claude setup-token 获取 token"
         },
         "openai": {
-          "label": "OpenAI 兼容",
-          "desc": "Codex 专用 —— 服务端必须支持 OpenAI Responses API"
+          "label": "OpenAI Responses",
+          "desc": "服务端必须支持 OpenAI Responses API（/v1/responses）"
+        },
+        "openaiChat": {
+          "label": "OpenAI Chat Completions",
+          "desc": "服务端必须支持 OpenAI Chat Completions API（/v1/chat/completions）"
         }
       },
       "actions": {


### PR DESCRIPTION
## Why

The existing `openai` provider type targets the OpenAI **Responses API** (`/v1/responses`), which the **Codex** core speaks. The **goose** core speaks the OpenAI **Chat Completions API** (`/v1/chat/completions`) instead. A single generic `openai` type conflated two incompatible wire protocols — a Chat-Completions-only gateway would pass validation for goose yet a Responses-only endpoint would silently fail, and vice versa.

## What

Add a distinct **`openai-chat`** provider type for Chat Completions endpoints. The existing `openai` value keeps its meaning (Responses), so **no data migration** is required.

- **web**
  - Add `openai-chat` to the provider create form (`ProviderFormFields.tsx`)
  - Agent→provider allowlist (`ModelFields.tsx`): `goose → ['openai-chat']`, `codex → ['openai']`
  - Inline-help docs (en/zh) for both types, describing each protocol **on its own terms** (no agent-core binding); relabel dropdown to "OpenAI Responses" / "OpenAI Chat Completions"
- **control-plane** (`routes/providers.ts`)
  - `isOpenAIType()` helper covers both types for model listing (shared `GET /v1/models`)
  - Test probe hits `/v1/chat/completions` directly for `openai-chat`; keeps Responses-first (with chat fallback) for `openai`
- **cores**: no change — `applyProviderEnv` in codex/goose never branched on `provider_type` (goose always sets `GOOSE_PROVIDER=openai` + Chat Completions); the gating lives entirely in the UI allowlist + control-plane recognition

## Migration note

`AGENT_PROVIDER_TYPES` is exclusive: an existing **goose** workspace that had an `openai`-typed provider selected will have that selection auto-cleared on load (allowlist no longer includes `openai`) and must pick an `openai-chat` provider instead.

## Verification

`tsc --noEmit` passes for both `web` and `control-plane`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)