### PR TITLE
fix(control-plane): stop double-appending /v1 in provider probes

### DIFF
--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -303,8 +303,14 @@ providers.openapi(listModelsRoute, async (c) => {
     }
 
     if (isOpenAIType(provider.provider_type)) {
-      const baseUrl = (provider.base_url || 'https://api.openai.com').replace(/\/+$/, '')
-      const res = await fetch(`${baseUrl}/v1/models`, {
+      // base_url is treated as version-complete (already ending in /v1 or the
+      // gateway's equivalent), matching how the agent runtimes consume it —
+      // goose sets OPENAI_BASE_PATH = <base_url path>/chat/completions and codex
+      // passes base_url straight to OPENAI_BASE_URL. So append only the endpoint,
+      // never another /v1; otherwise a base_url like `.../tos-provider/v1` becomes
+      // `.../v1/v1/models` and the gateway rejects it (404, or 401 at its auth layer).
+      const baseUrl = (provider.base_url || 'https://api.openai.com/v1').replace(/\/+$/, '')
+      const res = await fetch(`${baseUrl}/models`, {
         headers: { Authorization: `Bearer ${provider.api_key}` },
       })
       if (!res.ok) return c.json({ models: [], error: `${res.status} ${res.statusText}` }, 200)
@@ -389,13 +395,15 @@ providers.openapi(testRoute, async (c) => {
         }),
       })
     } else if (isOpenAIType(effective.provider_type)) {
-      const baseUrl = (effective.base_url || 'https://api.openai.com').replace(/\/+$/, '')
+      // base_url is version-complete; append only the endpoint (see the
+      // fetch-models handler above for why we must not add another /v1).
+      const baseUrl = (effective.base_url || 'https://api.openai.com/v1').replace(/\/+$/, '')
       const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${effective.api_key}`,
       }
       const probeChat = () =>
-        fetch(`${baseUrl}/v1/chat/completions`, {
+        fetch(`${baseUrl}/chat/completions`, {
           method: 'POST',
           headers,
           body: JSON.stringify({
@@ -410,8 +418,8 @@ providers.openapi(testRoute, async (c) => {
         res = await probeChat()
       } else {
         // `openai` = Responses API; fall back to Chat Completions for gateways
-        // that don't implement /v1/responses.
-        res = await fetch(`${baseUrl}/v1/responses`, {
+        // that don't implement /responses.
+        res = await fetch(`${baseUrl}/responses`, {
           method: 'POST',
           headers,
           body: JSON.stringify({


### PR DESCRIPTION
## Problem

The provider **model-list** and **test-connection** handlers in `control-plane/src/routes/providers.ts` append `/v1/...` to the provider's `base_url`. But the agent runtimes treat `base_url` as already version-complete:

- **goose** sets `OPENAI_BASE_PATH = <base_url path>/chat/completions` (`agents/goose/src/config.ts`)
- **codex** passes `base_url` straight to `OPENAI_BASE_URL`

So for any OpenAI-type provider whose `base_url` already ends in `/v1`, the probe requests `.../v1/v1/...`. Upstreams reject the doubled path — `/v1/v1/models` fails at the auth layer (**401**) and `/v1/v1/chat/completions` **404s** — even though the credential is valid and the agent runs fine. The result: the settings page shows a spurious `401 Unauthorized` on the model list and the test button reports `404`, for a working provider.

This is also inconsistent with the other in-repo OpenAI clients (`internal/titlegen`, ASR), which already treat `base_url` as version-complete and append only the endpoint.

## Fix

Append only the endpoint (`/models`, `/chat/completions`, `/responses`) — never another `/v1` — and default the fallback base to `https://api.openai.com/v1`. A successful probe now matches exactly what the runtime calls.

## Verification

Against a real OpenAI-compatible endpoint whose `base_url` ends in `/v1`, with a valid key:

| probe | before | after |
| --- | --- | --- |
| model list | 401 | **200** |
| test (chat) | 404 | **200** |

`tsc --noEmit` clean; biome/knip pass on pre-commit.