### PR TITLE
fix(providers): normalize base_url /v1 suffix for model list and test probe

### DIFF
--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -303,13 +303,15 @@ providers.openapi(listModelsRoute, async (c) => {
     }
 
     if (isOpenAIType(provider.provider_type)) {
-      // base_url is treated as version-complete (already ending in /v1 or the
-      // gateway's equivalent), matching how the agent runtimes consume it —
-      // goose sets OPENAI_BASE_PATH = <base_url path>/chat/completions and codex
-      // passes base_url straight to OPENAI_BASE_URL. So append only the endpoint,
-      // never another /v1; otherwise a base_url like `.../tos-provider/v1` becomes
-      // `.../v1/v1/models` and the gateway rejects it (404, or 401 at its auth layer).
-      const baseUrl = (provider.base_url || 'https://api.openai.com/v1').replace(/\/+$/, '')
+      // OpenAI model listing lives at `<base>/v1/models`. base_url may or may not
+      // already carry the `/v1` suffix: some gateways are configured version-
+      // complete (`.../tos-provider/v1`), others as a bare host
+      // (`https://proxy.example.com`). Append `/v1` only when it is missing, so
+      // both styles resolve to a single `/v1/models` — never `/models` (which a
+      // proxy serves its SPA index for → HTML → JSON parse error) and never
+      // `/v1/v1/models` (which the gateway 404s).
+      const raw = (provider.base_url || 'https://api.openai.com/v1').replace(/\/+$/, '')
+      const baseUrl = raw.endsWith('/v1') ? raw : `${raw}/v1`
       const res = await fetch(`${baseUrl}/models`, {
         headers: { Authorization: `Bearer ${provider.api_key}` },
       })
@@ -395,9 +397,11 @@ providers.openapi(testRoute, async (c) => {
         }),
       })
     } else if (isOpenAIType(effective.provider_type)) {
-      // base_url is version-complete; append only the endpoint (see the
-      // fetch-models handler above for why we must not add another /v1).
-      const baseUrl = (effective.base_url || 'https://api.openai.com/v1').replace(/\/+$/, '')
+      // Normalise to a single `/v1` suffix regardless of how base_url is stored
+      // (bare host or already version-complete); see the fetch-models handler
+      // above for why both `/models` and `/v1/v1/...` are wrong.
+      const raw = (effective.base_url || 'https://api.openai.com/v1').replace(/\/+$/, '')
+      const baseUrl = raw.endsWith('/v1') ? raw : `${raw}/v1`
       const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${effective.api_key}`,


### PR DESCRIPTION
## Problem

The model-list and test-probe handlers assumed `base_url` was always version-complete (ending in `/v1`) and appended only `/models`, `/chat/completions`, `/responses`.

Providers stored as a bare host (e.g. `https://proxy.example.com`, no `/v1`) then hit `/models`, which such gateways serve their SPA `index.html` for — **HTTP 200 `text/html`**. The web client JSON-parses that and surfaces `Unexpected token '<', "<!doctype "... is not valid JSON`.

This regressed the earlier double-`/v1` fix (`92250b5`): that solved base_urls ending in `/v1` (which became `/v1/v1/models`) but broke the ones that don't.

Verified against a live affected provider:
- `<host>/v1/models` → 200 JSON ✓
- `<host>/models` → 200 `text/html <!doctype` ✗

## Fix

Append `/v1` only when it is missing, so both storage styles resolve to a single `/v1/models` — never `/models`, never `/v1/v1/models`. Applied to the `openai` branch of both the list-models and test-probe handlers.

## Verification

- `tsc --noEmit` clean
- `npm run test:unit` — 207 passed / 12 files
- URL resolution checked for bare host, `/v1`-suffixed, default, and trailing-slash base_urls → all resolve to a single `/v1/models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)