### PR TITLE
feat(admin): expand admin console with fleet views and lifecycle ops

### DIFF
--- a/control-plane/src/routes/admin/index.ts
+++ b/control-plane/src/routes/admin/index.ts
@@ -4,6 +4,7 @@ import cluster from './cluster'
 import stats from './stats'
 import systemSettings from './system-settings'
 import users from './users'
+import workspaces from './workspaces'
 
 const admin = new Hono<AppEnv>()
 
@@ -19,6 +20,7 @@ admin.use('*', async (c, next) => {
 admin.route('/stats', stats)
 admin.route('/cluster', cluster)
 admin.route('/users', users)
+admin.route('/workspaces', workspaces)
 admin.route('/system-settings', systemSettings)
 
 export default admin

--- a/control-plane/src/routes/admin/stats.ts
+++ b/control-plane/src/routes/admin/stats.ts
@@ -4,23 +4,11 @@ import { pool } from '../../services/db/pool'
 
 const stats = new Hono<AppEnv>()
 
-// Refresh matviews in background, at most once every 10 minutes.
-let lastMatviewRefresh = 0
-function refreshBlockStats() {
-  const now = Date.now()
-  if (now - lastMatviewRefresh < 10 * 60 * 1000) return
-  lastMatviewRefresh = now
-  pool
-    .query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_workspace_stats')
-    .then(() => pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_daily_stats'))
-    .then(() => pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_user_stats'))
-    .then(() => pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_workspace_stats'))
-    .then(() => pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_daily_stats'))
-    .catch((e) => console.error('[Admin] matview refresh failed:', e))
-}
+// The admin_* matviews these handlers read are refreshed on a cadence by the
+// scheduler's admin-stats-refresh cron (scheduler/src/admin-stats-refresh.ts).
+// Handlers just read the latest snapshot — no on-request refresh here.
 
 stats.get('/totals', async (c) => {
-  refreshBlockStats()
   const result = await pool.query(`
     SELECT
       (SELECT count(*) FROM users WHERE role != 'system')::int AS total_users,
@@ -36,7 +24,6 @@ stats.get('/totals', async (c) => {
 })
 
 stats.get('/trends', async (c) => {
-  refreshBlockStats()
   const result = await pool.query(`
     WITH base AS (
       SELECT
@@ -95,7 +82,6 @@ stats.get('/session-sources', async (c) => {
 })
 
 stats.get('/power-users', async (c) => {
-  refreshBlockStats()
   const result = await pool.query(`
     SELECT
       u.display_name AS name,
@@ -113,7 +99,6 @@ stats.get('/power-users', async (c) => {
 })
 
 stats.get('/power-agents', async (c) => {
-  refreshBlockStats()
   const result = await pool.query(`
     SELECT
       w.name,
@@ -168,15 +153,14 @@ stats.get('/mcp-usage', async (c) => {
 // Served from the admin_token_* matviews (migration 111) instead of the raw
 // workspace_usage_events ledger: the all-time aggregates are full-table scans
 // that grow linearly with the append-only ledger, so reading the pre-rolled-up
-// matviews (refreshed ≤10min via refreshBlockStats, like the other admin
-// blocks) keeps the dashboard cheap as the ledger grows. The user/workspace
+// matviews (refreshed on a cadence by the scheduler's admin-stats-refresh
+// cron) keeps the dashboard cheap as the ledger grows. The user/workspace
 // names are joined live (small PK joins) so the matviews stay name-free.
 const TOKEN_SINCE = "(current_date - interval '29 days')::date"
 const TOKEN_ALL_IN =
   '(s.input_tokens + s.output_tokens + s.cache_read_tokens + s.cache_creation_tokens)'
 
 stats.get('/token-usage', async (c) => {
-  refreshBlockStats()
   const [overview, daily, topUsers, topAgents] = await Promise.all([
     pool.query(`
       SELECT

--- a/control-plane/src/routes/admin/users.ts
+++ b/control-plane/src/routes/admin/users.ts
@@ -1,31 +1,107 @@
 import { hash as argon2Hash } from '@node-rs/argon2'
 import { Hono } from 'hono'
 import type { AppEnv } from '../../lib/types'
+import { pool } from '../../services/db/pool'
 import {
   createUser,
   deleteUser,
   getUser,
   getUserByUsername,
-  listUsers,
   setUserPassword,
 } from '../../services/db/users'
 
 const users = new Hono<AppEnv>()
 
+// Whitelist of sortable columns → SQL expression. Guards against injection:
+// the query param is only ever used as a lookup key here, never interpolated.
+const USER_SORT_COLUMNS: Record<string, string> = {
+  tokens: 'tokens',
+  interactions: 'interactions',
+  agents: 'agent_count',
+  name: 'display_name',
+  created: 'created_at',
+  last_active: 'last_active_at',
+}
+
+// Paginated, sortable, searchable user list with per-user analytics
+// (owned-agent count, lifetime interactions, lifetime tokens, last activity).
+// Interactions/tokens come from the admin_* matviews (refreshed by the
+// scheduler cron); the aggregates are computed independently so joining
+// workspaces × sessions never fans out and double-counts a matview row.
 users.get('/', async (c) => {
-  const list = await listUsers()
-  return c.json(
-    list.map((u) => ({
-      id: u.id,
-      username: u.username,
-      display_name: u.display_name,
-      email: u.email,
-      role: u.role,
-      auth_source: u.password_hash ? ('password' as const) : ('ldap' as const),
-      created_at: u.created_at,
-      last_login_at: u.last_login_at,
-    })),
+  const q = (c.req.query('q') ?? '').trim()
+  const sortCol = USER_SORT_COLUMNS[c.req.query('sort') ?? ''] ?? 'tokens'
+  const order = c.req.query('order') === 'asc' ? 'ASC' : 'DESC'
+  const page = Math.max(1, Number(c.req.query('page')) || 1)
+  const pageSize = Math.min(100, Math.max(1, Number(c.req.query('pageSize')) || 10))
+  const offset = (page - 1) * pageSize
+
+  const params: unknown[] = []
+  let where = "WHERE role != 'system'"
+  if (q) {
+    params.push(`%${q}%`)
+    where += ` AND (username ILIKE $1 OR display_name ILIKE $1 OR coalesce(email, '') ILIKE $1)`
+  }
+
+  const countRes = await pool.query(`SELECT count(*)::int AS total FROM users ${where}`, params)
+  const total = countRes.rows[0].total as number
+
+  const limitIdx = params.length + 1
+  const offsetIdx = params.length + 2
+  const rowsRes = await pool.query(
+    `WITH filtered AS (
+       SELECT id, username, display_name, email, role, password_hash, created_at, last_login_at
+       FROM users ${where}
+     ),
+     ws_agg AS (
+       SELECT w.user_id,
+              count(*)::int AS agent_count,
+              coalesce(sum(ws.interactions), 0)::int AS interactions
+       FROM workspaces w
+       LEFT JOIN admin_workspace_stats ws ON ws.workspace_id = w.id
+       GROUP BY w.user_id
+     ),
+     act AS (
+       SELECT w.user_id, max(s.last_active_at) AS last_active_at
+       FROM workspaces w
+       JOIN sessions s ON s.workspace_id = w.id
+       GROUP BY w.user_id
+     )
+     SELECT f.id, f.username, f.display_name, f.email, f.role,
+            CASE WHEN f.password_hash IS NOT NULL THEN 'password' ELSE 'ldap' END AS auth_source,
+            f.created_at, f.last_login_at,
+            coalesce(wa.agent_count, 0)::int AS agent_count,
+            coalesce(wa.interactions, 0)::int AS interactions,
+            coalesce(tu.input_tokens + tu.output_tokens + tu.cache_read_tokens + tu.cache_creation_tokens, 0)::bigint AS tokens,
+            act.last_active_at
+     FROM filtered f
+     LEFT JOIN ws_agg wa ON wa.user_id = f.id
+     LEFT JOIN act ON act.user_id = f.id
+     LEFT JOIN admin_token_user_stats tu ON tu.user_id = f.id
+     ORDER BY ${sortCol} ${order} NULLS LAST, f.id ASC
+     LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
+    [...params, pageSize, offset],
   )
+
+  return c.json({
+    items: rowsRes.rows.map((r) => ({
+      id: r.id,
+      username: r.username,
+      display_name: r.display_name,
+      email: r.email,
+      role: r.role,
+      auth_source: r.auth_source,
+      created_at: r.created_at,
+      last_login_at: r.last_login_at,
+      agent_count: r.agent_count,
+      interactions: r.interactions,
+      tokens: Number(r.tokens),
+      last_active_at: r.last_active_at,
+    })),
+    total,
+    page,
+    pageSize,
+  })
 })
 
 users.post('/', async (c) => {
@@ -96,10 +172,9 @@ users.delete('/:id', async (c) => {
     return c.json({ error: 'User not found' }, 404)
   }
 
-  if (!user.password_hash) {
-    return c.json({ error: 'Cannot delete LDAP users' }, 400)
-  }
-
+  // LDAP users are deletable too (admin request): removing the local row is a
+  // cleanup — an active LDAP user re-provisions on next login. Password reset
+  // stays password-only (no local secret to set for LDAP), but delete does not.
   await deleteUser(userId)
   return c.json({ success: true })
 })

--- a/control-plane/src/routes/admin/workspaces.ts
+++ b/control-plane/src/routes/admin/workspaces.ts
@@ -1,0 +1,145 @@
+import { Hono } from 'hono'
+import type { AppEnv } from '../../lib/types'
+import { pool } from '../../services/db/pool'
+import { getWorkspace } from '../../services/db/workspaces'
+import { destroyWorkspace, stopWorkspace } from '../../services/workspace-lifecycle'
+
+const workspaces = new Hono<AppEnv>()
+
+// Whitelist of sortable columns → SQL expression. The query param is only ever
+// a lookup key here, never interpolated, so this guards against injection.
+const WS_SORT_COLUMNS: Record<string, string> = {
+  tokens: 'tokens',
+  interactions: 'interactions',
+  last_active: 'last_active_at',
+  created: 'created_at',
+  name: 'name',
+  status: 'status',
+}
+
+const WS_STATUSES = new Set(['running', 'stopped', 'error'])
+
+// Global, paginated, sortable, searchable workspace list across all owners.
+// Read-only fleet view: owner, status, agent type, and usage aggregates
+// (interactions/tokens from the admin_* matviews, last activity from sessions).
+// Deliberately exposes NO session/message content — admin privacy red line.
+workspaces.get('/', async (c) => {
+  const q = (c.req.query('q') ?? '').trim()
+  const status = c.req.query('status') ?? ''
+  const agentType = c.req.query('agentType') ?? ''
+  const ownerId = c.req.query('ownerId') ?? ''
+  const sortCol = WS_SORT_COLUMNS[c.req.query('sort') ?? ''] ?? 'tokens'
+  const order = c.req.query('order') === 'asc' ? 'ASC' : 'DESC'
+  const page = Math.max(1, Number(c.req.query('page')) || 1)
+  const pageSize = Math.min(100, Math.max(1, Number(c.req.query('pageSize')) || 10))
+  const offset = (page - 1) * pageSize
+
+  // Exclude internal/system workspaces from the fleet view.
+  const conds: string[] = ['w.is_system = false']
+  const params: unknown[] = []
+  if (status && WS_STATUSES.has(status)) {
+    params.push(status)
+    conds.push(`w.status = $${params.length}`)
+  }
+  if (agentType) {
+    params.push(agentType)
+    conds.push(`cfg.agent_type = $${params.length}`)
+  }
+  if (ownerId) {
+    params.push(ownerId)
+    conds.push(`w.user_id = $${params.length}`)
+  }
+  if (q) {
+    params.push(`%${q}%`)
+    conds.push(
+      `(w.name ILIKE $${params.length} OR u.display_name ILIKE $${params.length} OR u.username ILIKE $${params.length})`,
+    )
+  }
+  const where = `WHERE ${conds.join(' AND ')}`
+
+  const joins = `
+    FROM workspaces w
+    JOIN users u ON u.id = w.user_id
+    LEFT JOIN workspace_config cfg ON cfg.workspace_id = w.id`
+
+  const countRes = await pool.query(`SELECT count(*)::int AS total ${joins} ${where}`, params)
+  const total = countRes.rows[0].total as number
+
+  const limitIdx = params.length + 1
+  const offsetIdx = params.length + 2
+  const rowsRes = await pool.query(
+    `SELECT w.id, w.name, w.status, w.created_at,
+            w.user_id AS owner_id, u.display_name AS owner, u.username AS owner_username,
+            coalesce(cfg.agent_type, '') AS agent_type,
+            coalesce(ws.interactions, 0)::int AS interactions,
+            coalesce(tw.input_tokens + tw.output_tokens + tw.cache_read_tokens + tw.cache_creation_tokens, 0)::bigint AS tokens,
+            act.last_active_at
+     ${joins}
+     LEFT JOIN admin_workspace_stats ws ON ws.workspace_id = w.id
+     LEFT JOIN admin_token_workspace_stats tw ON tw.workspace_id = w.id
+     LEFT JOIN (
+       SELECT workspace_id, max(last_active_at) AS last_active_at
+       FROM sessions GROUP BY workspace_id
+     ) act ON act.workspace_id = w.id
+     ${where}
+     ORDER BY ${sortCol} ${order} NULLS LAST, w.id ASC
+     LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
+    [...params, pageSize, offset],
+  )
+
+  return c.json({
+    items: rowsRes.rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      status: r.status,
+      owner_id: r.owner_id,
+      owner: r.owner,
+      owner_username: r.owner_username,
+      agent_type: r.agent_type,
+      interactions: r.interactions,
+      tokens: Number(r.tokens),
+      last_active_at: r.last_active_at,
+      created_at: r.created_at,
+    })),
+    total,
+    page,
+    pageSize,
+  })
+})
+
+// Admin stop: reversible scale-down of any workspace (auth is the admin
+// middleware; no ownership check). Shares the exact orchestration the owner
+// stop route uses, so behaviour can't drift.
+workspaces.post('/:id/stop', async (c) => {
+  const id = c.req.param('id')
+  const workspace = await getWorkspace(id)
+  if (!workspace) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+  try {
+    console.log(`[Admin] Stop workspace=${id}`)
+    await stopWorkspace(workspace)
+    return c.json({ success: true })
+  } catch (e) {
+    return c.json({ error: e instanceof Error ? e.message : 'Failed to stop workspace' }, 500)
+  }
+})
+
+// Admin delete: tears down any workspace and its instance via the same shared
+// orchestration as the owner delete route.
+workspaces.delete('/:id', async (c) => {
+  const id = c.req.param('id')
+  const workspace = await getWorkspace(id)
+  if (!workspace) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+  try {
+    console.log(`[Admin] Delete workspace=${id}`)
+    await destroyWorkspace(workspace)
+    return c.json({ success: true })
+  } catch (e) {
+    return c.json({ error: e instanceof Error ? e.message : 'Failed to delete workspace' }, 500)
+  }
+})
+
+export default workspaces

--- a/control-plane/src/routes/workspaces/lifecycle.ts
+++ b/control-plane/src/routes/workspaces/lifecycle.ts
@@ -3,6 +3,7 @@ import type { AppEnv } from '../../lib/types'
 import { resetAllSessionsIdle } from '../../services/db/sessions'
 import { getWorkspace, updateWorkspace } from '../../services/db/workspaces'
 import { bumpWorkspaceSpec, setDesiredPhase } from '../../services/placement'
+import { stopWorkspace } from '../../services/workspace-lifecycle'
 import { reconcileWorkspacePod, startWorkspaceInstance } from '../../services/workspace-reconcile'
 import { canManage, interruptAllSessions } from './_shared'
 
@@ -108,11 +109,7 @@ lifecycle.openapi(stopRoute, async (c) => {
 
   try {
     console.log(`[Stop] Request workspace=${id}`)
-    await interruptAllSessions(workspace, 'Stop')
-    // Control inversion (P1): record desired=stopped; the env-runner scales down.
-    await setDesiredPhase(workspace.id, 'stopped')
-    await resetAllSessionsIdle(id)
-    await updateWorkspace(id, { status: 'stopped' })
+    await stopWorkspace(workspace)
     return c.json({ success: true }, 200)
   } catch (e: any) {
     return c.json({ error: e.message }, 500)

--- a/control-plane/src/routes/workspaces/write.ts
+++ b/control-plane/src/routes/workspaces/write.ts
@@ -5,30 +5,23 @@ import {
   WorkspaceCreateBodySchema,
   WorkspacePatchBodySchema,
 } from '../../../../internal/types/api'
-import * as jobs from '../../lib/jobs'
-import { fireDeleteHooks } from '../../lib/service-hooks'
 import type { AppEnv } from '../../lib/types'
-import { getWorkspaceAddress } from '../../lib/workspace-address'
-import { getWorkspacePlacementEnv } from '../../services/db/environments'
 import { attachStore, createStore } from '../../services/db/memory'
-import { listSchedulesByWorkspace } from '../../services/db/schedules'
-import { listActiveSessionIds } from '../../services/db/sessions'
 import { getTemplateForUser, getTemplateVersion } from '../../services/db/templates'
 import {
   createWorkspace,
-  deleteWorkspace,
   getWorkspace,
   updateWorkspace,
   updateWorkspaceConfig,
 } from '../../services/db/workspaces'
-import * as k8s from '../../services/k8s'
 import { isMemoryFuseAvailable } from '../../services/k8s'
-import { bumpWorkspaceSpec, placeWorkspace, setDesiredPhase } from '../../services/placement'
+import { bumpWorkspaceSpec, placeWorkspace } from '../../services/placement'
 import { chooseEnvironment } from '../../services/placement-decision'
 import { skillRepo } from '../../services/skills-composition'
 import { materializeTemplateLayout } from '../../services/template-layout'
 import { materializeTemplateSchedules } from '../../services/template-schedules'
 import { applyWorkspaceConfigUpdate } from '../../services/workspace-config'
+import { destroyWorkspace } from '../../services/workspace-lifecycle'
 import { canManage, toApiWorkspace } from './_shared'
 
 const write = new OpenAPIHono<AppEnv>()
@@ -316,40 +309,7 @@ write.openapi(deleteRouteDef, async (c) => {
     return c.json({ error: 'Workspace not found' }, 404)
   }
 
-  if (workspace.status === 'running') {
-    const address = getWorkspaceAddress(workspace.id)
-    const sessionIds = await listActiveSessionIds(workspace.id)
-    for (const sid of sessionIds) {
-      try {
-        await fetch(`${address}/sessions/${sid}/interrupt`, { method: 'POST' })
-      } catch (e) {
-        console.error('[Delete] Failed to interrupt session:', e)
-      }
-    }
-  }
-
-  // Unregister pg-boss timers before the schedule rows are CASCADE-deleted with
-  // the workspace — otherwise cron registrations / one-time jobs leak in pg-boss.
-  for (const s of await listSchedulesByWorkspace(id)) {
-    await jobs.cancelScheduleTimer(s).catch(() => {})
-  }
-
-  await fireDeleteHooks(id)
-
-  // Remote environments: cp can't reach the cluster to tear the pod down, and
-  // deleting the row now would CASCADE away the placement before the runner ever
-  // sees desired=deleted (orphan pod). Instead invert: mark desired=deleted and
-  // status=deleting; the runner destroys the pod + removes the placement, then
-  // the env projection reaps the workspace row. Built-in stays synchronous.
-  const placementEnv = await getWorkspacePlacementEnv(id)
-  if (placementEnv && !placementEnv.isBuiltin) {
-    await setDesiredPhase(id, 'deleted')
-    await updateWorkspace(id, { status: 'deleting' })
-    return c.json({ success: true }, 200)
-  }
-
-  await k8s.deleteInstance(workspace.id)
-  await deleteWorkspace(id)
+  await destroyWorkspace(workspace)
   return c.json({ success: true }, 200)
 })
 

--- a/control-plane/src/services/db/users.ts
+++ b/control-plane/src/services/db/users.ts
@@ -35,13 +35,6 @@ export async function getUserByUsername(username: string): Promise<User | null> 
   return (rows[0] as User) ?? null
 }
 
-export async function listUsers(): Promise<User[]> {
-  const { rows } = await pool.query(
-    "SELECT * FROM users WHERE role != 'system' ORDER BY created_at DESC",
-  )
-  return rows as User[]
-}
-
 export async function createUser(
   username: string,
   displayName: string,

--- a/control-plane/src/services/workspace-lifecycle.ts
+++ b/control-plane/src/services/workspace-lifecycle.ts
@@ -1,0 +1,60 @@
+import * as jobs from '../lib/jobs'
+import { fireDeleteHooks } from '../lib/service-hooks'
+import { interruptAllSessions } from '../routes/workspaces/_shared'
+import { getWorkspacePlacementEnv } from './db/environments'
+import { listSchedulesByWorkspace } from './db/schedules'
+import { resetAllSessionsIdle } from './db/sessions'
+import type { Workspace } from './db/types'
+import { deleteWorkspace, updateWorkspace } from './db/workspaces'
+import * as k8s from './k8s'
+import { setDesiredPhase } from './placement'
+
+/**
+ * Stop a workspace: interrupt active sessions, record desired=stopped (the
+ * env-runner scales the deployment down), reset session idle state, and mark
+ * the row stopped. Reversible — the workspace auto-starts on next chat/trigger.
+ *
+ * Shared by the owner stop route and the admin fleet view — the only difference
+ * between them is the authorization check the caller performs first.
+ */
+export async function stopWorkspace(workspace: Workspace): Promise<void> {
+  await interruptAllSessions(workspace, 'Stop')
+  await setDesiredPhase(workspace.id, 'stopped')
+  await resetAllSessionsIdle(workspace.id)
+  await updateWorkspace(workspace.id, { status: 'stopped' })
+}
+
+/**
+ * Delete a workspace and tear down its instance. Interrupts running sessions,
+ * unregisters pg-boss schedule timers before the CASCADE removes the rows
+ * (otherwise cron registrations / one-time jobs leak in pg-boss), and fires the
+ * delete hooks.
+ *
+ * Remote (non-builtin) environments invert control: cp can't reach the cluster
+ * to tear the pod down, and deleting the row now would CASCADE away the
+ * placement before the runner sees desired=deleted (orphan pod). So mark
+ * desired=deleted + status=deleting and let the runner reap the row via env
+ * projection. Built-in environments delete the k8s instance and the row
+ * synchronously.
+ *
+ * Shared by the owner delete route and the admin fleet view.
+ */
+export async function destroyWorkspace(workspace: Workspace): Promise<void> {
+  await interruptAllSessions(workspace, 'Delete')
+
+  for (const s of await listSchedulesByWorkspace(workspace.id)) {
+    await jobs.cancelScheduleTimer(s).catch(() => {})
+  }
+
+  await fireDeleteHooks(workspace.id)
+
+  const placementEnv = await getWorkspacePlacementEnv(workspace.id)
+  if (placementEnv && !placementEnv.isBuiltin) {
+    await setDesiredPhase(workspace.id, 'deleted')
+    await updateWorkspace(workspace.id, { status: 'deleting' })
+    return
+  }
+
+  await k8s.deleteInstance(workspace.id)
+  await deleteWorkspace(workspace.id)
+}

--- a/scheduler/src/admin-stats-refresh.ts
+++ b/scheduler/src/admin-stats-refresh.ts
@@ -1,0 +1,66 @@
+/**
+ * Admin dashboard stats refresh worker.
+ *
+ * The admin dashboard reads from a handful of materialized views (interaction
+ * and token aggregates). Control-plane refreshes them lazily on request, but
+ * throttled to at most once per 10 minutes per cp process and fire-and-forget —
+ * so with no admin traffic the views can drift arbitrarily stale, and the
+ * request that triggers a refresh still sees the pre-refresh data.
+ *
+ * This worker makes the refresh unconditional: a pg-boss cron fires once per
+ * tick cluster-wide (the pgboss clock holds a singleton lock), so exactly one
+ * scheduler instance refreshes each tick — no per-replica fan-out. The queue's
+ * 'stately' policy drops a tick whose predecessor is still running, so a slow
+ * refresh never stacks. The cp on-demand path stays as-is; the two coexist.
+ *
+ * DISABLE_ADMIN_STATS_REFRESH=1 is a hard kill-switch that also unschedules any
+ * previously-registered cron.
+ */
+import type { PgBoss } from 'pg-boss'
+import { refreshAdminMatviews } from './db'
+
+const QUEUE_NAME = 'admin-stats-refresh'
+
+// Env-overridable so the cadence can be tuned without a rebuild. pg-boss cron
+// granularity is 1 minute (sub-minute is not honored by its clock). Default
+// every 10 minutes, matching cp's on-demand throttle window.
+const REFRESH_CRON = process.env.ADMIN_STATS_REFRESH_CRON || '*/10 * * * *'
+
+export async function registerAdminStatsRefreshWorker(boss: PgBoss): Promise<void> {
+  if (process.env.DISABLE_ADMIN_STATS_REFRESH === '1') {
+    // Kill-switch: stop the cron from firing if it was registered by a prior boot.
+    await boss.unschedule(QUEUE_NAME).catch(() => {})
+    console.log('[AdminStatsRefresh] Disabled (DISABLE_ADMIN_STATS_REFRESH=1)')
+    return
+  }
+
+  const queueOptions = {
+    // 'stately': at most one job in created OR active at a time. While a refresh
+    // is queued or running, the next cron tick's send is dropped rather than
+    // piling up — no backlog of redundant refresh jobs.
+    policy: 'stately' as const,
+    // A failed or skipped refresh just waits for the next tick; no retry needed.
+    retryLimit: 0,
+    // REFRESH CONCURRENTLY on all views should finish well within this; the
+    // backstop only matters if a refresh wedges.
+    expireInSeconds: 5 * 60,
+    retentionSeconds: 24 * 3600,
+  }
+  // createQueue no-ops on an existing queue, so updateQueue applies config
+  // changes (e.g. the policy) to a queue created by a prior boot.
+  await boss.createQueue(QUEUE_NAME, queueOptions).catch(() => {})
+  await boss.updateQueue(QUEUE_NAME, queueOptions).catch(() => {})
+
+  // Idempotent upsert keyed by queue name; re-registering on each boot is safe.
+  await boss.schedule(QUEUE_NAME, REFRESH_CRON)
+
+  await boss.work(QUEUE_NAME, async () => {
+    try {
+      await refreshAdminMatviews()
+    } catch (e) {
+      console.error('[AdminStatsRefresh] refresh failed:', e instanceof Error ? e.message : e)
+    }
+  })
+
+  console.log(`[AdminStatsRefresh] Worker registered (cron ${REFRESH_CRON})`)
+}

--- a/scheduler/src/db.ts
+++ b/scheduler/src/db.ts
@@ -320,6 +320,27 @@ export async function cleanupOldThreadSessions(olderThanDays = 7): Promise<numbe
   return rowCount ?? 0
 }
 
+// --- Admin Stats Matviews ---
+
+/**
+ * Refresh the admin dashboard's materialized views. Mirrors the set that
+ * control-plane refreshes on-demand in routes/admin/stats.ts — keep the two
+ * lists in sync when a matview is added or removed.
+ *
+ * CONCURRENTLY keeps the dashboard readable during the refresh (no exclusive
+ * lock on the matview) and cannot run inside a transaction — so these go one
+ * per query on the pool, never wrapped in BEGIN/COMMIT. Sequential on purpose:
+ * the token matviews are cheap relative to the base ones and ordering keeps the
+ * lock footprint predictable.
+ */
+export async function refreshAdminMatviews(): Promise<void> {
+  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_workspace_stats')
+  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_daily_stats')
+  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_user_stats')
+  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_workspace_stats')
+  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_daily_stats')
+}
+
 // --- Session Title Generation ---
 
 /** Read the system-level title-gen config from the single system_settings row. */

--- a/scheduler/src/index.ts
+++ b/scheduler/src/index.ts
@@ -1,4 +1,5 @@
 import { type JobWithMetadata, PgBoss } from 'pg-boss'
+import { registerAdminStatsRefreshWorker } from './admin-stats-refresh'
 import {
   cleanupOldEventLogs,
   cleanupOldThreadSessions,
@@ -110,6 +111,9 @@ await registerSkillReloadWorker(boss)
 
 // Register the session title-generation cron worker.
 await registerTitleGenWorker(boss)
+
+// Register the admin dashboard stats-refresh cron worker.
+await registerAdminStatsRefreshWorker(boss)
 
 console.log('[Scheduler] Worker registered, waiting for jobs...')
 

--- a/web/src/components/admin/AdminPanel.tsx
+++ b/web/src/components/admin/AdminPanel.tsx
@@ -3,12 +3,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useInstancePersistentState } from '@/stores/instance-state-store'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
-import { DashboardSection } from './DashboardSection'
-import { InfraSection } from './InfraSection'
-import { SystemSettingsSection } from './SystemSettingsSection'
-import { UsersSection } from './UsersSection'
-
-type Section = 'dashboard' | 'users' | 'infra' | 'system'
+import { ADMIN_SECTIONS, DEFAULT_ADMIN_SECTION } from './registry'
 
 interface AdminPanelProps {
   instanceId: string
@@ -16,44 +11,35 @@ interface AdminPanelProps {
 
 export function AdminPanel({ instanceId }: AdminPanelProps) {
   const { t } = useTranslation()
-  const [section, setSection] = useInstancePersistentState<Section>(
+  const [section, setSection] = useInstancePersistentState<string>(
     instanceId,
     'adminSection',
-    () => 'dashboard',
+    () => DEFAULT_ADMIN_SECTION,
   )
   const headerSlot = useAppHeaderSlot()
+
+  // Fall back to the first section if the persisted id no longer exists
+  // (section removed or renamed between releases).
+  const active = ADMIN_SECTIONS.find((s) => s.id === section) ?? ADMIN_SECTIONS[0]
+  const ActiveComponent = active.Component
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {headerSlot &&
         createPortal(
-          <Tabs
-            value={section}
-            onValueChange={(v) => setSection(v as Section)}
-            className="shrink-0"
-          >
+          <Tabs value={active.id} onValueChange={setSection} className="shrink-0">
             <TabsList className="h-7 p-0.5">
-              <TabsTrigger value="dashboard" className="h-6 px-2 text-xs">
-                {t('pages.admin.navigation.dashboard')}
-              </TabsTrigger>
-              <TabsTrigger value="users" className="h-6 px-2 text-xs">
-                {t('pages.admin.navigation.users')}
-              </TabsTrigger>
-              <TabsTrigger value="infra" className="h-6 px-2 text-xs">
-                {t('pages.admin.navigation.infrastructure')}
-              </TabsTrigger>
-              <TabsTrigger value="system" className="h-6 px-2 text-xs">
-                {t('pages.admin.navigation.system')}
-              </TabsTrigger>
+              {ADMIN_SECTIONS.map((s) => (
+                <TabsTrigger key={s.id} value={s.id} className="h-6 px-2 text-xs">
+                  {t(s.labelKey)}
+                </TabsTrigger>
+              ))}
             </TabsList>
           </Tabs>,
           headerSlot,
         )}
       <div className="min-h-0 flex-1 overflow-y-auto p-3">
-        {section === 'dashboard' && <DashboardSection instanceId={instanceId} />}
-        {section === 'users' && <UsersSection instanceId={instanceId} />}
-        {section === 'infra' && <InfraSection instanceId={instanceId} />}
-        {section === 'system' && <SystemSettingsSection instanceId={instanceId} />}
+        <ActiveComponent instanceId={instanceId} />
       </div>
     </div>
   )

--- a/web/src/components/admin/UsersSection.tsx
+++ b/web/src/components/admin/UsersSection.tsx
@@ -1,69 +1,145 @@
 import CreateUserDialog from '@/components/dialogs/CreateUserDialog'
+import DeleteUserDialog from '@/components/dialogs/DeleteUserDialog'
 import ResetPasswordDialog from '@/components/dialogs/ResetPasswordDialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { ConfirmButton } from '@/components/ui/confirm-button'
+import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { api } from '@/lib/api/client'
-import type { AdminUser } from '@/lib/api/types'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { KeyRound, Plus, Trash2 } from 'lucide-react'
-import { useState } from 'react'
+import type { AdminUsersPage, AdminUsersSort } from '@/lib/api/types'
+import { useInstancePersistentState } from '@/stores/instance-state-store'
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  KeyRound,
+  Plus,
+  Search,
+  Trash2,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
+import { formatCompact } from './format'
 
+const PAGE_SIZE = 10
 const adminUsersQueryKey = ['admin-users'] as const
 
-// `instanceId` is reserved for future per-instance UI state (e.g. selection,
-// search) scoped via `useInstancePersistentState`. Currently unused.
-export function UsersSection({ instanceId: _instanceId }: { instanceId: string }) {
+export function UsersSection({ instanceId }: { instanceId: string }) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [resetTarget, setResetTarget] = useState<{ id: string; username: string } | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string
+    username: string
+    displayName: string
+  } | null>(null)
 
-  const { data: users = [], isLoading } = useQuery<AdminUser[]>({
-    queryKey: adminUsersQueryKey,
-    queryFn: () => api.getAdminUsers(),
+  // Sort preference persists across reopening the admin app; default token desc.
+  const [sort, setSort] = useInstancePersistentState<AdminUsersSort>(
+    instanceId,
+    'usersSort',
+    () => 'tokens',
+  )
+  const [order, setOrder] = useInstancePersistentState<'asc' | 'desc'>(
+    instanceId,
+    'usersOrder',
+    () => 'desc',
+  )
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const [q, setQ] = useState('')
+
+  // Debounce the search box, and snap back to page 1 whenever the term settles.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setQ(search.trim())
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  const { data, isLoading, isFetching } = useQuery<AdminUsersPage>({
+    queryKey: [...adminUsersQueryKey, { page, sort, order, q }],
+    queryFn: () => api.getAdminUsers({ page, pageSize: PAGE_SIZE, sort, order, q: q || undefined }),
+    placeholderData: keepPreviousData,
   })
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.deleteAdminUser(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: adminUsersQueryKey })
-    },
-  })
-
-  async function handleDelete(id: string) {
-    try {
-      await deleteMutation.mutateAsync(id)
-      toast.success(t('components.admin.usersSection.toasts.deleted'))
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t('components.admin.usersSection.errors.deleteFailed'),
-      )
+  function handleSort(col: AdminUsersSort) {
+    if (sort === col) {
+      setOrder(order === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSort(col)
+      setOrder('desc')
     }
+    setPage(1)
   }
 
-  const deletingId = deleteMutation.isPending ? (deleteMutation.variables ?? null) : null
+  const items = data?.items ?? []
+  const total = data?.total ?? 0
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE))
 
-  if (isLoading) {
+  function SortHeader({
+    label,
+    col,
+    numeric,
+  }: {
+    label: string
+    col: AdminUsersSort
+    numeric?: boolean
+  }) {
+    const active = sort === col
     return (
-      <div className="flex items-center justify-center py-8">
-        <Spinner />
-      </div>
+      <TableHead className={numeric ? 'text-right' : undefined}>
+        <button
+          type="button"
+          onClick={() => handleSort(col)}
+          className="inline-flex items-center gap-1 text-xs hover:text-foreground"
+        >
+          {label}
+          {active ? (
+            order === 'asc' ? (
+              <ArrowUp className="h-3 w-3" />
+            ) : (
+              <ArrowDown className="h-3 w-3" />
+            )
+          ) : (
+            <ArrowUpDown className="h-3 w-3 opacity-40" />
+          )}
+        </button>
+      </TableHead>
     )
   }
 
   return (
     <>
-      <div className="space-y-3">
-        <div className="flex justify-end">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <div className="relative max-w-xs flex-1">
+            <Search className="-translate-y-1/2 absolute top-1/2 left-2 h-3.5 w-3.5 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t('components.admin.usersSection.search.placeholder')}
+              className="h-7 pl-7 text-xs"
+            />
+          </div>
           <Button
             type="button"
             variant="outline"
             size="sm"
-            className="h-7 gap-1 px-2 text-xs"
+            className="ml-auto h-7 gap-1 px-2 text-xs"
             onClick={() => setShowCreateDialog(true)}
           >
             <Plus className="h-3 w-3" />
@@ -71,68 +147,146 @@ export function UsersSection({ instanceId: _instanceId }: { instanceId: string }
           </Button>
         </div>
 
-        {users.length === 0 ? (
-          <div className="py-6 text-center text-xs text-muted-foreground">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-10">
+            <Spinner />
+          </div>
+        ) : total === 0 ? (
+          <div className="py-10 text-center text-xs text-muted-foreground">
             {t('components.admin.usersSection.empty.noUsers')}
           </div>
         ) : (
-          <div className="space-y-1">
-            {users.map((u) => (
-              <div
-                key={u.id}
-                className="group flex items-center gap-2 rounded-md px-3 py-1.5 hover:bg-muted/50"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-xs font-medium truncate">{u.display_name}</span>
-                    <span className="text-tiny text-muted-foreground">{u.username}</span>
-                    {u.role === 'admin' && (
-                      <Badge variant="outline" className="text-mini px-1 py-0">
-                        {t('components.admin.usersSection.badges.roleAdmin')}
-                      </Badge>
-                    )}
-                    <Badge variant="secondary" className="text-mini px-1 py-0">
-                      {u.auth_source === 'password'
-                        ? t('components.admin.usersSection.badges.authSource.password')
-                        : t('components.admin.usersSection.badges.authSource.ldap')}
-                    </Badge>
-                  </div>
-                  <div className="text-tiny text-muted-foreground">
-                    {u.email && <span>{u.email}</span>}
-                    {u.last_login_at && (
-                      <span className="ml-2">
-                        {t('components.admin.usersSection.fields.lastLogin', {
-                          value: new Date(u.last_login_at).toLocaleDateString(),
-                        })}
-                      </span>
-                    )}
-                  </div>
-                </div>
-                {u.auth_source === 'password' && (
-                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      title={t('components.admin.usersSection.actions.resetPassword')}
-                      onClick={() => setResetTarget({ id: u.id, username: u.username })}
-                    >
-                      <KeyRound className="h-3 w-3" />
-                    </Button>
-                    <ConfirmButton
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0 text-destructive hover:text-destructive"
-                      icon={<Trash2 className="h-3 w-3" />}
-                      tooltip={t('components.admin.usersSection.actions.deleteUser')}
-                      disabled={deletingId === u.id}
-                      onConfirm={() => handleDelete(u.id)}
+          <>
+            <div
+              className={`rounded-md border transition-opacity ${isFetching ? 'opacity-60' : ''}`}
+            >
+              <Table className="text-xs">
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <SortHeader
+                      label={t('components.admin.usersSection.columns.name')}
+                      col="name"
                     />
-                  </div>
-                )}
+                    <SortHeader
+                      label={t('components.admin.usersSection.columns.agents')}
+                      col="agents"
+                      numeric
+                    />
+                    <SortHeader
+                      label={t('components.admin.usersSection.columns.interactions')}
+                      col="interactions"
+                      numeric
+                    />
+                    <SortHeader
+                      label={t('components.admin.usersSection.columns.tokens')}
+                      col="tokens"
+                      numeric
+                    />
+                    <SortHeader
+                      label={t('components.admin.usersSection.columns.lastActive')}
+                      col="last_active"
+                      numeric
+                    />
+                    <TableHead className="w-16" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map((u) => (
+                    <TableRow key={u.id} className="group">
+                      <TableCell>
+                        <div className="flex items-center gap-1.5">
+                          <span className="truncate font-medium">{u.display_name}</span>
+                          <span className="text-mini text-muted-foreground">{u.username}</span>
+                          {u.role === 'admin' && (
+                            <Badge variant="outline" className="px-1 py-0 text-mini">
+                              {t('components.admin.usersSection.badges.roleAdmin')}
+                            </Badge>
+                          )}
+                          {u.auth_source === 'ldap' && (
+                            <Badge variant="secondary" className="px-1 py-0 text-mini">
+                              {t('components.admin.usersSection.badges.authSource.ldap')}
+                            </Badge>
+                          )}
+                        </div>
+                        {u.email && (
+                          <div className="text-mini text-muted-foreground">{u.email}</div>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground tabular-nums">
+                        {u.agent_count.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground tabular-nums">
+                        {u.interactions.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right font-medium tabular-nums">
+                        {formatCompact(u.tokens)}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground tabular-nums">
+                        {u.last_active_at ? new Date(u.last_active_at).toLocaleDateString() : '—'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                          {u.auth_source === 'password' && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 w-6 p-0"
+                              title={t('components.admin.usersSection.actions.resetPassword')}
+                              onClick={() => setResetTarget({ id: u.id, username: u.username })}
+                            >
+                              <KeyRound className="h-3 w-3" />
+                            </Button>
+                          )}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                            title={t('components.admin.usersSection.actions.deleteUser')}
+                            onClick={() =>
+                              setDeleteTarget({
+                                id: u.id,
+                                username: u.username,
+                                displayName: u.display_name,
+                              })
+                            }
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{t('components.admin.usersSection.pagination.total', { count: total })}</span>
+              <div className="flex items-center gap-2">
+                <span className="tabular-nums">
+                  {t('components.admin.usersSection.pagination.page', { page, pageCount })}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  disabled={page >= pageCount}
+                  onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+                >
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </Button>
               </div>
-            ))}
-          </div>
+            </div>
+          </>
         )}
       </div>
 
@@ -152,6 +306,19 @@ export function UsersSection({ instanceId: _instanceId }: { instanceId: string }
           }}
           userId={resetTarget.id}
           username={resetTarget.username}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteUserDialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setDeleteTarget(null)
+          }}
+          userId={deleteTarget.id}
+          username={deleteTarget.username}
+          displayName={deleteTarget.displayName}
+          onDeleted={() => queryClient.invalidateQueries({ queryKey: adminUsersQueryKey })}
         />
       )}
     </>

--- a/web/src/components/admin/WorkspacesSection.tsx
+++ b/web/src/components/admin/WorkspacesSection.tsx
@@ -1,0 +1,430 @@
+import { ConfirmDialog } from '@/components/dialogs/ConfirmDialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { api } from '@/lib/api/client'
+import type { AdminWorkspace, AdminWorkspacesPage, AdminWorkspacesSort } from '@/lib/api/types'
+import { useInstancePersistentState } from '@/stores/instance-state-store'
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  CircleStop,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { formatCompact } from './format'
+
+const PAGE_SIZE = 10
+const STATUSES = ['running', 'stopped', 'error'] as const
+type Status = (typeof STATUSES)[number]
+
+const STATUS_VARIANT: Record<Status, 'success-soft' | 'secondary' | 'destructive-soft'> = {
+  running: 'success-soft',
+  stopped: 'secondary',
+  error: 'destructive-soft',
+}
+
+export function WorkspacesSection({ instanceId }: { instanceId: string }) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [action, setAction] = useState<{ kind: 'stop' | 'delete'; ws: AdminWorkspace } | null>(null)
+
+  const [sort, setSort] = useInstancePersistentState<AdminWorkspacesSort>(
+    instanceId,
+    'workspacesSort',
+    () => 'tokens',
+  )
+  const [order, setOrder] = useInstancePersistentState<'asc' | 'desc'>(
+    instanceId,
+    'workspacesOrder',
+    () => 'desc',
+  )
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const [q, setQ] = useState('')
+  const [status, setStatus] = useState<Status | ''>('')
+  const [agentType, setAgentType] = useState('')
+  const [owner, setOwner] = useState<{ id: string; name: string } | null>(null)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setQ(search.trim())
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  const { data, isLoading, isFetching } = useQuery<AdminWorkspacesPage>({
+    queryKey: ['admin-workspaces', { page, sort, order, q, status, agentType, ownerId: owner?.id }],
+    queryFn: () =>
+      api.getAdminWorkspaces({
+        page,
+        pageSize: PAGE_SIZE,
+        sort,
+        order,
+        q: q || undefined,
+        status: status || undefined,
+        agentType: agentType || undefined,
+        ownerId: owner?.id,
+      }),
+    placeholderData: keepPreviousData,
+  })
+
+  // Agent-type options reuse the dashboard's aggregate; drop the empty bucket.
+  const { data: agentTypes = [] } = useQuery({
+    queryKey: ['admin-agent-types'],
+    queryFn: () => api.getAdminAgentTypes(),
+  })
+  const agentTypeOptions = agentTypes.map((a) => a.agent_type).filter(Boolean)
+
+  function handleSort(col: AdminWorkspacesSort) {
+    if (sort === col) {
+      setOrder(order === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSort(col)
+      setOrder('desc')
+    }
+    setPage(1)
+  }
+
+  function resetPageThen<T>(setter: (v: T) => void) {
+    return (v: T) => {
+      setter(v)
+      setPage(1)
+    }
+  }
+
+  // Runs the pending stop/delete; throws propagate to the dialog's inline error.
+  async function runAction() {
+    if (!action) return
+    const { kind, ws } = action
+    if (kind === 'stop') {
+      await api.stopAdminWorkspace(ws.id)
+      toast.success(t('components.admin.workspacesSection.toasts.stopped', { name: ws.name }))
+    } else {
+      await api.deleteAdminWorkspace(ws.id)
+      toast.success(t('components.admin.workspacesSection.toasts.deleted', { name: ws.name }))
+    }
+    queryClient.invalidateQueries({ queryKey: ['admin-workspaces'] })
+  }
+
+  const items = data?.items ?? []
+  const total = data?.total ?? 0
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  function SortHeader({
+    label,
+    col,
+    numeric,
+  }: {
+    label: string
+    col: AdminWorkspacesSort
+    numeric?: boolean
+  }) {
+    const active = sort === col
+    return (
+      <TableHead className={numeric ? 'text-right' : undefined}>
+        <button
+          type="button"
+          onClick={() => handleSort(col)}
+          className="inline-flex items-center gap-1 text-xs hover:text-foreground"
+        >
+          {label}
+          {active ? (
+            order === 'asc' ? (
+              <ArrowUp className="h-3 w-3" />
+            ) : (
+              <ArrowDown className="h-3 w-3" />
+            )
+          ) : (
+            <ArrowUpDown className="h-3 w-3 opacity-40" />
+          )}
+        </button>
+      </TableHead>
+    )
+  }
+
+  function renderRow(w: AdminWorkspace) {
+    return (
+      <TableRow key={w.id} className="group">
+        <TableCell className="max-w-[16rem]">
+          <span className="block truncate font-medium">{w.name}</span>
+        </TableCell>
+        <TableCell>
+          <button
+            type="button"
+            onClick={() => {
+              setOwner({ id: w.owner_id, name: w.owner })
+              setPage(1)
+            }}
+            className="truncate text-muted-foreground hover:text-foreground hover:underline"
+            title={t('components.admin.workspacesSection.filterByOwner')}
+          >
+            {w.owner}
+          </button>
+        </TableCell>
+        <TableCell>
+          <Badge variant={STATUS_VARIANT[w.status]} className="px-1.5 py-0 text-mini">
+            {t(`components.admin.workspacesSection.status.${w.status}`)}
+          </Badge>
+        </TableCell>
+        <TableCell className="text-muted-foreground">{w.agent_type || '—'}</TableCell>
+        <TableCell className="text-right text-muted-foreground tabular-nums">
+          {w.interactions.toLocaleString()}
+        </TableCell>
+        <TableCell className="text-right font-medium tabular-nums">
+          {formatCompact(w.tokens)}
+        </TableCell>
+        <TableCell className="text-right text-muted-foreground tabular-nums">
+          {w.last_active_at ? new Date(w.last_active_at).toLocaleDateString() : '—'}
+        </TableCell>
+        <TableCell className="text-right text-muted-foreground tabular-nums">
+          {new Date(w.created_at).toLocaleDateString()}
+        </TableCell>
+        <TableCell className="text-right">
+          <div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+            {w.status === 'running' && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0"
+                title={t('components.admin.workspacesSection.actions.stop')}
+                onClick={() => setAction({ kind: 'stop', ws: w })}
+              >
+                <CircleStop className="h-3 w-3" />
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+              title={t('components.admin.workspacesSection.actions.delete')}
+              onClick={() => setAction({ kind: 'delete', ws: w })}
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        </TableCell>
+      </TableRow>
+    )
+  }
+
+  return (
+    <>
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative max-w-xs flex-1">
+            <Search className="-translate-y-1/2 absolute top-1/2 left-2 h-3.5 w-3.5 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t('components.admin.workspacesSection.search.placeholder')}
+              className="h-7 pl-7 text-xs"
+            />
+          </div>
+
+          <Select
+            value={status || 'all'}
+            onValueChange={resetPageThen((v: string) =>
+              setStatus(v === 'all' ? '' : (v as Status)),
+            )}
+          >
+            <SelectTrigger className="h-7 w-28 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">
+                {t('components.admin.workspacesSection.filters.allStatus')}
+              </SelectItem>
+              {STATUSES.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {t(`components.admin.workspacesSection.status.${s}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={agentType || 'all'}
+            onValueChange={resetPageThen((v: string) => setAgentType(v === 'all' ? '' : v))}
+          >
+            <SelectTrigger className="h-7 w-40 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">
+                {t('components.admin.workspacesSection.filters.allAgentTypes')}
+              </SelectItem>
+              {agentTypeOptions.map((a) => (
+                <SelectItem key={a} value={a}>
+                  {a}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {owner && (
+            <Badge variant="outline" className="h-7 gap-1 pr-1 pl-2 text-xs font-normal">
+              {t('components.admin.workspacesSection.ownerChip', { name: owner.name })}
+              <button
+                type="button"
+                onClick={() => {
+                  setOwner(null)
+                  setPage(1)
+                }}
+                className="rounded-sm p-0.5 hover:bg-muted"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-10">
+            <Spinner />
+          </div>
+        ) : total === 0 ? (
+          <div className="py-10 text-center text-xs text-muted-foreground">
+            {t('components.admin.workspacesSection.empty.noWorkspaces')}
+          </div>
+        ) : (
+          <>
+            <div
+              className={`rounded-md border transition-opacity ${isFetching ? 'opacity-60' : ''}`}
+            >
+              <Table className="text-xs">
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <SortHeader
+                      label={t('components.admin.workspacesSection.columns.name')}
+                      col="name"
+                    />
+                    <TableHead>{t('components.admin.workspacesSection.columns.owner')}</TableHead>
+                    <SortHeader
+                      label={t('components.admin.workspacesSection.columns.status')}
+                      col="status"
+                    />
+                    <TableHead>
+                      {t('components.admin.workspacesSection.columns.agentType')}
+                    </TableHead>
+                    <SortHeader
+                      label={t('components.admin.workspacesSection.columns.interactions')}
+                      col="interactions"
+                      numeric
+                    />
+                    <SortHeader
+                      label={t('components.admin.workspacesSection.columns.tokens')}
+                      col="tokens"
+                      numeric
+                    />
+                    <SortHeader
+                      label={t('components.admin.workspacesSection.columns.lastActive')}
+                      col="last_active"
+                      numeric
+                    />
+                    <SortHeader
+                      label={t('components.admin.workspacesSection.columns.created')}
+                      col="created"
+                      numeric
+                    />
+                    <TableHead className="w-16" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>{items.map(renderRow)}</TableBody>
+              </Table>
+            </div>
+
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>
+                {t('components.admin.workspacesSection.pagination.total', { count: total })}
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="tabular-nums">
+                  {t('components.admin.workspacesSection.pagination.page', { page, pageCount })}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  disabled={page >= pageCount}
+                  onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+                >
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {action && (
+        <ConfirmDialog
+          open
+          onOpenChange={(o) => {
+            if (!o) setAction(null)
+          }}
+          title={t(
+            action.kind === 'stop'
+              ? 'components.admin.workspacesSection.stopDialog.title'
+              : 'components.admin.workspacesSection.deleteDialog.title',
+          )}
+          description={t(
+            action.kind === 'stop'
+              ? 'components.admin.workspacesSection.stopDialog.description'
+              : 'components.admin.workspacesSection.deleteDialog.description',
+            { name: action.ws.name },
+          )}
+          confirmLabel={t(
+            action.kind === 'stop'
+              ? 'components.admin.workspacesSection.stopDialog.confirm'
+              : 'components.admin.workspacesSection.deleteDialog.confirm',
+          )}
+          confirmVariant={action.kind === 'delete' ? 'destructive' : 'default'}
+          confirmPhrase={action.kind === 'delete' ? action.ws.name : undefined}
+          confirmPhraseLabel={
+            action.kind === 'delete'
+              ? t('components.admin.workspacesSection.deleteDialog.confirmLabel', {
+                  name: action.ws.name,
+                })
+              : undefined
+          }
+          onConfirm={runAction}
+        />
+      )}
+    </>
+  )
+}

--- a/web/src/components/admin/format.ts
+++ b/web/src/components/admin/format.ts
@@ -1,0 +1,12 @@
+/** Abbreviate large counts (1234567 → 1.2M) to keep numeric columns narrow. */
+export function formatCompact(n: number): string {
+  if (n < 1000) return n.toLocaleString()
+  const units = ['K', 'M', 'B', 'T']
+  let u = -1
+  let v = n
+  while (v >= 1000 && u < units.length - 1) {
+    v /= 1000
+    u++
+  }
+  return `${v.toFixed(v < 10 ? 1 : 0)}${units[u]}`
+}

--- a/web/src/components/admin/registry.ts
+++ b/web/src/components/admin/registry.ts
@@ -1,0 +1,55 @@
+import type { ComponentType } from 'react'
+import { DashboardSection } from './DashboardSection'
+import { InfraSection } from './InfraSection'
+import { SystemSettingsSection } from './SystemSettingsSection'
+import { UsersSection } from './UsersSection'
+import { WorkspacesSection } from './WorkspacesSection'
+
+interface AdminSectionProps {
+  instanceId: string
+}
+
+/**
+ * A tab in the admin console. To add a section, append one entry here — the
+ * AdminPanel derives its tab bar and body from this list, nothing else changes.
+ */
+interface AdminSectionDef {
+  /**
+   * Stable id, persisted in instance state (`adminSection`). Keep it unchanged
+   * across label renames so open tabs don't reset to the default section.
+   */
+  id: string
+  /** i18n key for the tab label. */
+  labelKey: string
+  Component: ComponentType<AdminSectionProps>
+}
+
+export const ADMIN_SECTIONS: AdminSectionDef[] = [
+  {
+    id: 'dashboard',
+    labelKey: 'pages.admin.navigation.dashboard',
+    Component: DashboardSection,
+  },
+  {
+    id: 'users',
+    labelKey: 'pages.admin.navigation.users',
+    Component: UsersSection,
+  },
+  {
+    id: 'workspaces',
+    labelKey: 'pages.admin.navigation.workspaces',
+    Component: WorkspacesSection,
+  },
+  {
+    id: 'infra',
+    labelKey: 'pages.admin.navigation.infrastructure',
+    Component: InfraSection,
+  },
+  {
+    id: 'system',
+    labelKey: 'pages.admin.navigation.system',
+    Component: SystemSettingsSection,
+  },
+]
+
+export const DEFAULT_ADMIN_SECTION = ADMIN_SECTIONS[0].id

--- a/web/src/components/dialogs/ConfirmDialog.tsx
+++ b/web/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,114 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { type ReactNode, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: ReactNode
+  confirmLabel: string
+  confirmVariant?: 'default' | 'destructive'
+  /** When set, the user must type this exact phrase to enable the confirm button. */
+  confirmPhrase?: string
+  /** Label shown above the type-to-confirm input. */
+  confirmPhraseLabel?: string
+  /** The action; may throw to surface an inline error and keep the dialog open. */
+  onConfirm: () => Promise<void> | void
+}
+
+/**
+ * Reusable confirmation dialog. Without `confirmPhrase` it is a plain
+ * confirm/cancel; with it, the confirm button stays disabled until the user
+ * types the phrase (type-to-confirm for destructive actions).
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  confirmVariant = 'default',
+  confirmPhrase,
+  confirmPhraseLabel,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const { t } = useTranslation()
+  const [typed, setTyped] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function close() {
+    setTyped('')
+    setError(null)
+    onOpenChange(false)
+  }
+
+  const phraseOk = !confirmPhrase || typed.trim() === confirmPhrase
+  const canConfirm = phraseOk && !pending
+
+  async function handleConfirm() {
+    if (!canConfirm) return
+    setPending(true)
+    setError(null)
+    try {
+      await onConfirm()
+      close()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) close()
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          {description && <div className="text-xs text-muted-foreground">{description}</div>}
+          {confirmPhrase && (
+            <div className="space-y-1">
+              {confirmPhraseLabel && <Label className="text-xs">{confirmPhraseLabel}</Label>}
+              <Input
+                className="h-8 text-xs focus-visible:ring-inset"
+                value={typed}
+                placeholder={confirmPhrase}
+                autoComplete="off"
+                onChange={(e) => setTyped(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleConfirm()
+                }}
+              />
+            </div>
+          )}
+          {error && <div className="text-xs text-destructive">{error}</div>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={close}>
+            {t('common.cancel')}
+          </Button>
+          <Button variant={confirmVariant} size="sm" disabled={!canConfirm} onClick={handleConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/dialogs/DeleteUserDialog.tsx
+++ b/web/src/components/dialogs/DeleteUserDialog.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { api } from '@/lib/api/client'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+interface DeleteUserDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId: string
+  username: string
+  displayName: string
+  onDeleted: () => void
+}
+
+export default function DeleteUserDialog({
+  open,
+  onOpenChange,
+  userId,
+  username,
+  displayName,
+  onDeleted,
+}: DeleteUserDialogProps) {
+  const { t } = useTranslation()
+  const [confirm, setConfirm] = useState('')
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleClose() {
+    setConfirm('')
+    setError(null)
+    onOpenChange(false)
+  }
+
+  const canDelete = confirm.trim() === username && !isDeleting
+
+  async function handleDelete() {
+    if (!canDelete) return
+    setIsDeleting(true)
+    setError(null)
+    try {
+      await api.deleteAdminUser(userId)
+      toast.success(t('components.admin.deleteUser.toasts.deleted', { username }))
+      onDeleted()
+      handleClose()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : t('components.admin.deleteUser.errors.deleteFailed'),
+      )
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('components.admin.deleteUser.title')}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            {t('components.admin.deleteUser.warning', { displayName, username })}
+          </p>
+          <div className="space-y-1">
+            <Label className="text-xs">
+              {t('components.admin.deleteUser.confirmLabel', { username })}
+            </Label>
+            <Input
+              className="h-8 text-xs focus-visible:ring-inset"
+              value={confirm}
+              placeholder={username}
+              autoComplete="off"
+              onChange={(e) => setConfirm(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleDelete()
+              }}
+            />
+          </div>
+          {error && <div className="text-xs text-destructive">{error}</div>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={handleClose}>
+            {t('common.cancel')}
+          </Button>
+          <Button variant="destructive" size="sm" disabled={!canDelete} onClick={handleDelete}>
+            {t('components.admin.deleteUser.confirmButton')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,0 +1,70 @@
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-x-auto">
+      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  ),
+);
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+));
+TableBody.displayName = "TableBody";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-9 px-3 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("px-3 py-2 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -10,7 +10,10 @@ import type {
   AdminTokenUsage,
   AdminTotals,
   AdminTrend,
-  AdminUser,
+  AdminUsersPage,
+  AdminUsersQuery,
+  AdminWorkspacesPage,
+  AdminWorkspacesQuery,
   AgentInfo,
   ApiActivitySummary,
   ApiAgentRequest,
@@ -2050,8 +2053,15 @@ class ApiClient {
   }
 
   // Admin — User management
-  async getAdminUsers(): Promise<AdminUser[]> {
-    return this.request('/admin/users')
+  async getAdminUsers(params: AdminUsersQuery = {}): Promise<AdminUsersPage> {
+    const qs = new URLSearchParams()
+    if (params.page) qs.set('page', String(params.page))
+    if (params.pageSize) qs.set('pageSize', String(params.pageSize))
+    if (params.sort) qs.set('sort', params.sort)
+    if (params.order) qs.set('order', params.order)
+    if (params.q) qs.set('q', params.q)
+    const query = qs.toString()
+    return this.request(`/admin/users${query ? `?${query}` : ''}`)
   }
   async createAdminUser(data: {
     username: string
@@ -2070,6 +2080,27 @@ class ApiClient {
   }
   async deleteAdminUser(userId: string): Promise<void> {
     return this.request(`/admin/users/${userId}`, { method: 'DELETE' })
+  }
+
+  // Admin — Workspace fleet view
+  async getAdminWorkspaces(params: AdminWorkspacesQuery = {}): Promise<AdminWorkspacesPage> {
+    const qs = new URLSearchParams()
+    if (params.page) qs.set('page', String(params.page))
+    if (params.pageSize) qs.set('pageSize', String(params.pageSize))
+    if (params.sort) qs.set('sort', params.sort)
+    if (params.order) qs.set('order', params.order)
+    if (params.q) qs.set('q', params.q)
+    if (params.status) qs.set('status', params.status)
+    if (params.agentType) qs.set('agentType', params.agentType)
+    if (params.ownerId) qs.set('ownerId', params.ownerId)
+    const query = qs.toString()
+    return this.request(`/admin/workspaces${query ? `?${query}` : ''}`)
+  }
+  async stopAdminWorkspace(id: string): Promise<void> {
+    return this.request(`/admin/workspaces/${id}/stop`, { method: 'POST' })
+  }
+  async deleteAdminWorkspace(id: string): Promise<void> {
+    return this.request(`/admin/workspaces/${id}`, { method: 'DELETE' })
   }
 
   // Sandboxes

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -260,7 +260,7 @@ export interface AdminCluster {
   total_sandboxes: number
 }
 
-export interface AdminUser {
+interface AdminUser {
   id: string
   username: string
   display_name: string
@@ -269,6 +269,77 @@ export interface AdminUser {
   auth_source: 'password' | 'ldap'
   created_at: string
   last_login_at: string | null
+  /** Number of workspaces (agents) owned by this user. */
+  agent_count: number
+  /** Lifetime interaction count across the user's workspaces. */
+  interactions: number
+  /** Lifetime token total across the user's workspaces. */
+  tokens: number
+  /** Most recent session activity across the user's workspaces. */
+  last_active_at: string | null
+}
+
+export type AdminUsersSort =
+  | 'tokens'
+  | 'interactions'
+  | 'agents'
+  | 'name'
+  | 'created'
+  | 'last_active'
+
+export interface AdminUsersQuery {
+  page?: number
+  pageSize?: number
+  sort?: AdminUsersSort
+  order?: 'asc' | 'desc'
+  q?: string
+}
+
+export interface AdminUsersPage {
+  items: AdminUser[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+export interface AdminWorkspace {
+  id: string
+  name: string
+  status: 'running' | 'stopped' | 'error'
+  owner_id: string
+  owner: string
+  owner_username: string
+  agent_type: string
+  interactions: number
+  tokens: number
+  last_active_at: string | null
+  created_at: string
+}
+
+export type AdminWorkspacesSort =
+  | 'tokens'
+  | 'interactions'
+  | 'last_active'
+  | 'created'
+  | 'name'
+  | 'status'
+
+export interface AdminWorkspacesQuery {
+  page?: number
+  pageSize?: number
+  sort?: AdminWorkspacesSort
+  order?: 'asc' | 'desc'
+  q?: string
+  status?: 'running' | 'stopped' | 'error'
+  agentType?: string
+  ownerId?: string
+}
+
+export interface AdminWorkspacesPage {
+  items: AdminWorkspace[]
+  total: number
+  page: number
+  pageSize: number
 }
 
 export interface BrowserSession {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -127,6 +127,7 @@
       "navigation": {
         "dashboard": "Dashboard",
         "users": "Users",
+        "workspaces": "Workspaces",
         "infrastructure": "Infrastructure",
         "system": "System"
       }
@@ -3113,6 +3114,20 @@
           "resetPassword": "Reset password",
           "deleteUser": "Delete user"
         },
+        "search": {
+          "placeholder": "Search users…"
+        },
+        "columns": {
+          "name": "User",
+          "agents": "Agents",
+          "interactions": "Interactions",
+          "tokens": "Tokens",
+          "lastActive": "Last active"
+        },
+        "pagination": {
+          "total": "{{count}} users",
+          "page": "{{page}} / {{pageCount}}"
+        },
         "empty": {
           "noUsers": "No users"
         },
@@ -3132,6 +3147,58 @@
         "errors": {
           "loadFailed": "Failed to load users",
           "deleteFailed": "Failed to delete user"
+        }
+      },
+      "workspacesSection": {
+        "search": {
+          "placeholder": "Search name or owner…"
+        },
+        "filters": {
+          "allStatus": "All status",
+          "allAgentTypes": "All agent types"
+        },
+        "status": {
+          "running": "Running",
+          "stopped": "Stopped",
+          "error": "Error"
+        },
+        "columns": {
+          "name": "Name",
+          "owner": "Owner",
+          "status": "Status",
+          "agentType": "Agent type",
+          "interactions": "Interactions",
+          "tokens": "Tokens",
+          "lastActive": "Last active",
+          "created": "Created"
+        },
+        "ownerChip": "Owner: {{name}}",
+        "filterByOwner": "Filter by this owner",
+        "actions": {
+          "stop": "Stop workspace",
+          "delete": "Delete workspace"
+        },
+        "stopDialog": {
+          "title": "Stop workspace",
+          "description": "Stop \"{{name}}\"? Active sessions are interrupted and the instance scales down. It auto-starts again on the next chat or trigger.",
+          "confirm": "Stop"
+        },
+        "deleteDialog": {
+          "title": "Delete workspace",
+          "description": "This will permanently delete \"{{name}}\" and tear down its instance. This cannot be undone.",
+          "confirmLabel": "Type the workspace name {{name}} to confirm",
+          "confirm": "Delete"
+        },
+        "toasts": {
+          "stopped": "Workspace {{name}} stopped",
+          "deleted": "Workspace {{name}} deleted"
+        },
+        "pagination": {
+          "total": "{{count}} workspaces",
+          "page": "{{page}} / {{pageCount}}"
+        },
+        "empty": {
+          "noWorkspaces": "No workspaces"
         }
       },
       "createUser": {
@@ -3172,6 +3239,18 @@
         "errors": {
           "passwordTooShort": "Password must be at least 6 characters",
           "resetFailed": "Failed to reset password"
+        }
+      },
+      "deleteUser": {
+        "title": "Delete user",
+        "warning": "This will permanently delete {{displayName}} ({{username}}) and their data. This cannot be undone.",
+        "confirmLabel": "Type the username {{username}} to confirm",
+        "confirmButton": "Delete",
+        "toasts": {
+          "deleted": "User {{username}} deleted"
+        },
+        "errors": {
+          "deleteFailed": "Failed to delete user"
         }
       }
     },

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -127,6 +127,7 @@
       "navigation": {
         "dashboard": "仪表盘",
         "users": "用户",
+        "workspaces": "工作空间",
         "infrastructure": "基础设施",
         "system": "系统"
       }
@@ -3137,6 +3138,20 @@
           "resetPassword": "重置密码",
           "deleteUser": "删除用户"
         },
+        "search": {
+          "placeholder": "搜索用户…"
+        },
+        "columns": {
+          "name": "用户",
+          "agents": "Agent 数",
+          "interactions": "交互次数",
+          "tokens": "Token",
+          "lastActive": "最近活跃"
+        },
+        "pagination": {
+          "total": "共 {{count}} 位用户",
+          "page": "{{page}} / {{pageCount}}"
+        },
         "empty": {
           "noUsers": "当前没有用户"
         },
@@ -3156,6 +3171,58 @@
         "errors": {
           "loadFailed": "加载用户失败",
           "deleteFailed": "删除用户失败"
+        }
+      },
+      "workspacesSection": {
+        "search": {
+          "placeholder": "搜索名称或 owner…"
+        },
+        "filters": {
+          "allStatus": "全部状态",
+          "allAgentTypes": "全部 agent 类型"
+        },
+        "status": {
+          "running": "运行中",
+          "stopped": "已停止",
+          "error": "异常"
+        },
+        "columns": {
+          "name": "名称",
+          "owner": "Owner",
+          "status": "状态",
+          "agentType": "Agent 类型",
+          "interactions": "交互次数",
+          "tokens": "Token",
+          "lastActive": "最近活跃",
+          "created": "创建时间"
+        },
+        "ownerChip": "Owner：{{name}}",
+        "filterByOwner": "按该 owner 过滤",
+        "actions": {
+          "stop": "停止工作空间",
+          "delete": "删除工作空间"
+        },
+        "stopDialog": {
+          "title": "停止工作空间",
+          "description": "停止「{{name}}」？活跃会话会被中断，实例缩容。下次对话或触发时会自动重新启动。",
+          "confirm": "停止"
+        },
+        "deleteDialog": {
+          "title": "删除工作空间",
+          "description": "将永久删除「{{name}}」并销毁其实例，此操作不可撤销。",
+          "confirmLabel": "输入工作空间名称 {{name}} 确认",
+          "confirm": "删除"
+        },
+        "toasts": {
+          "stopped": "已停止工作空间 {{name}}",
+          "deleted": "已删除工作空间 {{name}}"
+        },
+        "pagination": {
+          "total": "共 {{count}} 个工作空间",
+          "page": "{{page}} / {{pageCount}}"
+        },
+        "empty": {
+          "noWorkspaces": "暂无工作空间"
         }
       },
       "createUser": {
@@ -3196,6 +3263,18 @@
         "errors": {
           "passwordTooShort": "密码长度至少为 6 位",
           "resetFailed": "重置密码失败"
+        }
+      },
+      "deleteUser": {
+        "title": "删除用户",
+        "warning": "将永久删除 {{displayName}}（{{username}}）及其数据，此操作不可撤销。",
+        "confirmLabel": "输入用户名 {{username}} 确认",
+        "confirmButton": "删除",
+        "toasts": {
+          "deleted": "已删除用户 {{username}}"
+        },
+        "errors": {
+          "deleteFailed": "删除用户失败"
         }
       }
     },


### PR DESCRIPTION
## What

Grows the ad-hoc 4-tab admin panel into a fuller, extensible console. Sections now share one paginated-table foundation.

**Section registry** — `AdminPanel` derives its tabs and body from `ADMIN_SECTIONS`; adding a section is one entry, not a panel edit.

**Dashboard stats refresh → scheduler** — a pg-boss cron (`admin-stats-refresh`) refreshes the dashboard materialized views on a cadence (cluster-wide singleton, overlap-protected). control-plane drops its throttled on-request refresh; `DISABLE_ADMIN_STATS_REFRESH` is the kill-switch.

**Users tab** — paginated / sortable / searchable table with per-user analytics (owned agents, interactions, tokens, last active). Default sort tokens desc. Adds a reusable `ui/table` primitive.

**Workspaces tab (new)** — global fleet view across all owners, with status / owner / agent-type filters. Exposes usage aggregates only — never session or message content.

**User deletion** — LDAP users are now deletable (self-delete guard kept); type-to-confirm dialog for all users.

**Workspace admin stop / delete** — `stopWorkspace` / `destroyWorkspace` extracted into a shared service; the owner stop/delete routes now call the same code so behaviour can't drift. Reusable `ConfirmDialog` supports optional type-to-confirm (simple confirm for stop, type-the-name for delete).

## Blast radius

The owner workspace stop/delete routes were refactored to call the new shared helpers. It's a literal statement-move (behaviour-equivalent), but it touches a critical path — worth a close look at the owner delete/stop flow.

## Testing

- `tsc --noEmit` clean across control-plane, web, scheduler; knip + biome pre-commit clean.
- Backend list/aggregate queries validated read-only against a live DB — confirmed the CTE aggregation does not fan out / double-count.
- Not yet exercised end-to-end in a running app (needs admin auth + destructive ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
