### PR TITLE
fix(codex): set INITIAL_AGENT_MODE=agent-full-access so memory/afs writes work

### DIFF
--- a/agents/codex/src/index.ts
+++ b/agents/codex/src/index.ts
@@ -76,7 +76,19 @@ if (rc) {
 
 // ── ACP bridge factory (1 bridge per session to avoid SQLite contention) ──
 
-const BRIDGE_OPTS = { program: 'codex-acp', args: [] as string[], cwd: WORKSPACE_DIR }
+// codex-acp (1.1.x) picks the sandbox from the INITIAL_AGENT_MODE env var
+// (`read-only` | `agent` | `agent-full-access`) — NOT from config.toml's
+// `sandbox_mode`, which it ignores. Unset, it defaults to `agent` =
+// workspace-write, whose writable roots are only /workspace + /tmp; writes to
+// /mnt/memory and /mnt/afs are then rejected with EROFS at the sandbox layer,
+// before they ever reach the FUSE mount. Force full access so agents can
+// persist memory and exchange files as the platform contract promises.
+const BRIDGE_OPTS = {
+  program: 'codex-acp',
+  args: [] as string[],
+  cwd: WORKSPACE_DIR,
+  env: { INITIAL_AGENT_MODE: 'agent-full-access' },
+}
 
 setBridgeFactory(async () => {
   const b = new AcpBridge(BRIDGE_OPTS)


### PR DESCRIPTION
## Problem

Agents running on codex could not write to `/mnt/memory` (persistent memory) or `/mnt/afs` (file sharing): every write failed with `Read-only file system` (EROFS), the memory-fuse sidecar never saw the request, and pod restarts did not help.

Root cause: **codex-acp 1.1.x selects its sandbox from the `INITIAL_AGENT_MODE` env var** (`read-only` | `agent` | `agent-full-access`), **not** from config.toml's `sandbox_mode` (which it ignores). We never set `INITIAL_AGENT_MODE`, so codex-acp fell back to its default `agent` mode = `workspace-write`, whose writable roots are only `/workspace` and `/tmp`. Writes to `/mnt/memory` and `/mnt/afs` were rejected with EROFS at the sandbox (landlock) layer — before ever reaching the FUSE mount, which is itself writable (verified: an out-of-sandbox `os.open(O_CREAT)` on the same path succeeds).

This regressed when we upgraded to the TypeScript codex-acp / codex 0.144: the previous path honored `config.toml` `sandbox_mode = "danger-full-access"`; the new one keys off `INITIAL_AGENT_MODE`. Fleet-wide, no codex workspace could persist memory since the upgrade.

Evidence: a running session's `turn_context` showed `sandbox_policy: workspace-write` with writable roots `/workspace`, `/tmp`, `$TMPDIR` and root read-only — despite the pod's `config.toml` reading `sandbox_mode = "danger-full-access"`.

## Fix

Inject `INITIAL_AGENT_MODE=agent-full-access` into the codex-acp child env (the bridge merges `{ ...process.env, ...options.env }`), so the sandbox matches the platform's intent (`danger-full-access`).

## Rollout note

Requires rebuilding the codex agent image and restarting existing codex pods (the running codex-acp child inherits env at spawn; only fresh pods pick up the new mode).

## Verification

- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)