### PR TITLE
feat(self-host): air-gapped / offline install support

### DIFF
--- a/docs-site/src/components/self-host/SelfHostShell.tsx
+++ b/docs-site/src/components/self-host/SelfHostShell.tsx
@@ -24,7 +24,7 @@ interface TabDef {
 const STR = {
   en: {
     headEyebrow: 'Neutree Agent Platform — Self-Host',
-    headTag: 'Install the platform on your own Kubernetes cluster, pulling images from public registries',
+    headTag: 'Install the platform on your own Kubernetes cluster — pulling images from a public registry, or fully air-gapped from your own',
     printTitle: 'Print all sections together or export to PDF',
     printBtn: 'Print / Export PDF',
     tocLabel: 'On this page',
@@ -38,7 +38,7 @@ const STR = {
   },
   'zh-CN': {
     headEyebrow: 'Neutree Agent Platform — 私有化部署',
-    headTag: '在你自己的 Kubernetes 集群上安装平台，从公共镜像仓库拉取镜像',
+    headTag: '在你自己的 Kubernetes 集群上安装平台 —— 从公共镜像仓库拉取镜像，或从你自己的私有仓库完全离线部署',
     printTitle: '将所有章节一起打印或导出为 PDF',
     printBtn: '打印 / 导出 PDF',
     tocLabel: '本页目录',
@@ -242,7 +242,7 @@ const PANEL_STR = {
     ovCapH2: 'What one install gives you',
     ovIntro: (
       <>
-        This is the <strong>connected / online</strong> installer: the target cluster must be able to reach the public internet. Images are pulled directly from public registries (<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>) and prerequisite charts/manifests are fetched from their public sources. There is no offline image bundle, no in-cluster registry, and no host image-loading step. For fully air-gapped sites, a separate offline installer ships an image tarball, an in-cluster registry, and a host-prep step.
+        The same <code>./install.sh</code> brings up the platform either way — the only difference is where the images come from. Every node pulls them from a registry it can reach: <strong>connected</strong>, that's a public registry (<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>) or a mirror you point <code>REGISTRY</code> at; <strong>air-gapped</strong>, it's your own private registry, seeded from an image bundle you build on a connected host with <code>offline/save-images.sh</code> and push in with <code>offline/load-images.sh</code>. For a single machine, see the <a href="/self-host/single-node/">single-node profile</a>, which brings up an in-cluster registry so no external one is needed at all.
       </>
     ),
     ovCoreH3: 'Core platform (always installed)',
@@ -265,9 +265,9 @@ const PANEL_STR = {
     ovWorkers: 'Worker nodes',
     ovWorkersReq: '4 vCPU / 8GB RAM minimum',
     ovWorkersNote: 'Agent pods are created per workspace dynamically',
-    ovRegAccess: 'Public registry access',
-    ovRegAccessReq: <>Nodes can pull from <code>ghcr.io</code>, <code>docker.io</code>, <code>registry.k8s.io</code></>,
-    ovRegAccessNote: <>Override <code>REGISTRY</code> only to use a mirror</>,
+    ovRegAccess: 'Container registry',
+    ovRegAccessReq: <>A registry every node can pull from — a public one (connected) or your own private registry (air-gapped)</>,
+    ovRegAccessNote: <>Set <code>REGISTRY</code> to it; fill <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> when it needs a login</>,
     ovRwx: 'RWX shared storage',
     ovRwxReq: 'A CSI that supports ReadWriteMany (NFS is the most common)',
     ovRwxNote: 'Backs the AFS shared directory, 500Gi by default',
@@ -285,7 +285,7 @@ const PANEL_STR = {
     ovStorageReach: 'Storage reachability',
     ovStorageReachReq: 'All nodes can mount the two storage classes above (NFS / block-storage CSI, etc.)',
     ovRegReach: 'Registry reachability',
-    ovRegReachReq: 'All nodes can pull images from the public registries',
+    ovRegReachReq: 'All nodes can pull images from the registry above (a public one, or your private registry)',
     ovLlmH3: 'LLM API',
     ovLlmIntro: 'The platform does not bundle any model. Depending on the agent types you enable, you must provide protocol-compatible API endpoints:',
     ovThAgentType: 'Agent type',
@@ -317,12 +317,16 @@ const PANEL_STR = {
     inToolEnvsubst: <><code>envsubst</code> — usually shipped with the <code>gettext</code> package</>,
     inToolOpenssl: <><code>openssl</code> — used by <code>gen-secrets.sh</code> to generate random secrets</>,
     inToolHelm: <><code>helm</code> 3.x — only needed when the cluster doesn't already have an NFS provisioner; invoked by <code>install.sh</code>'s prerequisites stage</>,
-    inToolsNote: <>The cluster nodes (not the operator machine) must be able to pull from <code>ghcr.io</code>, <code>docker.io</code>, and <code>registry.k8s.io</code>.</>,
+    inToolLoader: <><code>docker</code> or <code>nerdctl</code> — used by <code>offline/load-images.sh</code> to push the image bundle into your registry (air-gapped installs only)</>,
+    inToolsNote: <>The cluster nodes (not the operator machine) must be able to pull from your <code>REGISTRY</code>. Connected, that's a public registry (<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>); air-gapped, it's your own registry and they never touch the internet.</>,
     inQuickH2: 'Quick start',
     inQuickAfter: <>When it finishes, open <code>http://&lt;NAP_HOST&gt;:&lt;NAP_NODE_PORT&gt;</code> and log in with the admin username / password from <code>values.env</code>.</>,
     inStepsH2: 'Step by step',
     inStep1H3: 'Get the installer',
-    inStep1Note: <>All first-party images are pulled from the public registry (<code>${'{'}REGISTRY{'}'}</code>, default <code>ghcr.io/neutree-ai/agent-platform</code>); there is no image tarball to load. Override <code>REGISTRY</code> only if you mirror the images elsewhere.</>,
+    inStep1Note: <>For a connected install, all first-party images are pulled from the public registry (<code>${'{'}REGISTRY{'}'}</code>, default <code>ghcr.io/neutree-ai/agent-platform</code>). Override <code>REGISTRY</code> only if you mirror the images elsewhere.</>,
+    inAirgapLead: 'Air-gapped —',
+    inAirgapBody: <> on a connected host run <code>./offline/save-images.sh</code> to build <code>offline/nap-images.tar.gz</code> plus the prerequisite charts, move it to the air-gapped side, then <code>./offline/load-images.sh --registry &lt;your-registry&gt;</code> loads, retags, and pushes every image into your registry and prints the exact <code>REGISTRY=</code> / <code>*_IMAGE=</code> lines to paste into <code>values.env</code>. Vendor delivered a bundle? Skip <code>save-images</code> and start at <code>load-images</code>.</>,
+    inRegAuthNote: <>If your registry needs a login, set <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> in <code>values.env</code> — the installer builds a <code>regcred</code> imagePullSecret from them automatically and attaches it to the platform, CNPG, and the workspace pods.</>,
     inStep2H3: 'Prepare values.env',
     inStep2GenBtn: 'configuration generator',
     inStep2P1Pre: 'We recommend the',
@@ -336,15 +340,16 @@ const PANEL_STR = {
     inSubH2: 'install.sh subcommands',
     inSubIntro: <>For running stages separately; a single <code>./install.sh</code> is enough for the normal case.</>,
     inSingleH2: 'Single-node profile',
-    inSingleP: <>A single k3s node that pulls every image straight from the public registry — same as the full profile, just with <code>PG_INSTANCES=1</code> and an in-cluster NFS server for RWX storage (a single node has no external NFS). It does not bring up an in-cluster registry and does not load any tarball.</>,
+    inSingleP: <>A single k3s node — same as the full profile, just with <code>PG_INSTANCES=1</code> and an in-cluster NFS server for RWX storage (a single node has no external NFS). <strong>Connected</strong>, it pulls every image from the public registry. <strong>Air-gapped</strong>, it brings up an in-cluster registry and seeds it from the image bundle, so no external registry is needed at all. See the <a href="/self-host/single-node/">single-node page</a> for both paths.</>,
     inSingleNote: <>Run this on a host that has a working k3s with its kubeconfig at <code>/etc/rancher/k3s/k3s.yaml</code> (the default in the single-node example).</>,
-    inOfflineH2: 'Air-gapped sites',
-    inOfflineP: <>This page documents the connected installer. For fully air-gapped / offline sites there is a separate offline installer that ships an image tarball, an in-cluster registry, and a host image-loading step.</>,
+    inOfflineH2: 'Air-gapped: build the image bundle',
+    inOfflineP: <>On a connected host, <code>./offline/save-images.sh</code> pulls every first-party and prerequisite image and writes <code>offline/nap-images.tar.gz</code> plus the prereq charts under <code>prereqs/</code>. Move that to the air-gapped side and load it with <code>./offline/load-images.sh --registry &lt;your-registry&gt;</code> (add <code>--insecure-registry</code> for a plain-HTTP registry) — it pushes every image into your registry and prints the <code>values.env</code> overrides to paste. Set those, then <code>./install.sh</code> runs exactly as it does online — it auto-detects the offline prereq bundles and wires the pull secret from <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code>. If a vendor delivered a prebuilt bundle, skip <code>save-images</code> and start at <code>load-images</code>. For a single machine with no external registry, use the <a href="/self-host/single-node/">single-node profile</a> instead.</>,
     // Upgrade
     upPathH2: 'Upgrade',
     upPathP1: <>Upgrading is the same command as a first install. Pin <code>IMAGE_TAG</code> to the new release tag (or keep <code>latest</code>) in your existing <code>values.env</code>, then re-run:</>,
     upPathP2: <><code>install.sh</code> is idempotent, so the upgrade path matches the first install. It re-renders and re-applies the manifests and refreshes the first-party deployments to pick up new image digests. SQL migrations run automatically when <code>nap-cp</code> starts.</>,
     upCallout: <><strong>Do not change secrets</strong> · Reuse the <code>values.env</code> from your first install. If a machine-internal secret (e.g. <code>JWT_SECRET</code>) changes, all issued session tokens are invalidated and the existing database can no longer be reached.</>,
+    upAirgapNote: <><strong>Air-gapped</strong> — before an air-gapped upgrade, re-run <code>offline/save-images.sh</code> / <code>offline/load-images.sh</code> to push the new image tags into your registry first, then the same <code>./install.sh</code>.</>,
     upCompatH2: 'Upgrading from a pre-2026-05 release',
     upCompatP: <>Optional-module defaults changed from "enabled unless configured" to "disabled unless configured". If the following <code>_ENABLED</code> fields aren't set explicitly in <code>values.env</code>, the corresponding capabilities are off after the upgrade:</>,
     upThCapability: 'Capability',
@@ -362,7 +367,7 @@ const PANEL_STR = {
     tsErrH2: 'install.sh fails',
     tsErrIntro: <>First find the deployment that isn't ready (replace <code>$NAMESPACE</code> with{' '}<code>NAMESPACE</code> from <code>values.env</code>, default <code>nap</code>):</>,
     tsErrCommon: 'Common causes:',
-    tsErrPull: <><strong>Images won't pull</strong> → confirm the nodes can reach{' '}<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>. If you mirror images, check <code>REGISTRY</code> and the <code>IMAGE_PULL_SECRET</code> you configured.</>,
+    tsErrPull: <><strong>Images won't pull</strong> → <strong>connected</strong>: confirm the nodes can reach{' '}<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>. <strong>Air-gapped</strong>: confirm <code>load-images.sh</code> pushed the bundle into your <code>REGISTRY</code> and that <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> are set — the installer builds the regcred pull secret from them. A plain-HTTP registry also needs the nodes' container runtime to trust it as insecure.</>,
     tsErrPvc: <><strong>PVCs stuck Pending</strong> → run{' '}<code>kubectl -n $NAMESPACE get pvc</code> and check the StorageClass exists and its provisioner is healthy</>,
     tsErrPg: <><strong>PostgreSQL won't start</strong> →{' '}<code>kubectl -n $NAMESPACE describe cluster.postgresql.cnpg.io nap-pg</code>; the most common cause is the CSI behind <code>PG_STORAGE_CLASS</code> not being writable</>,
     tsErrPort: <><strong>NodePort already in use</strong> → change <code>NAP_NODE_PORT</code> /{' '}<code>BROWSER_NODE_PORT</code> / <code>SANDBOX_NODE_PORT</code> and re-run{' '}<code>install.sh</code></>,
@@ -395,7 +400,7 @@ const PANEL_STR = {
     ovCapH2: '一次安装能得到什么',
     ovIntro: (
       <>
-        这是 <strong>联网 / 在线</strong> 安装器：目标集群必须能访问公网。镜像直接从公共仓库（<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>）拉取，前置 chart/manifest 也从各自的公共来源获取。没有离线镜像包、没有集群内仓库，也没有主机侧加载镜像的步骤。对于完全隔离网络的场景，另有一套离线安装器，提供镜像 tarball、集群内仓库和主机准备步骤。
+        无论哪种方式，都是同一条 <code>./install.sh</code> 把平台装起来 —— 唯一的区别是镜像从哪里来。每个节点都从一个它能访问的仓库拉取镜像：<strong>联网</strong> 时是公共仓库（<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>）或你用 <code>REGISTRY</code> 指向的镜像源；<strong>隔离网络</strong> 时是你自己的私有仓库，由你在一台联网机器上用 <code>offline/save-images.sh</code> 构建、再用 <code>offline/load-images.sh</code> 推入的镜像包填充。若只有一台机器，见 <a href="/self-host/single-node/">单节点 profile</a>，它会启动集群内仓库，完全不需要外部仓库。
       </>
     ),
     ovCoreH3: '核心平台（始终安装）',
@@ -418,9 +423,9 @@ const PANEL_STR = {
     ovWorkers: 'Worker 节点',
     ovWorkersReq: '至少 4 vCPU / 8GB 内存',
     ovWorkersNote: 'Agent pod 按 Workspace 动态创建',
-    ovRegAccess: '公共仓库访问',
-    ovRegAccessReq: <>节点能从 <code>ghcr.io</code>、<code>docker.io</code>、<code>registry.k8s.io</code> 拉取镜像</>,
-    ovRegAccessNote: <>仅在使用镜像源时才覆盖 <code>REGISTRY</code></>,
+    ovRegAccess: '容器镜像仓库',
+    ovRegAccessReq: <>一个所有节点都能拉取的仓库 —— 公共仓库（联网）或你自己的私有仓库（隔离网络）</>,
+    ovRegAccessNote: <>把 <code>REGISTRY</code> 指向它；仓库需要登录时填写 <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code></>,
     ovRwx: 'RWX 共享存储',
     ovRwxReq: '支持 ReadWriteMany 的 CSI（最常见的是 NFS）',
     ovRwxNote: '承载 AFS 共享目录，默认 500Gi',
@@ -438,7 +443,7 @@ const PANEL_STR = {
     ovStorageReach: '存储可达性',
     ovStorageReachReq: '所有节点都能挂载上面两个 storage class（NFS / 块存储 CSI 等）',
     ovRegReach: '仓库可达性',
-    ovRegReachReq: '所有节点都能从公共仓库拉取镜像',
+    ovRegReachReq: '所有节点都能从上面那个仓库拉取镜像（公共仓库，或你的私有仓库）',
     ovLlmH3: 'LLM API',
     ovLlmIntro: '平台不内置任何模型。根据启用的 Agent 类型，你需要提供协议兼容的 API endpoint：',
     ovThAgentType: 'Agent 类型',
@@ -470,12 +475,16 @@ const PANEL_STR = {
     inToolEnvsubst: <><code>envsubst</code> — 通常随 <code>gettext</code> 包一起提供</>,
     inToolOpenssl: <><code>openssl</code> — 被 <code>gen-secrets.sh</code> 用来生成随机密钥</>,
     inToolHelm: <><code>helm</code> 3.x — 仅当集群尚未有 NFS provisioner 时需要；由 <code>install.sh</code> 的前置阶段调用</>,
-    inToolsNote: <>集群节点（而非操作者机器）必须能从 <code>ghcr.io</code>、<code>docker.io</code> 和 <code>registry.k8s.io</code> 拉取镜像。</>,
+    inToolLoader: <><code>docker</code> 或 <code>nerdctl</code> — 供 <code>offline/load-images.sh</code> 把镜像包推入你的仓库（仅隔离网络安装需要）</>,
+    inToolsNote: <>集群节点（而非操作者机器）必须能从你的 <code>REGISTRY</code> 拉取镜像。联网时是公共仓库（<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>）；隔离网络时是你自己的仓库，节点完全不碰公网。</>,
     inQuickH2: '快速开始',
     inQuickAfter: <>完成后打开 <code>http://&lt;NAP_HOST&gt;:&lt;NAP_NODE_PORT&gt;</code>，用 <code>values.env</code> 里的管理员用户名 / 密码登录。</>,
     inStepsH2: '分步操作',
     inStep1H3: '获取安装器',
-    inStep1Note: <>所有第一方镜像都从公共仓库拉取（<code>${'{'}REGISTRY{'}'}</code>，默认 <code>ghcr.io/neutree-ai/agent-platform</code>）；没有镜像 tarball 需要加载。仅当你把镜像放到别处镜像源时才覆盖 <code>REGISTRY</code>。</>,
+    inStep1Note: <>联网安装时，所有第一方镜像都从公共仓库拉取（<code>${'{'}REGISTRY{'}'}</code>，默认 <code>ghcr.io/neutree-ai/agent-platform</code>）。仅当你把镜像放到别处镜像源时才覆盖 <code>REGISTRY</code>。</>,
+    inAirgapLead: '隔离网络 ——',
+    inAirgapBody: <> 在一台联网机器上执行 <code>./offline/save-images.sh</code> 构建 <code>offline/nap-images.tar.gz</code> 及前置 chart，拷到隔离侧，再用 <code>./offline/load-images.sh --registry &lt;你的仓库&gt;</code> 加载、重打 tag 并把所有镜像推入你的仓库，同时打印出需要粘贴进 <code>values.env</code> 的 <code>REGISTRY=</code> / <code>*_IMAGE=</code> 各行。厂商已交付镜像包？跳过 <code>save-images</code>，直接从 <code>load-images</code> 开始。</>,
+    inRegAuthNote: <>若你的仓库需要登录，在 <code>values.env</code> 里设置 <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> —— 安装器会据此自动创建 <code>regcred</code> imagePullSecret，并挂到平台、CNPG 与 workspace pod 上。</>,
     inStep2H3: '准备 values.env',
     inStep2GenBtn: '配置生成器',
     inStep2P1Pre: '我们推荐使用',
@@ -489,15 +498,16 @@ const PANEL_STR = {
     inSubH2: 'install.sh 子命令',
     inSubIntro: <>用于单独运行各阶段；通常情况下一条 <code>./install.sh</code> 就够了。</>,
     inSingleH2: 'Single-node profile',
-    inSingleP: <>单个 k3s 节点，所有镜像直接从公共仓库拉取 — 与完整 profile 相同，只是改成 <code>PG_INSTANCES=1</code> 并用集群内 NFS server 提供 RWX 存储（单节点没有外部 NFS）。它不会启动集群内仓库，也不加载任何 tarball。</>,
+    inSingleP: <>单个 k3s 节点 —— 与完整 profile 相同，只是改成 <code>PG_INSTANCES=1</code> 并用集群内 NFS server 提供 RWX 存储（单节点没有外部 NFS）。<strong>联网</strong> 时所有镜像直接从公共仓库拉取。<strong>隔离网络</strong> 时它会启动集群内仓库并用镜像包填充，完全不需要外部仓库。两种路径详见 <a href="/self-host/single-node/">单节点页面</a>。</>,
     inSingleNote: <>在一台已经跑好 k3s、kubeconfig 位于 <code>/etc/rancher/k3s/k3s.yaml</code>（single-node 示例中的默认值）的主机上运行。</>,
-    inOfflineH2: '隔离网络场景',
-    inOfflineP: <>本页文档讲的是联网安装器。对于完全隔离网络 / 离线的场景，另有一套离线安装器，提供镜像 tarball、集群内仓库和主机侧加载镜像的步骤。</>,
+    inOfflineH2: '隔离网络：构建镜像包',
+    inOfflineP: <>在一台联网机器上，<code>./offline/save-images.sh</code> 会拉取全部第一方与前置镜像，产出 <code>offline/nap-images.tar.gz</code> 以及 <code>prereqs/</code> 下的前置 chart。把它拷到隔离侧，用 <code>./offline/load-images.sh --registry &lt;你的仓库&gt;</code> 加载（纯 HTTP 仓库加 <code>--insecure-registry</code>）—— 它会把所有镜像推入你的仓库并打印出需要粘贴的 <code>values.env</code> 覆盖项。设好之后，<code>./install.sh</code> 的运行方式与联网时完全一致 —— 它会自动识别离线前置包，并据 <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> 接好 pull secret。若厂商已交付预构建镜像包，跳过 <code>save-images</code>，直接从 <code>load-images</code> 开始。若是单台机器、没有外部仓库，改用 <a href="/self-host/single-node/">单节点 profile</a>。</>,
     // Upgrade
     upPathH2: '升级',
     upPathP1: <>升级与首次安装用的是同一条命令。在现有 <code>values.env</code> 里把 <code>IMAGE_TAG</code> 固定到新的发布 tag（或保持 <code>latest</code>），然后重新运行：</>,
     upPathP2: <><code>install.sh</code> 是幂等的，所以升级路径与首次安装一致。它会重新渲染并重新 apply manifest，并刷新第一方 deployment 以拉取新的镜像 digest。<code>nap-cp</code> 启动时会自动运行 SQL 迁移。</>,
     upCallout: <><strong>不要修改密钥</strong> · 复用首次安装时的 <code>values.env</code>。如果机器内部密钥（例如 <code>JWT_SECRET</code>）发生变化，所有已签发的会话 token 都会失效，现有数据库也将无法访问。</>,
+    upAirgapNote: <><strong>隔离网络</strong> —— 隔离网络升级前，先重新执行 <code>offline/save-images.sh</code> / <code>offline/load-images.sh</code> 把新的镜像 tag 推入你的仓库，然后再跑同一条 <code>./install.sh</code>。</>,
     upCompatH2: '从 2026-05 之前的版本升级',
     upCompatP: <>可选模块的默认值从"未配置即启用"改为"未配置即禁用"。如果以下 <code>_ENABLED</code> 字段没有在 <code>values.env</code> 里显式设置，升级后对应能力将处于关闭状态：</>,
     upThCapability: '能力',
@@ -515,7 +525,7 @@ const PANEL_STR = {
     tsErrH2: 'install.sh 失败',
     tsErrIntro: <>先找出未就绪的 deployment（把 <code>$NAMESPACE</code> 替换为{' '}<code>values.env</code> 里的 <code>NAMESPACE</code>，默认 <code>nap</code>）：</>,
     tsErrCommon: '常见原因：',
-    tsErrPull: <><strong>镜像拉不下来</strong> → 确认节点能访问{' '}<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>。如果你用镜像源，检查 <code>REGISTRY</code> 和你配置的 <code>IMAGE_PULL_SECRET</code>。</>,
+    tsErrPull: <><strong>镜像拉不下来</strong> → <strong>联网</strong>：确认节点能访问{' '}<code>ghcr.io</code> / <code>docker.io</code> / <code>registry.k8s.io</code>。<strong>隔离网络</strong>：确认 <code>load-images.sh</code> 已把镜像包推入你的 <code>REGISTRY</code>，且 <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> 已设置 —— 安装器会据此生成 regcred pull secret。纯 HTTP 仓库还需让节点容器运行时将其信任为 insecure。</>,
     tsErrPvc: <><strong>PVC 卡在 Pending</strong> → 运行{' '}<code>kubectl -n $NAMESPACE get pvc</code>，检查 StorageClass 是否存在、其 provisioner 是否健康</>,
     tsErrPg: <><strong>PostgreSQL 起不来</strong> →{' '}<code>kubectl -n $NAMESPACE describe cluster.postgresql.cnpg.io nap-pg</code>；最常见的原因是 <code>PG_STORAGE_CLASS</code> 背后的 CSI 不可写</>,
     tsErrPort: <><strong>NodePort 已被占用</strong> → 修改 <code>NAP_NODE_PORT</code> /{' '}<code>BROWSER_NODE_PORT</code> / <code>SANDBOX_NODE_PORT</code> 并重新运行{' '}<code>install.sh</code></>,
@@ -753,6 +763,7 @@ function Install({ onGo, locale = 'en' }: { onGo: (id: TabId) => void; locale?: 
           <li>{t.inToolEnvsubst}</li>
           <li>{t.inToolOpenssl}</li>
           <li>{t.inToolHelm}</li>
+          <li>{t.inToolLoader}</li>
         </ul>
         <p class="sh-muted">{t.inToolsNote}</p>
       </section>
@@ -774,6 +785,13 @@ vi values.env                   # set NAP_HOST, ADMIN_PASSWORD, storage, etc.
             <h3>{t.inStep1H3}</h3>
             <CodeBlock locale={locale}>{`git clone <this-repo> && cd self-host`}</CodeBlock>
             <p class="sh-muted">{t.inStep1Note}</p>
+            <div class="sh-callout sh-callout-airgap">
+              <svg class="sh-callout-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+              <strong>{t.inAirgapLead}</strong>{t.inAirgapBody}
+            </div>
           </li>
           <li>
             <h3>{t.inStep2H3}</h3>
@@ -788,6 +806,7 @@ vi values.env                   # set NAP_HOST, ADMIN_PASSWORD, storage, etc.
               {t.inStep2P1Post}<code>self-host/</code>{t.inStep2P1End}
             </p>
             <p class="sh-muted">{t.inStep2Note}</p>
+            <p class="sh-muted">{t.inRegAuthNote}</p>
           </li>
           <li>
             <h3>{t.inStep3H3}</h3>
@@ -839,6 +858,7 @@ function Upgrade({ locale = 'en' }: { locale?: string }) {
         <CodeBlock locale={locale}>{`./install.sh`}</CodeBlock>
         <p>{t.upPathP2}</p>
         <div class="sh-callout sh-callout-warn">{t.upCallout}</div>
+        <div class="sh-callout sh-callout-airgap">{t.upAirgapNote}</div>
       </section>
 
       <section>

--- a/docs-site/src/components/self-host/ValuesGenerator.tsx
+++ b/docs-site/src/components/self-host/ValuesGenerator.tsx
@@ -179,6 +179,10 @@ const SCHEMA_ZH: {
       title: '容器镜像仓库',
       desc: '存放所有第一方镜像的公共镜像仓库路径',
     },
+    registryAuth: {
+      title: '私有仓库鉴权（可选）',
+      desc: '仅当你的仓库需要登录时填写 —— 私有 / 镜像源 / 隔离网络仓库。公共或匿名仓库留空即可；安装器会据此创建 regcred imagePullSecret。',
+    },
     cluster: {
       title: '集群与访问',
       desc: 'K8s 命名空间、kubeconfig 路径，以及用户访问平台所用的 IP / NodePort',
@@ -215,6 +219,12 @@ const SCHEMA_ZH: {
     },
     IMAGE_TAG: {
       hint: '所有第一方镜像的 tag。固定到某个发布 tag 可获得可复现的安装',
+    },
+    REGISTRY_SERVER: {
+      hint: '仓库主机名（用于生成 imagePullSecret）。仅当仓库需要鉴权时填写',
+    },
+    REGISTRY_USERNAME: {
+      hint: '当仓库需要鉴权时填写；安装器会据此创建 regcred imagePullSecret',
     },
     NAP_HOST: {
       hint: '用户访问平台所用的 IP 或主机名（某个 worker 节点）',
@@ -326,6 +336,32 @@ const SCHEMA: SectionDef[] = [
         label: 'IMAGE_TAG',
         default: 'latest',
         hint: 'Tag for all first-party images. Pin to a release tag for a reproducible install',
+      },
+    ],
+  },
+  {
+    id: 'registryAuth',
+    title: 'Private registry auth (optional)',
+    envTitle: 'Private Registry Auth (optional)',
+    desc: 'Only when your registry needs a login — a private / mirrored / air-gapped registry. Leave blank for a public or anonymous one; the installer builds a regcred imagePullSecret from these.',
+    fields: [
+      {
+        key: 'REGISTRY_SERVER',
+        kind: 'text',
+        label: 'REGISTRY_SERVER',
+        hint: 'Registry hostname (used to build the imagePullSecret). Fill in only when the registry requires authentication',
+        placeholder: 'registry.example.com',
+      },
+      {
+        key: 'REGISTRY_USERNAME',
+        kind: 'text',
+        label: 'REGISTRY_USERNAME',
+        hint: 'Fill in when the registry requires authentication; the installer builds a regcred imagePullSecret from it',
+      },
+      {
+        key: 'REGISTRY_PASSWORD',
+        kind: 'password',
+        label: 'REGISTRY_PASSWORD',
       },
     ],
   },

--- a/docs-site/src/components/self-host/self-host-shell.css
+++ b/docs-site/src/components/self-host/self-host-shell.css
@@ -523,6 +523,18 @@ main:has(.sh-root) > .content-panel:first-child {
 .sh-callout-warn {
   border-left-color: var(--sl-color-orange, #f59e0b);
 }
+/* Air-gap addendum: calm, accent-tinted — distinct from the orange warning but
+   not alarming. Mirrors .sh-callout-warn's border-only approach, adding a faint
+   accent wash so it reads as a labeled aside on the connected-first spine. */
+.sh-callout-airgap {
+  border-left-color: var(--sl-color-accent);
+  background: color-mix(in srgb, var(--sl-color-accent) 8%, var(--sl-color-bg-nav));
+}
+.sh-callout-icon {
+  vertical-align: -2px;
+  margin-right: 0.3rem;
+  color: var(--sl-color-accent);
+}
 
 /* ---- Misc -------------------------------------------------------------- */
 

--- a/docs-site/src/content/docs/self-host/single-node.mdx
+++ b/docs-site/src/content/docs/self-host/single-node.mdx
@@ -3,11 +3,9 @@ title: Single-Node k3s Quick Deploy
 description: Bring up the full Neutree Agent Platform on one machine with k3s — the quickest install path. Pulls images from the public registry.
 ---
 
-Install Neutree Agent Platform on a single-node k3s cluster — the quickest way to get the full platform running. The single-node profile matches the full one, just with a single PostgreSQL instance and an in-cluster NFS server for shared storage. Every image is pulled from the public registry (`ghcr.io` / `docker.io` / `registry.k8s.io`), so the node needs internet access.
+Install Neutree Agent Platform on a single-node k3s cluster — the quickest way to get the full platform running. The single-node profile matches the full one, just with a single PostgreSQL instance and an in-cluster NFS server for shared storage. By default every image is pulled from the public registry (`ghcr.io` / `docker.io` / `registry.k8s.io`), so the node needs internet access. For a node with **no internet access**, jump to [Air-gapped install](#air-gapped-install) — it brings up an in-cluster registry seeded from an image bundle, so nothing is pulled from the internet.
 
 Recommended spec: **8 vCPU / 32 GB / 200 GB disk** — comfortable for roughly **10 concurrent workspaces**. When you need HA or horizontal scale, use the [production deployment](/self-host/).
-
-> Fully air-gapped (offline) installs are possible but not yet packaged for the open-source distribution — [open a GitHub issue](https://github.com/neutree-ai/agent-platform/issues) if you need one.
 
 ## One-line install
 
@@ -80,6 +78,59 @@ Everything else (PG replica count, storage classes, NFS backend) is preset for t
 `install.sh` first brings up the in-cluster NFS server (`nap-nfs-server` pod, backed by `local-path`), installs the CloudNativePG operator and the NFS subdir provisioner from their public sources, renders and applies the manifests, then seeds the admin user, OAuth clients, and the MCP catalog. All images are pulled from the public registry.
 
 ### 3. Log in
+
+```
+http://<NAP_HOST>:30080
+admin / <ADMIN_PASSWORD>
+```
+
+## Air-gapped install
+
+A node with **no internet access** installs from two bundles built on a connected host — the platform image bundle and a k3s prep bundle. `install.sh` brings up an in-cluster registry (`nap-registry`) and seeds it from the image bundle, so the node never reaches the internet and you need no external registry.
+
+### 1. Build the bundles (connected host)
+
+On any internet-connected machine, from the `self-host/` directory:
+
+```bash
+./offline/save-images.sh                         # → offline/nap-images.tar.gz + prereq charts
+./single-node-prep/package-prep.sh --arch amd64  # → k3s + helm/envsubst/crane + airgap images
+```
+
+`save-images.sh` writes `offline/nap-images.tar.gz` (every first-party and third-party image, plus `registry:2`) and the CNPG / NFS-provisioner charts under `prereqs/`. `package-prep.sh` bundles the k3s binary, its airgap images, and the CLI tools `install.sh` depends on — pick the `--arch` (`amd64` / `arm64`) that matches the target node. If a vendor delivered these bundles, skip this step.
+
+### 2. Stage on the node
+
+Copy both bundles to the air-gapped node and extract them so `single-node-prep/` sits alongside `self-host/offline/nap-images.tar.gz` — `preinstall.sh` looks for the image bundle there.
+
+### 3. Prepare values.env
+
+```bash
+cd self-host
+cp values.env.single-node.example values.env
+./gen-secrets.sh        # fills random JWT / PG / TURN / SANDBOX secrets
+vi values.env           # set NAP_HOST + ADMIN_PASSWORD
+```
+
+Set `NAP_HOST` **before** the next step — `preinstall.sh` writes the containerd config that lets the node reach the in-cluster registry over HTTP, and it needs the host.
+
+### 4. Preinstall — install k3s and import images
+
+```bash
+cd single-node-prep
+sudo ./preinstall.sh
+```
+
+This installs k3s from the bundle, drops in helm / envsubst / crane, imports `nap-images.tar.gz` into k3s containerd (priming `registry:2` and the third-party images), and configures containerd to treat the in-cluster registry as plain HTTP. Re-run it any time after editing `values.env`.
+
+### 5. Install
+
+```bash
+cd ..
+./install.sh --profile=single-node
+```
+
+Because `offline/nap-images.tar.gz` is present, `install.sh` brings up the in-cluster `nap-registry`, seeds it from the bundle, and points every workload at it — no external registry, no internet. Everything else (in-cluster NFS server, CloudNativePG, seeding the admin user and MCP catalog) matches the connected flow. Log in the same way:
 
 ```
 http://<NAP_HOST>:30080

--- a/docs-site/src/content/docs/zh-cn/self-host/single-node.mdx
+++ b/docs-site/src/content/docs/zh-cn/self-host/single-node.mdx
@@ -3,11 +3,9 @@ title: 单节点 k3s 快速部署
 description: 在一台机器上用 k3s 拉起完整的 Neutree Agent Platform —— 最快的安装路径。镜像从公共 registry 拉取。
 ---
 
-在单节点 k3s 集群上安装 Neutree Agent Platform —— 让完整平台跑起来的最快方式。单节点 profile 与完整 profile 一致，只是 PostgreSQL 为单实例、共享存储由集群内 NFS server 提供。所有镜像都从公共 registry（`ghcr.io` / `docker.io` / `registry.k8s.io`）拉取，节点需要能访问互联网。
+在单节点 k3s 集群上安装 Neutree Agent Platform —— 让完整平台跑起来的最快方式。单节点 profile 与完整 profile 一致，只是 PostgreSQL 为单实例、共享存储由集群内 NFS server 提供。默认所有镜像都从公共 registry（`ghcr.io` / `docker.io` / `registry.k8s.io`）拉取，节点需要能访问互联网。若节点**完全无法访问互联网**，直接看[隔离网络安装](#隔离网络安装) —— 它会启动集群内仓库并用镜像包填充，全程不从互联网拉取任何镜像。
 
 推荐配置：**8 vCPU / 32 GB / 200 GB 磁盘**，约可支撑 **10 个并发 workspace**。需要 HA 或横向扩展时，走[生产部署](/zh-cn/self-host/)。
-
-> 完全隔离（air-gapped）的离线安装是可行的，但尚未打包进开源发行版 —— 有需要请提 [GitHub issue](https://github.com/neutree-ai/agent-platform/issues)。
 
 ## 一行命令安装
 
@@ -80,6 +78,59 @@ vi values.env           # set NAP_HOST + ADMIN_PASSWORD
 `install.sh` 会先拉起集群内 NFS server（`nap-nfs-server` pod，以 `local-path` 为后端），从公共源安装 CloudNativePG operator 和 NFS subdir provisioner，渲染并应用 manifest，然后初始化（seed）admin 用户、OAuth client 和 MCP 目录。所有镜像都从公共 registry 拉取。
 
 ### 3. 登录
+
+```
+http://<NAP_HOST>:30080
+admin / <ADMIN_PASSWORD>
+```
+
+## 隔离网络安装
+
+**完全无法访问互联网**的节点，从两个在联网机器上构建的物料包安装 —— 平台镜像包和 k3s 准备包。`install.sh` 会启动集群内仓库（`nap-registry`）并用镜像包填充，节点全程不碰互联网，也无需外部仓库。
+
+### 1. 构建物料包（联网机器）
+
+在任意联网机器上，进入 `self-host/` 目录：
+
+```bash
+./offline/save-images.sh                         # → offline/nap-images.tar.gz + 前置 chart
+./single-node-prep/package-prep.sh --arch amd64  # → k3s + helm/envsubst/crane + airgap 镜像
+```
+
+`save-images.sh` 产出 `offline/nap-images.tar.gz`（全部第一方、第三方镜像及 `registry:2`）以及 `prereqs/` 下的 CNPG / NFS provisioner chart。`package-prep.sh` 打包 k3s 二进制、其 airgap 镜像和 `install.sh` 依赖的 CLI 工具 —— 按目标节点架构选择 `--arch`（`amd64` / `arm64`）。若厂商已交付这些物料包，可跳过此步。
+
+### 2. 在节点上就位
+
+把两个物料包拷到隔离节点并解压，使 `single-node-prep/` 与 `self-host/offline/nap-images.tar.gz` 相邻 —— `preinstall.sh` 会在那里查找镜像包。
+
+### 3. 准备 values.env
+
+```bash
+cd self-host
+cp values.env.single-node.example values.env
+./gen-secrets.sh        # fills random JWT / PG / TURN / SANDBOX secrets
+vi values.env           # set NAP_HOST + ADMIN_PASSWORD
+```
+
+请在下一步**之前**设好 `NAP_HOST` —— `preinstall.sh` 会写入让节点通过 HTTP 访问集群内仓库的 containerd 配置，而它需要该 host。
+
+### 4. Preinstall —— 安装 k3s 并导入镜像
+
+```bash
+cd single-node-prep
+sudo ./preinstall.sh
+```
+
+它会从物料包安装 k3s，放入 helm / envsubst / crane，把 `nap-images.tar.gz` 导入 k3s containerd（预置 `registry:2` 和第三方镜像），并配置 containerd 将集群内仓库视为纯 HTTP。修改 `values.env` 后可随时重跑。
+
+### 5. 安装
+
+```bash
+cd ..
+./install.sh --profile=single-node
+```
+
+由于 `offline/nap-images.tar.gz` 存在，`install.sh` 会启动集群内 `nap-registry`、用镜像包填充，并把所有工作负载指向它 —— 无需外部仓库、不碰互联网。其余流程（集群内 NFS server、CloudNativePG、初始化 admin 用户和 MCP 目录）与联网流程一致。登录方式相同：
 
 ```
 http://<NAP_HOST>:30080

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -2,13 +2,18 @@
 set -euo pipefail
 
 # ============================================================================
-# Neutree Agent Platform — Self-Hosted Installer (CONNECTED variant)
+# Neutree Agent Platform — Self-Hosted Installer
 # ============================================================================
-# This is the connected / online installer: the target cluster MUST be able to
-# reach the public internet. Images are pulled directly from a public registry
-# and prereq charts/manifests are fetched from their public sources. There is
-# no offline image bundle, no in-cluster registry, no HTTP registry mirror.
-# (For air-gapped / offline sites, use the separate offline "super" installer.)
+# Connected (default): images are pulled directly from a public registry and
+# prereq charts/manifests are fetched from their public sources.
+#
+# Air-gapped / offline: point REGISTRY at your own private registry, load the
+# image bundle into it with offline/load-images.sh (build the bundle first on a
+# connected host with offline/save-images.sh, or use one your vendor delivered),
+# and place the prereq charts under prereqs/. The installer then applies the
+# offline CNPG/NFS bundles and wires an imagePullSecret from REGISTRY_USERNAME /
+# REGISTRY_PASSWORD automatically. No separate installer — the offline path is
+# gated on the bundle being present, so the same command serves both.
 #
 # Usage:
 #   ./install.sh                  # Full install (prereqs + manifests + seed admin)
@@ -19,15 +24,17 @@ set -euo pipefail
 #
 # Single-node profile (DEPLOY_PROFILE=single-node in values.env, or
 #   --profile=single-node CLI flag):
-#   A 1-node k3s that pulls images straight from the public registry — exactly
-#   like the full profile, just PG_INSTANCES=1 and an in-cluster NFS server for
-#   RWX (no external NFS available on a single node). It brings up NO in-cluster
-#   registry and loads NO tarball.
+#   A 1-node k3s — like the full profile, just PG_INSTANCES=1 and an in-cluster
+#   NFS server for RWX (no external NFS on a single node). Connected: pulls from
+#   the public registry. Air-gapped: when offline/nap-images.tar.gz is present it
+#   brings up an in-cluster registry and seeds it from the bundle, so no external
+#   registry is needed at all. Must run ON the k3s node (uses crane / k3s ctr).
 #
 # Prerequisites:
 #   - kubectl, envsubst on the machine running this script
 #   - helm (only if the NFS provisioner isn't pre-installed)
-#   - the cluster nodes can reach ghcr.io / docker.io / registry.k8s.io
+#   - connected: the cluster nodes can reach ghcr.io / docker.io / registry.k8s.io
+#   - air-gapped: a registry every node can pull from + the loaded image bundle
 #   - values.env filled in from values.env.example
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -89,9 +96,23 @@ export AFS_IMAGE="${AFS_IMAGE:-ghcr.io/neutree-ai/afs:latest}"
 AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}-agent}"
 export AGENT_IMAGE_PREFIX
 
+# Registry authentication. Blank for a public / anonymous registry. When both
+# username and password are set, the installer creates a 'regcred'
+# docker-registry Secret and attaches it as an imagePullSecret to the platform
+# ServiceAccounts, CNPG, coturn, and the workspace pods cp spawns.
+export REGISTRY_SERVER="${REGISTRY_SERVER:-}"
+export REGISTRY_USERNAME="${REGISTRY_USERNAME:-}"
+export REGISTRY_PASSWORD="${REGISTRY_PASSWORD:-}"
+
 # imagePullSecret name cp injects into spawned workspace pods. Empty on a
-# connected install (public agent images); a mirror/offline install sets it.
-export IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-}"
+# connected/anonymous install (public agent images); derived as 'regcred' when
+# the registry is authenticated. An unauthenticated mirror (e.g. the single-node
+# in-cluster registry) needs none, matching create_regcred's condition.
+if [ -n "$REGISTRY_USERNAME" ] && [ -n "$REGISTRY_PASSWORD" ]; then
+  export IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-regcred}"
+else
+  export IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-}"
+fi
 
 export KUBECONFIG="${KUBECONFIG:-./kubeconfig.yaml}"
 
@@ -101,6 +122,11 @@ export AFS_STORAGE_SIZE="${AFS_STORAGE_SIZE:-500Gi}"
 export AGENT_NODE_SELECTOR="${AGENT_NODE_SELECTOR:-}"
 
 export DEPLOY_PROFILE="${DEPLOY_PROFILE:-multi-node}"
+# In-cluster registry config, consumed only by the single-node offline path
+# (single_node_load_registry + manifests/registry.yaml). Safe to render in any
+# profile.
+export REGISTRY_NODE_PORT="${REGISTRY_NODE_PORT:-30500}"
+export REGISTRY_STORAGE_SIZE="${REGISTRY_STORAGE_SIZE:-20Gi}"
 # Backing PVC size for the in-cluster NFS server (single-node only).
 export SINGLE_NODE_NFS_SIZE="${SINGLE_NODE_NFS_SIZE:-100Gi}"
 
@@ -266,6 +292,7 @@ render_manifests() {
   VARS+='${SERVICE_TYPE}'
   VARS+='${PG_SYNC_REPLICAS}'
   VARS+='${SINGLE_NODE_NFS_SIZE}'
+  VARS+='${REGISTRY_NODE_PORT}${REGISTRY_STORAGE_SIZE}'
 
   for tmpl in "$SCRIPT_DIR"/manifests/*.yaml; do
     local name
@@ -310,6 +337,55 @@ ensure_recreate_strategy() {
   fi
 }
 
+# --- Registry credentials --------------------------------------------------
+
+# Create the 'regcred' docker-registry Secret in a namespace. No-op on an
+# unauthenticated registry (username/password blank) or if it already exists.
+create_regcred() {
+  local ns="$1"
+  if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
+    return 0
+  fi
+  if kubectl -n "$ns" get secret regcred &>/dev/null; then
+    log "  imagePullSecret 'regcred' already exists in $ns"
+    return 0
+  fi
+  log "  Creating imagePullSecret in $ns ..."
+  kubectl -n "$ns" create secret docker-registry regcred \
+    --docker-server="${REGISTRY_SERVER}" \
+    --docker-username="${REGISTRY_USERNAME}" \
+    --docker-password="${REGISTRY_PASSWORD}"
+}
+
+# The shared manifests intentionally carry no imagePullSecrets. For an
+# authenticated registry we wire the pull secret at the ServiceAccount level so
+# every pod using that SA inherits it. Patched before the workloads are applied
+# so their pods get it at creation time. No-op when IMAGE_PULL_SECRET is empty.
+attach_pull_secret_to_sa() {
+  local ns="$1" sa="$2"
+  [ -z "$IMAGE_PULL_SECRET" ] && return 0
+  # The default SA is created asynchronously after the namespace, and the cp SA
+  # is owned by its manifest — create-if-missing so we can patch it up front.
+  # The manifest re-apply later won't drop imagePullSecrets: server-side apply
+  # only manages fields present in the applied config, and the SA manifests
+  # declare none.
+  kubectl -n "$ns" create serviceaccount "$sa" --dry-run=client -o yaml \
+    | kubectl apply -f - >/dev/null
+  kubectl -n "$ns" patch serviceaccount "$sa" \
+    -p "{\"imagePullSecrets\":[{\"name\":\"${IMAGE_PULL_SECRET}\"}]}" >/dev/null
+  log "  attached imagePullSecret '${IMAGE_PULL_SECRET}' to sa/$sa in $ns"
+}
+
+# CNPG manages its own instance pods, so the pull secret goes on the Cluster
+# spec (its native field) rather than a SA. No-op on an unauthenticated registry.
+attach_pull_secret_to_cnpg() {
+  [ -z "$IMAGE_PULL_SECRET" ] && return 0
+  kubectl -n "${NAMESPACE}" patch cluster.postgresql.cnpg.io "${APP_PREFIX}-pg" \
+    --type merge \
+    -p "{\"spec\":{\"imagePullSecrets\":[{\"name\":\"${IMAGE_PULL_SECRET}\"}]}}" >/dev/null \
+    && log "  attached imagePullSecret '${IMAGE_PULL_SECRET}' to cluster/${APP_PREFIX}-pg"
+}
+
 # --- coturn (TURN server) --------------------------------------------------
 
 # Patch the rendered coturn manifest with optional nodeSelector, apply, wait
@@ -333,6 +409,12 @@ apply_coturn() {
   log "Deploying coturn ..."
   ensure_recreate_strategy coturn
   kapply -f "$RENDERED_DIR/coturn.yaml"
+
+  # imagePullSecrets (authenticated registry only)
+  if [ -n "$IMAGE_PULL_SECRET" ]; then
+    kubectl -n "${NAMESPACE}" patch deployment coturn \
+      -p "{\"spec\":{\"template\":{\"spec\":{\"imagePullSecrets\":[{\"name\":\"${IMAGE_PULL_SECRET}\"}]}}}}"
+  fi
 
   # nodeSelector + matching tolerations (so tainted nodes still accept)
   if [ -n "$COTURN_NODE_SELECTOR" ]; then
@@ -363,11 +445,29 @@ apply_coturn() {
 
 install_cnpg_operator() {
   log "Installing CloudNativePG operator v${CNPG_VERSION} ..."
-  # Connected variant: always fetch the operator manifest from GitHub. The
-  # manifest already references CNPG's public GHCR image, so there's no
-  # registry re-point step.
-  kapply -f \
-    "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${CNPG_VERSION%.*}/releases/cnpg-${CNPG_VERSION}.yaml"
+  # Offline bundle (prereqs/cnpg-<ver>.yaml, written by offline/save-images.sh)
+  # takes precedence: apply it locally and re-point the operator image at the
+  # mirror, since the upstream GHCR image is unreachable in an air-gapped site.
+  # Connected default: fetch the manifest from GitHub — it already references
+  # CNPG's public GHCR image, so no re-point step.
+  local cnpg_yaml="$SCRIPT_DIR/prereqs/cnpg-${CNPG_VERSION}.yaml"
+  if [ -f "$cnpg_yaml" ]; then
+    log "  Using offline bundle: $cnpg_yaml"
+    kapply -f "$cnpg_yaml"
+    log "  Re-pointing operator image at ${REGISTRY}/cloudnative-pg:${CNPG_VERSION}"
+    kubectl -n cnpg-system set env deployment/cnpg-controller-manager \
+      OPERATOR_IMAGE_NAME="${REGISTRY}/cloudnative-pg:${CNPG_VERSION}"
+    kubectl -n cnpg-system set image deployment/cnpg-controller-manager \
+      manager="${REGISTRY}/cloudnative-pg:${CNPG_VERSION}"
+    if [ -n "$IMAGE_PULL_SECRET" ]; then
+      create_regcred cnpg-system
+      kubectl -n cnpg-system patch deployment cnpg-controller-manager \
+        -p "{\"spec\":{\"template\":{\"spec\":{\"imagePullSecrets\":[{\"name\":\"${IMAGE_PULL_SECRET}\"}]}}}}"
+    fi
+  else
+    kapply -f \
+      "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${CNPG_VERSION%.*}/releases/cnpg-${CNPG_VERSION}.yaml"
+  fi
 
   kubectl rollout status deployment -n cnpg-system cnpg-controller-manager --timeout=180s
   log "CNPG operator ready."
@@ -410,15 +510,30 @@ install_nfs_provisioner() {
     die "helm is required to install NFS provisioner. Install helm or pre-install the provisioner."
   fi
 
-  # Connected variant: always add the upstream helm repo and install from it.
-  # The chart's default image (registry.k8s.io/sig-storage/...) is public, so
-  # no registry re-point step is needed.
-  helm repo add nfs-subdir-external-provisioner \
-    https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/ 2>/dev/null || true
-  helm repo update nfs-subdir-external-provisioner
+  # Offline bundle (prereqs/nfs-subdir-external-provisioner-chart.tgz, written by
+  # offline/save-images.sh) takes precedence: install from the local chart and
+  # re-point the image at the mirror. Connected default: add the upstream helm
+  # repo and install from it — the chart's default image (registry.k8s.io/...)
+  # is public, so no re-point step.
+  local chart_ref extra_args=()
+  local offline_chart="$SCRIPT_DIR/prereqs/nfs-subdir-external-provisioner-chart.tgz"
+  if [ -f "$offline_chart" ]; then
+    log "  Using offline chart: $offline_chart"
+    chart_ref="$offline_chart"
+    extra_args+=(--set "image.repository=${REGISTRY}/nfs-subdir-external-provisioner")
+    if [ -n "$IMAGE_PULL_SECRET" ]; then
+      create_regcred "${NAMESPACE}"
+      extra_args+=(--set "imagePullSecrets[0].name=${IMAGE_PULL_SECRET}")
+    fi
+  else
+    helm repo add nfs-subdir-external-provisioner \
+      https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/ 2>/dev/null || true
+    helm repo update nfs-subdir-external-provisioner
+    chart_ref="nfs-subdir-external-provisioner/nfs-subdir-external-provisioner"
+  fi
 
   helm upgrade --install --force nfs-subdir-external-provisioner \
-    nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+    "$chart_ref" \
     --namespace "${NAMESPACE}" --create-namespace \
     --set nfs.server="${NFS_SERVER}" \
     --set nfs.path="${NFS_PATH}" \
@@ -428,7 +543,8 @@ install_nfs_provisioner() {
     --set storageClass.archiveOnDelete=true \
     --set storageClass.volumeBindingMode=Immediate \
     --set storageClass.allowVolumeExpansion=true \
-    --set 'storageClass.mountOptions={vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport}'
+    --set 'storageClass.mountOptions={vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport}' \
+    ${extra_args[@]+"${extra_args[@]}"}
 
   log "NFS provisioner installed. StorageClass: ${NFS_STORAGE_CLASS}"
 }
@@ -445,6 +561,153 @@ install_prereqs() {
   fi
 }
 
+# --- Single-node profile: in-cluster registry bootstrap ---------------------
+
+# Air-gapped single-node only. Brings up an in-cluster registry and seeds it
+# from the offline image bundle, so workspace pods (which reference a registry
+# URL) have a registry to pull from without any external one. Runs only when
+# DEPLOY_PROFILE=single-node AND the bundle is present — a connected single-node
+# install pulls from the public registry and skips this entirely. Must execute
+# on the k3s node itself (uses crane against the in-cluster registry over HTTP).
+single_node_load_registry() {
+  local archive="${IMAGES_ARCHIVE:-$SCRIPT_DIR/offline/nap-images.tar.gz}"
+  if [ ! -f "$archive" ]; then
+    log "single-node: no offline bundle at $archive — assuming a connected registry, skipping in-cluster registry."
+    return 0
+  fi
+  if ! command -v crane &>/dev/null; then
+    die "single-node offline profile requires crane (single-node-prep/preinstall.sh bundles it)"
+  fi
+
+  # Preflight: containerd must know the in-cluster registry NodePort speaks
+  # plain HTTP, or pod-side pulls fail with "server gave HTTP response to HTTPS
+  # client". single-node-prep/preinstall.sh writes both files, but only once
+  # NAP_HOST is set in values.env — if preinstall ran before values.env was
+  # filled (or NAP_HOST changed since), they're missing/stale and the failure
+  # only surfaces much later (CNPG / app pods stuck ImagePullBackOff). Fail fast
+  # here with the exact remedy instead.
+  local endpoint="${NAP_HOST}:${REGISTRY_NODE_PORT}"
+  local hosts_toml="/var/lib/rancher/k3s/agent/etc/containerd/certs.d/${endpoint}/hosts.toml"
+  if ! grep -qF "$endpoint" /etc/rancher/k3s/registries.yaml 2>/dev/null || [ ! -f "$hosts_toml" ]; then
+    die "containerd has no plain-HTTP mirror for ${endpoint} (registries.yaml / hosts.toml missing or stale).
+       This is written by single-node-prep/preinstall.sh AFTER NAP_HOST is set in values.env.
+       Set NAP_HOST=${NAP_HOST:-<this-host-ip>} in values.env, then re-run preinstall:
+         sudo IMAGES_ARCHIVE=${archive} <prep-dir>/preinstall.sh
+       (preinstall rewrites registries.yaml + hosts.toml and restarts k3s.)"
+  fi
+
+  log "Bringing up in-cluster registry ..."
+  render_manifests
+  kapply -f "$RENDERED_DIR/namespace.yaml"
+  kapply -f "$RENDERED_DIR/registry.yaml"
+  kubectl -n "${NAMESPACE}" rollout status deployment/nap-registry --timeout=120s || {
+    die "nap-registry not ready; check kubectl -n ${NAMESPACE} describe deploy nap-registry"
+  }
+
+  local push_endpoint="${NAP_HOST}:${REGISTRY_NODE_PORT}"
+
+  # docker-archive is read sequentially. Reading from .tar.gz forces a full
+  # decompression per image (gzip has no random access). Decompress once to a
+  # plain .tar so per-image extraction below can seek directly.
+  local plain_archive="$archive"
+  if [[ "$archive" == *.gz ]]; then
+    plain_archive="${archive%.gz}"
+    if [ ! -f "$plain_archive" ] || [ "$archive" -nt "$plain_archive" ]; then
+      log "Decompressing $archive → $plain_archive (one-time) ..."
+      gunzip -k -f "$archive"
+    fi
+  fi
+
+  # Read manifest.json from the docker-save tarball to get image refs to push.
+  # We push these and only these — k3s ctr push hangs under k3s's auto-generated
+  # hosts.toml (HTTP host is pull-only), so we use crane against the in-cluster
+  # registry over plain HTTP (--insecure).
+  log "Reading archive manifest ..."
+  local refs
+  refs=$(tar -xOf "$plain_archive" manifest.json | python3 -c '
+import json, sys
+for entry in json.load(sys.stdin):
+    for tag in entry.get("RepoTags", []):
+        print(tag)
+')
+  if [ -z "$refs" ]; then
+    die "no images parsed from $plain_archive manifest.json"
+  fi
+
+  # crane's `push` CLI loads a tarball with tarball.ImageFromPath(path, nil),
+  # which only works for single-image tarballs. The multi-image bundle has 20+
+  # entries in manifest.json, so feeding the whole archive fails. For each image
+  # we materialize a small per-image tarball in /tmp containing just that image's
+  # Config + Layers + a filtered manifest.json, push with crane, then delete.
+  local total
+  total=$(echo "$refs" | wc -l | tr -d ' ')
+  log "Pushing $total images to $push_endpoint via crane ..."
+
+  local stage
+  stage="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$stage'" RETURN
+
+  local i=0
+  local src
+  while IFS= read -r src; do
+    i=$((i + 1))
+    # Collapse each source ref to the short name the values.env image vars
+    # expect under ${REGISTRY}/<short> — must match offline/load-images.sh.
+    local short
+    case "$src" in
+      *cloudnative-pg/postgresql:*) short="cloudnative-pg-postgresql:${src##*:}" ;;
+      *cloudnative-pg/cloudnative-pg:*) short="cloudnative-pg:${src##*:}" ;;
+      *sig-storage/nfs-subdir-external-provisioner:*) short="nfs-subdir-external-provisioner:${src##*:}" ;;
+      *) short="${src##*/}" ;;
+    esac
+    # registry:2 (if bundled) stays local: the registry pod uses IfNotPresent +
+    # a pre-loaded image, and pushing it to itself is a chicken-and-egg no-op.
+    if [ "$short" = "registry:2" ]; then
+      log "  [$i/$total] skipping registry:2"
+      continue
+    fi
+    local dst="${push_endpoint}/nap/${short}"
+    log "  [$i/$total] $src → $dst"
+
+    local per_image_tar="$stage/img.tar"
+    python3 - "$plain_archive" "$src" "$per_image_tar" <<'PY' || die "failed to build per-image tarball for $src"
+import io, json, sys, tarfile
+src_tar, ref, out_tar = sys.argv[1], sys.argv[2], sys.argv[3]
+with tarfile.open(src_tar, "r") as tin:
+    manifest = json.load(tin.extractfile("manifest.json"))
+    entry = next((e for e in manifest if ref in e.get("RepoTags", [])), None)
+    if entry is None:
+        sys.exit(f"ref {ref} not found in manifest.json")
+    wanted = {entry["Config"]} | set(entry.get("Layers", []))
+    # Single-image manifest.json with RepoTags trimmed to just the requested
+    # ref (some entries list multiple tags; crane would push all of them).
+    new_entry = dict(entry, RepoTags=[ref])
+    new_manifest = json.dumps([new_entry]).encode()
+    with tarfile.open(out_tar, "w") as tout:
+        for name in wanted:
+            ti = tin.getmember(name)
+            tout.addfile(ti, tin.extractfile(ti))
+        ti = tarfile.TarInfo("manifest.json")
+        ti.size = len(new_manifest)
+        tout.addfile(ti, io.BytesIO(new_manifest))
+PY
+
+    crane push --insecure "$per_image_tar" "$dst" >/dev/null || {
+      die "crane push failed for $src"
+    }
+    rm -f "$per_image_tar"
+  done <<< "$refs"
+  log "Registry seeded with $total images."
+
+  # Decompressed copy is only useful during seeding; the .gz original is the
+  # on-disk artifact for any future re-seed. Drop the .tar to reclaim space.
+  if [ "$plain_archive" != "$archive" ] && [ -f "$plain_archive" ]; then
+    log "Reclaiming $plain_archive ($(du -h "$plain_archive" | cut -f1))"
+    rm -f "$plain_archive"
+  fi
+}
+
 # --- Apply manifests -------------------------------------------------------
 
 apply_manifests() {
@@ -452,12 +715,19 @@ apply_manifests() {
 
   log "Applying manifests to namespace ${NAMESPACE} ..."
 
-  # Order matters: namespace → secrets → postgres → services
+  # Order matters: namespace → regcred → secrets → postgres → services
   kapply -f "$RENDERED_DIR/namespace.yaml"
+  # Authenticated registry: create the pull secret and attach it to the SAs so
+  # every platform pod (and the workspace pods cp spawns via the default SA)
+  # inherits it. No-op on a public/anonymous registry.
+  create_regcred "${NAMESPACE}"
+  attach_pull_secret_to_sa "${NAMESPACE}" default
+  attach_pull_secret_to_sa "${NAMESPACE}" "${APP_PREFIX}-cp"
   kapply -f "$RENDERED_DIR/secrets.yaml"
 
   log "Creating PostgreSQL cluster ..."
   kapply -f "$RENDERED_DIR/postgres.yaml"
+  attach_pull_secret_to_cnpg
   log "Waiting for PostgreSQL cluster to be ready (this may take a few minutes) ..."
   # Use the fully-qualified resource name: the bare `cluster` short name is
   # ambiguous if the target cluster also has Cluster API CRDs installed
@@ -647,11 +917,14 @@ MODE="${1:-full}"
 check_prereqs
 
 if [ "$DEPLOY_PROFILE" = "single-node" ]; then
-  log "DEPLOY_PROFILE=single-node — 1-node k3s pulling images from the public registry."
+  log "DEPLOY_PROFILE=single-node — 1-node k3s. Connected: pulls from the public"
+  log "  registry. Air-gapped: seeds an in-cluster registry from the offline bundle"
+  log "  (offline/nap-images.tar.gz) when present."
 fi
 
 case "$MODE" in
   --prereqs-only)
+    [ "$DEPLOY_PROFILE" = "single-node" ] && single_node_load_registry
     install_prereqs
     ;;
   --manifests-only)
@@ -667,6 +940,7 @@ case "$MODE" in
     log "Dry run complete. Check $RENDERED_DIR/"
     ;;
   full|"")
+    [ "$DEPLOY_PROFILE" = "single-node" ] && single_node_load_registry
     install_prereqs
     apply_manifests
     seed_admin

--- a/self-host/manifests/registry.yaml
+++ b/self-host/manifests/registry.yaml
@@ -1,0 +1,91 @@
+# In-cluster image registry used by the single-node profile to keep the host
+# free of external registry dependencies. Rendered unconditionally so other
+# profiles can ignore it; install.sh only applies it when DEPLOY_PROFILE=single-node
+# (single_node_load_registry) and an offline bundle is present.
+#
+# Reachability:
+#   - in-cluster pods → Service ClusterIP `nap-registry:5000`
+#   - host containerd & install.sh → NodePort `${NAP_HOST}:${REGISTRY_NODE_PORT}`
+# Same backing pod; using a single `${NAP_HOST}:${REGISTRY_NODE_PORT}` hostname
+# everywhere (manifests + crane push) avoids cluster-DNS / hosts-file gymnastics.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nap-registry-data
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: ${REGISTRY_STORAGE_SIZE}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nap-registry
+  namespace: ${NAMESPACE}
+  labels:
+    app: nap-registry
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nap-registry
+  template:
+    metadata:
+      labels:
+        app: nap-registry
+    spec:
+      containers:
+        - name: registry
+          # Pre-loaded into k3s containerd by single-node-prep/preinstall.sh
+          # (k3s ctr images import of nap-images.tar.gz, which carries registry:2
+          # via this manifest's render). IfNotPresent avoids a chicken-and-egg
+          # pull at boot — there is no registry to pull the registry from yet.
+          image: registry:2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5000
+              name: http
+          env:
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "20m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: nap-registry-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nap-registry
+  namespace: ${NAMESPACE}
+spec:
+  type: NodePort
+  selector:
+    app: nap-registry
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+      nodePort: ${REGISTRY_NODE_PORT}

--- a/self-host/offline/load-images.sh
+++ b/self-host/offline/load-images.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Load the offline image bundle and push every image to a target registry
+# ============================================================================
+# Usage:
+#   ./load-images.sh --registry registry.example.com/nap --archive nap-images.tar.gz
+#
+# Retags every image in the bundle to ${TARGET_REGISTRY}/<short> and pushes it,
+# then prints the exact values.env overrides to paste. <short> collapses each
+# source ref the same way install.sh's single_node_load_registry does, so the
+# two air-gap paths (external mirror vs. in-cluster registry) stay in lockstep.
+
+# Container CLI: docker, or nerdctl on containerd-only hosts (K3s, plain
+# containerd). Both expose identical load/tag/push/image-inspect subcommands.
+# Override with CONTAINER_CLI=... if autodetection picks the wrong one.
+CONTAINER_CLI="${CONTAINER_CLI:-}"
+if [ -z "$CONTAINER_CLI" ]; then
+  if command -v docker &>/dev/null; then
+    CONTAINER_CLI=docker
+  elif command -v nerdctl &>/dev/null; then
+    CONTAINER_CLI=nerdctl
+  else
+    echo "ERROR: neither docker nor nerdctl found." >&2
+    echo "Install one, or set CONTAINER_CLI explicitly." >&2
+    exit 1
+  fi
+fi
+
+ARCHIVE=""
+TARGET_REGISTRY=""
+INSECURE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --registry)           TARGET_REGISTRY="$2"; shift 2 ;;
+    --archive)            ARCHIVE="$2"; shift 2 ;;
+    --insecure-registry)  INSECURE=true; shift ;;
+    *)                    echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [ -z "$TARGET_REGISTRY" ] || [ -z "$ARCHIVE" ]; then
+  echo "Usage: $0 --registry <target-registry> --archive <tar-file> [--insecure-registry]"
+  echo ""
+  echo "  --insecure-registry  push over plain HTTP (registry without TLS)"
+  echo ""
+  echo "Example:"
+  echo "  $0 --registry registry.example.com/nap --archive nap-images.tar.gz"
+  exit 1
+fi
+
+# Plain-HTTP registry support. nerdctl/docker default to HTTPS; an HTTP-only
+# registry returns "server gave HTTP response to HTTPS client" without this.
+PUSH_OPTS=""
+if [ "$INSECURE" = true ]; then
+  if [ "$CONTAINER_CLI" = "nerdctl" ]; then
+    PUSH_OPTS="--insecure-registry"
+  else
+    echo "WARNING: --insecure-registry has no effect with docker." >&2
+    echo "         Add \"$TARGET_REGISTRY\" host to daemon.json insecure-registries" >&2
+    echo "         and restart the docker daemon." >&2
+  fi
+fi
+
+if [ ! -f "$ARCHIVE" ]; then
+  echo "ERROR: Archive not found: $ARCHIVE"
+  exit 1
+fi
+
+# Remove trailing slash
+TARGET_REGISTRY="${TARGET_REGISTRY%/}"
+
+echo "==> Loading images from $ARCHIVE (via $CONTAINER_CLI) ..."
+"$CONTAINER_CLI" load -i "$ARCHIVE"
+
+# --- Short-name mapping -----------------------------------------------------
+# Collapse a source ref to the <short> used under ${TARGET_REGISTRY}/<short>.
+# MUST stay identical to install.sh single_node_load_registry.
+short_name() {
+  case "$1" in
+    *cloudnative-pg/postgresql:*)                    echo "cloudnative-pg-postgresql:${1##*:}" ;;
+    *cloudnative-pg/cloudnative-pg:*)                echo "cloudnative-pg:${1##*:}" ;;
+    *sig-storage/nfs-subdir-external-provisioner:*)  echo "nfs-subdir-external-provisioner:${1##*:}" ;;
+    *)                                               echo "${1##*/}" ;;
+  esac
+}
+
+# Resolve a source ref to whatever form is actually present locally. docker
+# normalizes docker.io refs (docker.io/library/node:22-bookworm → node:22-bookworm,
+# docker.io/coturn/coturn:4.6 → coturn/coturn:4.6) while nerdctl keeps the full
+# form. Try the ref as written, then the docker-normalized variants.
+resolve_local_ref() {
+  local ref="$1" v
+  for v in "$ref" "${ref#docker.io/library/}" "${ref#docker.io/}"; do
+    if "$CONTAINER_CLI" image inspect "$v" &>/dev/null; then echo "$v"; return 0; fi
+  done
+  return 1
+}
+
+retag_push() {
+  # retag_push <source-ref>
+  local src short dst local_ref
+  src="$1"
+  short="$(short_name "$src")"
+  dst="${TARGET_REGISTRY}/${short}"
+  if local_ref="$(resolve_local_ref "$src")"; then
+    echo "    $local_ref → $dst"
+    "$CONTAINER_CLI" tag "$local_ref" "$dst"
+    "$CONTAINER_CLI" push $PUSH_OPTS "$dst"
+  else
+    echo "    WARNING: $src not found in loaded images, skipping"
+  fi
+}
+
+# --- First-party images -----------------------------------------------------
+# All under one source registry. Derive it from the loaded */nap-cp image and
+# exclude the target registry: a previous (possibly failed) run leaves retagged
+# ${TARGET_REGISTRY}/nap-cp images in the local store, and matching one of those
+# would make every other first-party image resolve to a nonexistent source tag.
+SOURCE_REGISTRY=$("$CONTAINER_CLI" images --format '{{.Repository}}' \
+  | grep '/nap-cp$' \
+  | grep -vF "${TARGET_REGISTRY}/" \
+  | head -1 | sed 's|/nap-cp$||')
+
+if [ -z "$SOURCE_REGISTRY" ]; then
+  echo "ERROR: could not determine source registry — no nap-cp image found" >&2
+  echo "       in the archive. Is $ARCHIVE the correct image bundle?" >&2
+  exit 1
+fi
+echo "==> Source registry: $SOURCE_REGISTRY"
+
+# First-party service + agent images live under ${SOURCE_REGISTRY}/<short>.
+# chromium-headful shares the same registry; afs ships from its own repo and is
+# handled in the third-party list below.
+FIRST_PARTY_NAMES=(
+  nap-cp
+  nap-cg
+  nap-scheduler
+  nap-browser
+  nap-sandbox
+  nap-skills-content-service
+  nap-env-runner-k8s
+  nap-memory-fuse
+  chromium-headful
+  nap-agent-claude-code
+  nap-agent-codex
+)
+
+echo "==> Retagging and pushing first-party images to ${TARGET_REGISTRY} ..."
+for name in "${FIRST_PARTY_NAMES[@]}"; do
+  # Find whatever tag was bundled for this repo (latest, a release tag, ...).
+  while IFS= read -r local_ref; do
+    [ -n "$local_ref" ] || continue
+    retag_push "$local_ref"
+  done < <("$CONTAINER_CLI" images --format '{{.Repository}}:{{.Tag}}' \
+             | grep -E "^${SOURCE_REGISTRY}/${name}:")
+done
+
+# --- Third-party images -----------------------------------------------------
+# Absolute source refs (their registries differ from SOURCE_REGISTRY). registry:2
+# is intentionally NOT here: multi-node targets pull from this registry directly
+# and never run the in-cluster registry, so registry:2 is only used by the
+# single-node preinstall path (imported straight into containerd).
+THIRD_PARTY_SRCS=(
+  "ghcr.io/cloudnative-pg/postgresql:16"
+  "ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1"
+  "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2"
+  "docker.io/gotenberg/gotenberg:8"
+  "docker.io/coturn/coturn:4.6"
+  "ghcr.io/obeone/nfs-server:2.2.3"
+  "docker.io/library/node:22-bookworm"
+  "docker.io/library/python:3.12-bookworm"
+  "docker.io/library/golang:1.23"
+  "registry.k8s.io/pause:3.9"
+  "ghcr.io/neutree-ai/afs:latest"
+)
+
+echo "==> Retagging and pushing third-party images ..."
+for src in "${THIRD_PARTY_SRCS[@]}"; do
+  retag_push "$src"
+done
+
+echo ""
+echo "==> All images pushed to ${TARGET_REGISTRY}"
+echo ""
+echo "============================================================================"
+echo "Paste these into your values.env (uncomment the third-party block):"
+echo "============================================================================"
+echo "REGISTRY=${TARGET_REGISTRY}"
+echo "POSTGRES_IMAGE=${TARGET_REGISTRY}/cloudnative-pg-postgresql:16"
+echo "GOTENBERG_IMAGE=${TARGET_REGISTRY}/gotenberg:8"
+echo "COTURN_IMAGE=${TARGET_REGISTRY}/coturn:4.6"
+echo "NFS_SERVER_IMAGE=${TARGET_REGISTRY}/nfs-server:2.2.3"
+echo "RUNTIME_NODE_IMAGE=${TARGET_REGISTRY}/node:22-bookworm"
+echo "RUNTIME_PYTHON_IMAGE=${TARGET_REGISTRY}/python:3.12-bookworm"
+echo "RUNTIME_GOLANG_IMAGE=${TARGET_REGISTRY}/golang:1.23"
+echo "PAUSE_IMAGE=${TARGET_REGISTRY}/pause:3.9"
+echo "AFS_IMAGE=${TARGET_REGISTRY}/afs:latest"
+echo "============================================================================"
+echo "The CNPG operator + NFS provisioner images are pushed too; install.sh"
+echo "re-points them at \${REGISTRY} automatically when the offline prereqs are"
+echo "present, so no extra values.env entry is needed for those."

--- a/self-host/offline/save-images.sh
+++ b/self-host/offline/save-images.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Save all images + prereqs for an air-gapped Neutree Agent Platform install
+# ============================================================================
+# Runs on a CONNECTED build host. Produces:
+#   nap-images.tar.gz          — all container images (docker save | gzip)
+#   ../prereqs/                — CNPG operator YAML + NFS provisioner Helm chart
+#
+# The image set is DERIVED, not hand-maintained: we render the manifests with
+# ./install.sh --render-only and grep the resolved `image:` lines. This keeps
+# the bundle authoritative — it can never drift from what the manifests deploy.
+# A short supplement adds images that are NOT in any manifest (agent pods are
+# spawned dynamically; the CNPG operator + NFS provisioner ship as prereqs).
+#
+# Build-host prereqs: docker, helm, kubectl, envsubst, curl
+#   (kubectl + envsubst are needed by `install.sh --render-only`).
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SELF_HOST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RENDERED_DIR="$SELF_HOST_DIR/rendered"
+
+OUTPUT="${OUTPUT:-$SCRIPT_DIR/nap-images.tar.gz}"
+
+# First-party image coordinates. Defaults match install.sh; the render below is
+# the source of truth for first-party service images, so these only feed the
+# agent-image supplement (agents are spawned dynamically, never in a manifest).
+REGISTRY="${REGISTRY:-ghcr.io/neutree-ai/agent-platform}"
+APP_PREFIX="${APP_PREFIX:-nap}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+AGENT_IMAGE_TAG="${AGENT_IMAGE_TAG:-latest}"
+AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}-agent}"
+
+# Prereq versions are pinned in install.sh — grep them so this script can't
+# drift from the versions the installer actually re-points images at.
+CNPG_VERSION="$(grep -E '^CNPG_VERSION=' "$SELF_HOST_DIR/install.sh" | head -1 | cut -d'"' -f2)"
+NFS_PROVISIONER_VERSION="$(grep -E '^NFS_PROVISIONER_VERSION=' "$SELF_HOST_DIR/install.sh" | head -1 | cut -d'"' -f2)"
+[ -n "$CNPG_VERSION" ] || { echo "ERROR: could not read CNPG_VERSION from install.sh" >&2; exit 1; }
+[ -n "$NFS_PROVISIONER_VERSION" ] || { echo "ERROR: could not read NFS_PROVISIONER_VERSION from install.sh" >&2; exit 1; }
+
+# --- Derive the first + third-party image set from rendered manifests --------
+echo "==> Rendering manifests to derive the authoritative image set ..."
+( cd "$SELF_HOST_DIR" && ./install.sh --render-only >/dev/null )
+[ -d "$RENDERED_DIR" ] || { echo "ERROR: render produced no $RENDERED_DIR" >&2; exit 1; }
+
+# Pull the resolved `image:` values out of every rendered manifest. envsubst has
+# already substituted REGISTRY / *_IMAGE / tags, so these are concrete refs
+# (first-party services, postgres, gotenberg, coturn, nfs-server, afs, the
+# language runtimes, pause, chromium-headful, and registry:2 from registry.yaml).
+RENDERED_IMAGES=()
+while IFS= read -r img; do
+  [ -n "$img" ] && RENDERED_IMAGES+=("$img")
+done < <(
+  grep -hE '^[[:space:]]*image:[[:space:]]' "$RENDERED_DIR"/*.yaml \
+    | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/["'\'']//g' \
+    | grep -v '\${' \
+    | sort -u
+)
+[ "${#RENDERED_IMAGES[@]}" -gt 0 ] || { echo "ERROR: no image: lines found in rendered manifests" >&2; exit 1; }
+
+# --- Supplement: images NOT present as an `image:` line in any manifest ------
+#   - agent images: spawned dynamically by the control-plane, never templated
+#   - memory-fuse: passed to cp/env-runner as an env VALUE (the image of a pod
+#     they spawn), so it never appears on an `image:` line the render grep sees
+#   - CNPG operator image: install.sh applies the operator YAML as a prereq
+#   - NFS provisioner image: install.sh installs it via Helm as a prereq
+SUPPLEMENT_IMAGES=(
+  "${AGENT_IMAGE_PREFIX}-claude-code:${AGENT_IMAGE_TAG}"
+  "${AGENT_IMAGE_PREFIX}-codex:${AGENT_IMAGE_TAG}"
+  "${REGISTRY}/${APP_PREFIX}-memory-fuse:${IMAGE_TAG}"
+  "ghcr.io/cloudnative-pg/cloudnative-pg:${CNPG_VERSION}"
+  "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:${NFS_PROVISIONER_VERSION}"
+)
+
+# Merge + de-dup (no bash-4 associative arrays — build host may be bash 3.2).
+ALL_IMAGES=()
+for img in "${RENDERED_IMAGES[@]}" "${SUPPLEMENT_IMAGES[@]}"; do
+  [ -n "$img" ] || continue
+  case " ${ALL_IMAGES[*]} " in
+    *" $img "*) ;;                # already present
+    *) ALL_IMAGES+=("$img") ;;
+  esac
+done
+
+# Auto-detect host arch; override with PLATFORM=linux/<arch>.
+case "$(uname -m)" in
+  x86_64)         HOST_PLATFORM="linux/amd64" ;;
+  aarch64|arm64)  HOST_PLATFORM="linux/arm64" ;;
+  *)              HOST_PLATFORM="linux/$(uname -m)" ;;
+esac
+PLATFORM="${PLATFORM:-$HOST_PLATFORM}"
+
+echo "==> Fetching ${#ALL_IMAGES[@]} images (${PLATFORM}) ..."
+# Set PULL_POLICY=never to skip all pulls (use the local cache only).
+for img in "${ALL_IMAGES[@]}"; do
+  if docker image inspect "$img" &>/dev/null; then
+    echo "    cached  $img"
+  elif [ "${PULL_POLICY:-}" = "never" ]; then
+    echo "    WARNING: $img not cached and PULL_POLICY=never, skipping"
+  else
+    echo "    pulling $img"
+    docker pull --platform "$PLATFORM" "$img" || {
+      echo "ERROR: failed to pull $img — aborting (set PULL_POLICY=never to skip pulls; see save-images.sh)" >&2
+      exit 1
+    }
+  fi
+done
+
+echo "==> Saving images to $OUTPUT ..."
+docker save "${ALL_IMAGES[@]}" | gzip > "$OUTPUT"
+SIZE=$(du -h "$OUTPUT" | cut -f1)
+echo "==> Images saved: $OUTPUT ($SIZE)"
+
+# --- Download prereqs for the offline install -------------------------------
+PREREQS_DIR="$SELF_HOST_DIR/prereqs"
+mkdir -p "$PREREQS_DIR"
+
+echo "==> Downloading CNPG operator manifest (v${CNPG_VERSION}) ..."
+curl -fsSL -o "$PREREQS_DIR/cnpg-${CNPG_VERSION}.yaml" \
+  "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-${CNPG_VERSION%.*}/releases/cnpg-${CNPG_VERSION}.yaml"
+echo "    saved prereqs/cnpg-${CNPG_VERSION}.yaml"
+
+echo "==> Downloading NFS provisioner Helm chart ..."
+helm repo add nfs-subdir-external-provisioner \
+  https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/ 2>/dev/null || true
+helm repo update nfs-subdir-external-provisioner
+# Drop any previous copy so the rename below doesn't get confused by a glob
+# matching both the freshly-pulled tarball and the old -chart.tgz.
+rm -f "$PREREQS_DIR/nfs-subdir-external-provisioner-chart.tgz"
+helm pull nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+  -d "$PREREQS_DIR"
+mv "$PREREQS_DIR"/nfs-subdir-external-provisioner-*.tgz \
+   "$PREREQS_DIR/nfs-subdir-external-provisioner-chart.tgz"
+echo "    saved prereqs/nfs-subdir-external-provisioner-chart.tgz"
+
+echo ""
+echo "==> Done. Deliverables for an air-gapped install:"
+echo "    1. self-host/              (this directory)"
+echo "    2. $OUTPUT     (container images)"
+echo "    3. self-host/prereqs/      (CNPG + NFS provisioner charts, just created)"
+echo ""
+echo "On the target machine:"
+echo "    1. ./offline/load-images.sh --registry <your-registry> --archive $OUTPUT"
+echo "       (prints the exact values.env image overrides to paste)"
+echo "    2. ./gen-secrets.sh && vi values.env"
+echo "    3. ./install.sh"

--- a/self-host/single-node-prep/package-prep.sh
+++ b/self-host/single-node-prep/package-prep.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Build the single-node-prep tarball.
+# ============================================================================
+# Output:
+#   ../../nap-self-host-single-node-prep-<arch>-<fp8>.tar.gz
+#
+# The filename carries an 8-char content fingerprint, NOT the platform release.
+# The prep bundle changes far less often than the platform itself — it only
+# depends on pinned tool versions, the nfs-common debs, and preinstall.sh. The
+# fingerprint is derived from exactly those inputs, so two builds cut for
+# different platform releases produce an IDENTICAL filename whenever the prep
+# content is unchanged. Customers compare the filename: same fp → skip
+# re-upload / re-download; new fp → prep really changed.
+#
+# Bundles:
+#   preinstall.sh
+#   k3s-<arch>                          (binary; symlinked as kubectl by preinstall)
+#   k3s-airgap-images-<arch>.tar.gz
+#   helm / envsubst / crane             (CLI tools install.sh depends on)
+#   k9s                                 (k8s TUI for on-host debugging)
+#   nfs-debs/                           (offline nfs-common for no-apt hosts)
+#
+# The in-cluster NFS server image is a public image already carried by the main
+# bundle (offline/nap-images.tar.gz), so it is NOT special-cased here.
+#
+# Usage:
+#   ./package-prep.sh --arch amd64 [--version <label>]
+#   ./package-prep.sh --arch arm64 [--version <label>]
+# --version is optional metadata only (recorded as built_with= in VERSION);
+# it does not affect the fingerprint or the filename.
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+K3S_VERSION="${K3S_VERSION:-v1.32.5+k3s1}"
+# Pinned for reproducible builds. Bump deliberately.
+HELM_VERSION="${HELM_VERSION:-v3.16.4}"
+ENVSUBST_VERSION="${ENVSUBST_VERSION:-v1.4.3}"   # a8m/envsubst (Go reimpl, single static binary)
+CRANE_VERSION="${CRANE_VERSION:-v0.20.2}"         # google/go-containerregistry
+K9S_VERSION="${K9S_VERSION:-v0.50.18}"            # derailed/k9s
+
+VERSION=""
+ARCH=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --arch)    ARCH="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$ARCH" ] || { echo "--arch required (amd64|arm64)" >&2; exit 1; }
+
+case "$ARCH" in
+  amd64) K3S_BIN_URL_SUFFIX="" ; K3S_AIRGAP_SUFFIX="amd64" ;;
+  arm64) K3S_BIN_URL_SUFFIX="-arm64" ; K3S_AIRGAP_SUFFIX="arm64" ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+STAGING="$(mktemp -d)"
+trap "rm -rf $STAGING" EXIT
+DEST="$STAGING/single-node-prep"
+mkdir -p "$DEST"
+
+echo "==> Staging preinstall.sh"
+install -m 0755 "$SCRIPT_DIR/preinstall.sh" "$DEST/preinstall.sh"
+
+K3S_BASE="https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION//+/%2B}"
+echo "==> Downloading k3s binary ($K3S_VERSION, $ARCH)"
+curl -fsSL -o "$DEST/k3s-$ARCH" "$K3S_BASE/k3s$K3S_BIN_URL_SUFFIX"
+chmod +x "$DEST/k3s-$ARCH"
+
+echo "==> Downloading k3s airgap images ($ARCH)"
+curl -fsSL -o "$DEST/k3s-airgap-images-$ARCH.tar.gz" \
+  "$K3S_BASE/k3s-airgap-images-$K3S_AIRGAP_SUFFIX.tar.gz"
+
+# --- Bundled CLI tools (so a no-apt host still has helm / envsubst / crane / kubectl) ---
+TMP_DL="$(mktemp -d)"
+trap "rm -rf $STAGING $TMP_DL" EXIT
+
+echo "==> Downloading helm $HELM_VERSION ($ARCH)"
+curl -fsSL -o "$TMP_DL/helm.tar.gz" \
+  "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
+tar -xzf "$TMP_DL/helm.tar.gz" -C "$TMP_DL"
+install -m 0755 "$TMP_DL/linux-${ARCH}/helm" "$DEST/helm"
+
+echo "==> Downloading envsubst $ENVSUBST_VERSION ($ARCH)"
+# a8m/envsubst release artifact naming: envsubst-Linux-x86_64 / envsubst-Linux-arm64
+case "$ARCH" in
+  amd64) envsubst_asset="envsubst-Linux-x86_64" ;;
+  arm64) envsubst_asset="envsubst-Linux-arm64" ;;
+esac
+curl -fsSL -o "$DEST/envsubst" \
+  "https://github.com/a8m/envsubst/releases/download/${ENVSUBST_VERSION}/${envsubst_asset}"
+chmod 0755 "$DEST/envsubst"
+
+echo "==> Downloading crane $CRANE_VERSION ($ARCH)"
+# go-containerregistry release artifact naming: go-containerregistry_Linux_x86_64.tar.gz / _arm64.tar.gz
+case "$ARCH" in
+  amd64) crane_asset="go-containerregistry_Linux_x86_64.tar.gz" ;;
+  arm64) crane_asset="go-containerregistry_Linux_arm64.tar.gz" ;;
+esac
+curl -fsSL -o "$TMP_DL/crane.tar.gz" \
+  "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/${crane_asset}"
+tar -xzf "$TMP_DL/crane.tar.gz" -C "$TMP_DL" crane
+install -m 0755 "$TMP_DL/crane" "$DEST/crane"
+
+echo "==> Downloading k9s $K9S_VERSION ($ARCH)"
+# derailed/k9s release artifact naming: k9s_Linux_amd64.tar.gz / k9s_Linux_arm64.tar.gz
+curl -fsSL -o "$TMP_DL/k9s.tar.gz" \
+  "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz"
+tar -xzf "$TMP_DL/k9s.tar.gz" -C "$TMP_DL" k9s
+install -m 0755 "$TMP_DL/k9s" "$DEST/k9s"
+
+# Host needs mount.nfs (nfs-common) to mount the in-cluster nap-nfs-server svc
+# for nfs-subdir-external-provisioner. Cloud images / minimal Ubuntu installs
+# don't ship it. Fetch the deb + transitive deps from a clean Ubuntu container
+# so airgapped hosts can dpkg -i them in preinstall.sh.
+echo "==> Fetching nfs-common debs (linux/$ARCH, Ubuntu 24.04) for prep bundle"
+mkdir -p "$DEST/nfs-debs"
+DEB_TMP="$(mktemp -d)"
+trap "rm -rf $STAGING $TMP_DL $DEB_TMP" EXIT
+docker run --rm --platform "linux/$ARCH" -v "$DEB_TMP:/out" -w /out ubuntu:24.04 bash -c '
+  set -e
+  apt-get update -qq
+  pkgs=$(apt-get install -s -y --no-install-recommends nfs-common | awk "/^Inst / {print \$2}")
+  apt-get download $pkgs
+'
+mv "$DEB_TMP"/*.deb "$DEST/nfs-debs/"
+echo "==> Staged $(ls "$DEST/nfs-debs" | wc -l) nfs-common debs ($(du -sh "$DEST/nfs-debs" | cut -f1))"
+
+# --- Content fingerprint --------------------------------------------------
+# Deterministic identity of the prep bundle, independent of build time and of
+# the platform release. Derived from the inputs that actually determine content:
+#   - pinned tool versions (each version string fully determines the downloaded
+#     binary — no need to hash the bytes, which wouldn't be reproducible anyway)
+#   - sha256 of preinstall.sh (the only script we author here)
+#   - sorted nfs-debs filenames (deb names carry arch + Ubuntu version, so they
+#     shift exactly when the offline nfs-common set changes)
+# The sorted manifest is hashed; first 8 hex chars go into the filename.
+FP_MANIFEST="$(mktemp)"
+{
+  echo "arch=$ARCH"
+  echo "k3s=$K3S_VERSION"
+  echo "helm=$HELM_VERSION"
+  echo "envsubst=$ENVSUBST_VERSION"
+  echo "crane=$CRANE_VERSION"
+  echo "k9s=$K9S_VERSION"
+  echo "preinstall.sha256=$(sha256sum "$DEST/preinstall.sh" | awk '{print $1}')"
+  (cd "$DEST/nfs-debs" && ls | sed 's/^/deb:/')
+} | LC_ALL=C sort > "$FP_MANIFEST"
+FP="$(sha256sum "$FP_MANIFEST" | awk '{print $1}')"
+FP8="${FP:0:8}"
+echo "==> Prep content fingerprint: $FP8"
+
+# VERSION records the fingerprint (the real identity) + component versions.
+# built_with is informational only — the platform release this prep happened to
+# be cut alongside. It is NOT part of the fingerprint, so re-cutting prep for a
+# new platform release with unchanged inputs yields the same fp / same filename.
+cat > "$DEST/VERSION" <<EOF
+fingerprint=$FP8
+built_with=${VERSION:-unspecified}
+k3s=$K3S_VERSION
+helm=$HELM_VERSION
+envsubst=$ENVSUBST_VERSION
+crane=$CRANE_VERSION
+k9s=$K9S_VERSION
+arch=$ARCH
+EOF
+cp "$FP_MANIFEST" "$DEST/PREP_FINGERPRINT_INPUTS"
+rm -f "$FP_MANIFEST"
+
+OUT="$SCRIPT_DIR/../../nap-self-host-single-node-prep-${ARCH}-${FP8}.tar.gz"
+echo "==> Packaging $OUT"
+tar -C "$STAGING" -czf "$OUT" single-node-prep
+ls -lh "$OUT"

--- a/self-host/single-node-prep/preinstall.sh
+++ b/self-host/single-node-prep/preinstall.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Single-Node Preinstall
+# ============================================================================
+# Prepares a bare Linux host (Ubuntu 24.04+ recommended) to run the single-node
+# profile: installs k3s, drops in helm/envsubst/crane/k9s, and seeds k3s
+# containerd with the offline image tarball so install.sh can come up without
+# any external registry. NFS runs in-cluster (nap-nfs-server pod), so no NFS
+# server package is required on the host — only the mount.nfs client.
+#
+# Idempotent. Re-run after package upgrades or values.env changes.
+#
+# Bundled artifacts (siblings to this script after extraction):
+#   k3s-<arch>                          k3s binary (also symlinked as kubectl)
+#   k3s-airgap-images-<arch>.tar.gz     pause / coredns / local-path-provisioner
+#   helm / envsubst / crane             CLI tools install.sh depends on
+#   k9s                                 k8s TUI for on-host debugging
+#
+# Reads the host image bundle from:
+#   ../offline/nap-images.tar.gz        (from the main self-host tarball)
+#   or $IMAGES_ARCHIVE if set.
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+case "$(uname -m)" in
+  x86_64)        ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+log() { echo "==> $*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_root() {
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "preinstall.sh must run as root (sudo ./preinstall.sh)" >&2
+    exit 1
+  fi
+}
+
+install_k3s() {
+  if command -v k3s &>/dev/null; then
+    log "k3s already installed ($(k3s --version | head -1))"
+    return 0
+  fi
+  local bin="$SCRIPT_DIR/k3s-$ARCH"
+  local airgap="$SCRIPT_DIR/k3s-airgap-images-$ARCH.tar.gz"
+  [ -f "$bin" ] || { echo "missing $bin" >&2; exit 1; }
+  [ -f "$airgap" ] || { echo "missing $airgap" >&2; exit 1; }
+
+  log "Installing k3s binary"
+  install -m 0755 "$bin" /usr/local/bin/k3s
+
+  log "Staging k3s airgap images"
+  mkdir -p /var/lib/rancher/k3s/agent/images
+  cp "$airgap" /var/lib/rancher/k3s/agent/images/
+
+  # Disable traefik (we expose via NodePort) + servicelb (single-node, not needed).
+  log "Starting k3s server"
+  cat > /etc/systemd/system/k3s.service <<'UNIT'
+[Unit]
+Description=Lightweight Kubernetes
+After=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/k3s server --disable=traefik --disable=servicelb --write-kubeconfig-mode=644
+Restart=always
+RestartSec=5s
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Delegate=yes
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+  systemctl daemon-reload
+  systemctl enable --now k3s
+  log "Waiting for k3s API to respond ..."
+  for _ in $(seq 1 60); do
+    k3s kubectl get nodes &>/dev/null && break
+    sleep 2
+  done
+  k3s kubectl get nodes
+}
+
+install_kubectl_symlink() {
+  # k3s is multi-call: when invoked as `kubectl` it dispatches the same way as
+  # `k3s kubectl ...`. install.sh's check_prereqs requires `kubectl` on PATH;
+  # symlinking avoids shipping a separate kubectl binary.
+  local link=/usr/local/bin/kubectl
+  if [ -L "$link" ] && [ "$(readlink "$link")" = "/usr/local/bin/k3s" ]; then
+    log "kubectl symlink already in place"
+    return 0
+  fi
+  log "Linking kubectl → k3s"
+  ln -sf /usr/local/bin/k3s "$link"
+}
+
+install_bundled_bin() {
+  # install_bundled_bin <name> <version-substring>
+  # Drop bundled binary to /usr/local/bin/<name> unless an equivalent is
+  # already there (cheap idempotency check via version output).
+  local name="$1"
+  local marker="$2"
+  local src="$SCRIPT_DIR/$name"
+  local dst="/usr/local/bin/$name"
+  [ -f "$src" ] || { echo "missing bundled binary: $src" >&2; exit 1; }
+  if [ -x "$dst" ] && "$dst" --version 2>&1 | grep -q -- "$marker"; then
+    log "$name already installed at $dst ($marker)"
+    return 0
+  fi
+  log "Installing $name → $dst"
+  install -m 0755 "$src" "$dst"
+}
+
+install_cli_tools() {
+  # Versions kept in sync with package-prep.sh. The grep markers are loose on
+  # purpose — we just want to skip reinstall when the bundled version matches.
+  install_bundled_bin helm     "v3.16.4"
+  install_bundled_bin envsubst "v1.4.3"
+  install_bundled_bin crane    "0.20.2"
+  install_bundled_bin k9s      "v0.50.18"
+}
+
+import_images() {
+  local archive="${IMAGES_ARCHIVE:-}"
+  if [ -z "$archive" ]; then
+    # Default layout: prep tarball is extracted *inside* self-host/, so
+    #   $SCRIPT_DIR = .../self-host/single-node-prep
+    #   archive    = .../self-host/offline/nap-images.tar.gz
+    # Customers sometimes extract the prep tarball as a sibling of self-host/
+    # instead. Probe both before bailing.
+    for cand in \
+      "$SCRIPT_DIR/../offline/nap-images.tar.gz" \
+      "$SCRIPT_DIR/../self-host/offline/nap-images.tar.gz" \
+      "$(dirname "$SCRIPT_DIR")/self-host/offline/nap-images.tar.gz"; do
+      if [ -f "$cand" ]; then archive="$cand"; break; fi
+    done
+  fi
+  if [ ! -f "$archive" ]; then
+    die "nap-images.tar.gz not found near $SCRIPT_DIR — extract the main self-host tarball alongside single-node-prep (or set IMAGES_ARCHIVE)"
+  fi
+  log "Importing $archive into k3s containerd (primes registry:2 + 3rd-party for install.sh)"
+  k3s ctr -n k8s.io images import "$archive"
+}
+
+configure_registries() {
+  # Tell k3s containerd that the in-cluster registry NodePort speaks plain HTTP;
+  # otherwise pod-side pulls would fail the TLS handshake.
+  # NAP_HOST + REGISTRY_NODE_PORT are read from values.env (sourced below if present).
+  local values_file="${VALUES_FILE:-}"
+  if [ -z "$values_file" ]; then
+    for cand in \
+      "$SCRIPT_DIR/../values.env" \
+      "$SCRIPT_DIR/../self-host/values.env" \
+      "$(dirname "$SCRIPT_DIR")/self-host/values.env"; do
+      if [ -f "$cand" ]; then values_file="$cand"; break; fi
+    done
+  fi
+  if [ -f "$values_file" ]; then
+    set -a; source "$values_file"; set +a
+  fi
+  local host="${NAP_HOST:-}"
+  local port="${REGISTRY_NODE_PORT:-30500}"
+  if [ -z "$host" ]; then
+    log "WARNING: NAP_HOST not set in $values_file — skipping registries.yaml (re-run preinstall after editing values.env)"
+    return 0
+  fi
+  local endpoint="${host}:${port}"
+  log "Configuring k3s containerd to treat $endpoint as plain HTTP"
+  mkdir -p /etc/rancher/k3s
+  cat > /etc/rancher/k3s/registries.yaml <<YAML
+mirrors:
+  "${endpoint}":
+    endpoint:
+      - "http://${endpoint}"
+YAML
+  if systemctl is-active --quiet k3s; then
+    systemctl restart k3s
+    for _ in $(seq 1 30); do
+      k3s kubectl get nodes &>/dev/null && break
+      sleep 2
+    done
+  fi
+
+  # k3s auto-generates hosts.toml with the HTTP host limited to `pull, resolve`.
+  # Push falls back to the HTTPS `server` field which our registry doesn't
+  # serve → ctr push hangs on the TLS handshake. Override the file so the HTTP
+  # endpoint also carries the `push` capability. K3s only regenerates this on
+  # restart; we don't restart k3s during install.sh, so the override sticks.
+  local hosts_dir="/var/lib/rancher/k3s/agent/etc/containerd/certs.d/${endpoint}"
+  mkdir -p "$hosts_dir"
+  cat > "$hosts_dir/hosts.toml" <<TOML
+# Override of k3s default — required so push can use plain HTTP.
+server = "http://${endpoint}/v2"
+capabilities = ["pull", "resolve", "push"]
+
+[host]
+
+[host."http://${endpoint}/v2"]
+  capabilities = ["pull", "resolve", "push"]
+TOML
+  log "Wrote $hosts_dir/hosts.toml (push capability over HTTP)"
+}
+
+check_nfs_client() {
+  # Host needs mount.nfs (from nfs-common on Debian/Ubuntu, nfs-utils on RHEL)
+  # so kubelet can mount the in-cluster nap-nfs-server svc for the
+  # nfs-subdir-external-provisioner pod. install.sh has no way to provide this
+  # post-hoc — the mount happens before the storage class is usable.
+  if [ -x /sbin/mount.nfs ] || command -v mount.nfs &>/dev/null; then
+    log "/sbin/mount.nfs present"
+    return 0
+  fi
+  local debs_dir="$SCRIPT_DIR/nfs-debs"
+  if [ -d "$debs_dir" ] && [ -n "$(ls -A "$debs_dir" 2>/dev/null)" ]; then
+    log "Installing nfs-common offline from $debs_dir"
+    # Two-pass dpkg -i tolerates ordering issues from intra-set deps. apt-get
+    # would pull in some transitional packages (python3 meta etc) whose post-
+    # install scripts are noisy in lean environments; we tolerate non-zero
+    # exit as long as /sbin/mount.nfs ends up in place (the only thing we
+    # actually need from this set).
+    dpkg -i "$debs_dir"/*.deb 2>/dev/null || true
+    dpkg -i "$debs_dir"/*.deb 2>&1 | tail -20 || true
+  elif command -v apt-get &>/dev/null; then
+    log "nfs-debs/ not staged; falling back to online apt-get install nfs-common"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nfs-common \
+      || die "apt-get install nfs-common failed — host needs offline nfs-debs/ or apt access"
+  else
+    die "mount.nfs not found, no offline nfs-debs/, no apt-get — install nfs-common / nfs-utils manually"
+  fi
+  [ -x /sbin/mount.nfs ] || die "mount.nfs still missing after package install"
+}
+
+load_nfs_modules() {
+  # Two host kernel modules are needed for in-cluster NFS:
+  #   nfsd — nap-nfs-server container mounts nfsd + rpc_pipefs at startup
+  #   nfs  — nfs-subdir provisioner / kubelet mounting the NFS export
+  # The client `nfs` module is usually autoloaded by mount.nfs, but some distros
+  # (observed on Ubuntu 24.04 / kernel 6.8, also some minimal VM templates) ship
+  # neither loaded, so load both explicitly.
+  local mod
+  for mod in nfs nfsd; do
+    if lsmod | grep -q "^${mod} "; then
+      log "$mod kernel module already loaded"
+    else
+      log "Loading $mod kernel module"
+      modprobe "$mod" || die "modprobe $mod failed — install kernel modules (e.g. apt-get install linux-modules-extra-\$(uname -r)) or run on a host whose kernel supports NFS"
+    fi
+  done
+  # Persist across reboots.
+  if [ ! -f /etc/modules-load.d/nfs.conf ] || ! grep -q '^nfsd$' /etc/modules-load.d/nfs.conf 2>/dev/null; then
+    printf 'nfs\nnfsd\n' > /etc/modules-load.d/nfs.conf
+    log "Wrote /etc/modules-load.d/nfs.conf"
+  fi
+}
+
+main() {
+  require_root
+  install_k3s
+  install_kubectl_symlink
+  install_cli_tools
+  check_nfs_client
+  load_nfs_modules
+  import_images
+  configure_registries
+  log ""
+  if [ -f /etc/rancher/k3s/registries.yaml ]; then
+    # configure_registries wrote the HTTP-mirror config (NAP_HOST was set) —
+    # everything's primed, go straight to install.
+    log "Preinstall complete. registries.yaml in place. Next:"
+    log "  cd .. && ./install.sh --profile=single-node"
+  else
+    # NAP_HOST wasn't set, so configure_registries skipped registries.yaml.
+    # install.sh's single-node preflight will reject this — fill NAP_HOST and
+    # re-run preinstall so the HTTP-mirror config gets written.
+    log "Preinstall done, but registries.yaml was NOT written — NAP_HOST is unset in values.env."
+    log "Single-node install needs it. Fill values.env FIRST, then re-run preinstall:"
+    log "  cp ../values.env.single-node.example ../values.env   # if not already"
+    log "  vi ../values.env   # set NAP_HOST (+ ADMIN_PASSWORD, secrets)"
+    log "  sudo ./preinstall.sh   # re-run; now registries.yaml picks up NAP_HOST"
+    log "  cd .. && ./install.sh --profile=single-node"
+  fi
+}
+
+main "$@"

--- a/self-host/values.env.example
+++ b/self-host/values.env.example
@@ -1,22 +1,37 @@
 # ============================================================================
-# Neutree Agent Platform — Self-Hosted Deployment Configuration (CONNECTED)
+# Neutree Agent Platform — Self-Hosted Deployment Configuration
 # ============================================================================
 # Copy this file to values.env and fill in the required values.
 #
-# This is the connected / online deployment: the cluster pulls images directly
-# from the public registry. No offline bundle, no in-cluster registry.
+# Default is a connected install: the cluster pulls images directly from the
+# public registry. For an air-gapped / offline site, point REGISTRY at your own
+# private registry (see offline/save-images.sh + offline/load-images.sh) and
+# fill in REGISTRY_USERNAME / REGISTRY_PASSWORD below if it needs a login.
 #
 # All optional modules default to OFF — set the *_ENABLED toggle to "true" to
 # enable each one.
 
 # --- Container Registry -----------------------------------------------------
-# Public registry path under which all first-party service images live as
-# sub-paths, e.g. ${REGISTRY}/nap-cp:${IMAGE_TAG}. Default is the official
-# public registry; override only if you mirror the images elsewhere.
+# Registry path under which all first-party service images live as sub-paths,
+# e.g. ${REGISTRY}/nap-cp:${IMAGE_TAG}. Defaults to the official public
+# registry. For a mirror or an air-gapped install, set this to your own
+# registry (e.g. registry.example.com/nap) after loading the image bundle into
+# it — see offline/load-images.sh.
 REGISTRY=ghcr.io/neutree-ai/agent-platform
 # Tag applied to every first-party image. Default "latest"; pin to a release
 # tag (e.g. v4.2.0) for a reproducible install.
 IMAGE_TAG=latest
+
+# Registry authentication. Leave blank for a public / anonymous registry. When
+# your registry requires a login, set all three: the installer creates a
+# `regcred` docker-registry Secret from them and attaches it as an
+# imagePullSecret to the platform ServiceAccounts (and to CNPG + spawned agent
+# pods), so no manual IMAGE_PULL_SECRET is needed.
+#   REGISTRY_SERVER — the registry HOST only (no image path), e.g.
+#                     registry.example.com — matched against REGISTRY's host.
+# REGISTRY_SERVER=
+# REGISTRY_USERNAME=
+# REGISTRY_PASSWORD=
 
 # --- Advanced: naming & third-party images ----------------------------------
 # These have sane defaults for a connected install — leave them commented out

--- a/self-host/values.env.single-node.example
+++ b/self-host/values.env.single-node.example
@@ -16,9 +16,21 @@ DEPLOY_PROFILE=single-node
 SINGLE_NODE_NFS_SIZE=100Gi
 
 # --- Container Registry -----------------------------------------------------
-# Public registry path under which all first-party service images live.
+# CONNECTED single-node: leave REGISTRY at the public default below — the node
+# pulls every image straight from the public registry.
+#
+# AIR-GAPPED single-node: an in-cluster registry (nap-registry) is brought up by
+# install.sh and seeded from offline/nap-images.tar.gz. Point REGISTRY at its
+# NodePort sub-path so workspace/agent pods pull from it, and uncomment the
+# third-party image block at the bottom of this file.
+#   REGISTRY=${NAP_HOST}:${REGISTRY_NODE_PORT}/nap
 REGISTRY=ghcr.io/neutree-ai/agent-platform
 IMAGE_TAG=latest
+
+# In-cluster registry (air-gapped single-node only; ignored when connected).
+# NodePort the host + containerd reach the registry on, and the backing PVC size.
+REGISTRY_NODE_PORT=30500
+REGISTRY_STORAGE_SIZE=20Gi
 
 # --- Cluster & Access -------------------------------------------------------
 NAMESPACE=nap
@@ -97,3 +109,24 @@ LDAP_ATTR_USERNAME=
 LDAP_ATTR_NAME=
 LDAP_ATTR_EMAIL=
 LDAP_SEARCH_BASE=
+
+# ============================================================================
+# Air-gapped single-node only — third-party images.
+# ============================================================================
+# NOT needed for a connected install: leave this whole block commented and the
+# defaults pull each image from its public upstream.
+#
+# For an offline site, offline/load-images.sh (or the in-cluster registry seed)
+# mirrors every third-party image under ${REGISTRY}/<short>. Set REGISTRY above
+# to your in-cluster registry sub-path, then uncomment these so pods pull the
+# mirrored copies instead of the unreachable upstreams. load-images.sh prints
+# this exact list at the end of its run.
+# POSTGRES_IMAGE=${REGISTRY}/cloudnative-pg-postgresql:16
+# GOTENBERG_IMAGE=${REGISTRY}/gotenberg:8
+# COTURN_IMAGE=${REGISTRY}/coturn:4.6
+# NFS_SERVER_IMAGE=${REGISTRY}/nfs-server:2.2.3
+# RUNTIME_NODE_IMAGE=${REGISTRY}/node:22-bookworm
+# RUNTIME_PYTHON_IMAGE=${REGISTRY}/python:3.12-bookworm
+# RUNTIME_GOLANG_IMAGE=${REGISTRY}/golang:1.23
+# PAUSE_IMAGE=${REGISTRY}/pause:3.9
+# AFS_IMAGE=${REGISTRY}/afs:latest


### PR DESCRIPTION
## Summary

Grows the connected-only self-host installer into one that serves **both connected and air-gapped sites from a single `./install.sh`**, gated on whether an offline image bundle is present. Connected stays the default and every connected-path behavior is unchanged — the offline path only activates when the bundle / prereq charts are staged.

## Tooling

- **`install.sh`** — derives a `regcred` imagePullSecret from `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` and attaches it to the platform ServiceAccounts, CNPG, coturn, and the workspace pods control-plane spawns. Applies the offline CNPG/NFS prereq bundles and re-points their images at `${REGISTRY}` when present. Adds `single_node_load_registry()` — brings up an in-cluster registry and seeds it from the bundle for single-node air-gapped installs.
- **`offline/save-images.sh`** — builds the image bundle on a connected host. The image list is **derived from the rendered manifests** (authoritative, can't drift) plus a small supplement for images not on an `image:` line (agent images, memory-fuse, CNPG operator, NFS provisioner).
- **`offline/load-images.sh`** — loads, retags, and pushes the bundle into a private registry, then prints the exact `values.env` `REGISTRY=` / `*_IMAGE=` overrides to paste.
- **`manifests/registry.yaml`**, **`single-node-prep/{preinstall,package-prep}.sh`** — in-cluster `registry:2` manifest + single-node host prep (k3s, containerd plain-HTTP mirror, image import).
- **`values.env.example`**, **`values.env.single-node.example`** — registry auth + in-cluster registry knobs.

## Docs

- The `/self-host/` page is reframed **connected-first**, with inline "Air-gapped" addendum callouts only at the few steps where the image source actually differs (no whole-page offline reframe).
- `ValuesGenerator` gains an optional **Private registry auth** section (`REGISTRY_SERVER` / `USERNAME` / `PASSWORD`).
- The single-node page documents the air-gapped path (in-cluster registry seeded from the bundle).
- en + zh-CN throughout.

## Verification

- `bash -n` clean on all scripts; `install.sh --render-only` (single-node) renders `registry.yaml` with no leftover tokens.
- `astro build` succeeds; `tsc` adds zero new type errors.
- Naming hygiene: no `tos` / `smtx` / internal identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)