### PR TITLE
fix(self-host): set CG_URL from APP_PREFIX

### DIFF
--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -122,6 +122,11 @@ spec:
               value: "http://${APP_PREFIX}-cp:3000"
             - name: SKILLS_CONTENT_URL
               value: "http://${APP_PREFIX}-skills:3008"
+            # Reverse-proxy target for /_cg/* (cg-proxy). Without it the code
+            # falls back to http://nap-cg:3002, which only resolves when
+            # APP_PREFIX is "nap", so /_cg/connectors 502s on other installs.
+            - name: CG_URL
+              value: "http://${APP_PREFIX}-cg:3002"
             - name: AFS_ENABLED
               value: "true"
             - name: AFS_IMAGE


### PR DESCRIPTION
## Problem

control-plane's `cg-proxy` reverse-proxies `/_cg/*` to `CG_URL`, defaulting to `http://nap-cg:3002` when unset. The self-host `control-plane.yaml` manifest templates every other platform service URL by `${APP_PREFIX}` but never set `CG_URL`, so on any install where `APP_PREFIX != "nap"` (e.g. `tos`) the fallback points at a non-existent `nap-cg` service → `fetch` fails → `/_cg/connectors` returns 502.

This is the third `nap-*` fallback the manifest failed to override; #1312f0b fixed `CP_SERVICE_URL` and `SKILLS_CONTENT_URL` but its "only two missing" claim missed `CG_URL`.

## Fix

Set `CG_URL` from `${APP_PREFIX}` in the self-host control-plane manifest, matching the existing pattern.

```yaml
- name: CG_URL
  value: "http://${APP_PREFIX}-cg:3002"
```

## Impact

Hit by a self-hosted `tos`-prefix customer (502 on `/_cg/connectors`). Immediate mitigation for existing installs: `kubectl set env deployment/<prefix>-cp -c control-plane CG_URL=http://<prefix>-cg:3002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)