### PR TITLE
fix(memory): treat empty if_match_sha256 as "skip" in move/delete preconditions

### DIFF
--- a/control-plane/src/services/db/memory.ts
+++ b/control-plane/src/services/db/memory.ts
@@ -309,7 +309,11 @@ export async function deleteMemoryByPath(input: {
       await client.query('ROLLBACK')
       return false
     }
-    if (input.ifMatchSha256 !== undefined && input.ifMatchSha256 !== row.content_sha256) {
+    if (
+      input.ifMatchSha256 !== undefined &&
+      input.ifMatchSha256 !== '' &&
+      input.ifMatchSha256 !== row.content_sha256
+    ) {
       throw new PreconditionFailedError(row.content_sha256)
     }
     await client.query('DELETE FROM memories WHERE id = $1', [row.id])
@@ -383,7 +387,11 @@ export async function moveMemory(input: {
       await client.query('ROLLBACK')
       return null
     }
-    if (input.ifMatchSha256 !== undefined && input.ifMatchSha256 !== fromRow.content_sha256) {
+    if (
+      input.ifMatchSha256 !== undefined &&
+      input.ifMatchSha256 !== '' &&
+      input.ifMatchSha256 !== fromRow.content_sha256
+    ) {
       throw new PreconditionFailedError(fromRow.content_sha256)
     }
     if (toRow) {


### PR DESCRIPTION
## Problem

`moveMemory` and `deleteMemoryByPath` only skipped the sha256 precondition when `ifMatchSha256` was `undefined`, not when it was an empty string.

The memory-fuse client passes `""` to mean "no precondition" (matching the `putMemory` convention). As a result, **every rename that overwrites an existing memory** — the write-temp-then-rename atomic-save path used by editors and `apply_patch` — failed with a spurious `PreconditionFailedError`, surfaced to the agent as `EIO` ("Input/output error").

`renameChild` (memory-fuse) calls `MoveMemory(..., overwrite, "")`; the server's `moveMemory` then evaluated `"" !== undefined && "" !== fromRow.content_sha256` → always true for a real row → threw. `deleteMemoryByPath` carried the same latent mismatch (not hit today because the client always passes a real sha on delete).

## Fix

Treat `""` the same as `undefined` (skip the precondition), consistent with `putMemory` (`memory.ts:214/251`) and the client contract.

## Verification

- `tsc --noEmit` clean
- `npm run test:unit` — 207 passed / 12 files, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)