### PR TITLE
feat(self-host): make offline image tooling APP_PREFIX-aware

### DIFF
--- a/docs-site/src/components/self-host/SelfHostShell.tsx
+++ b/docs-site/src/components/self-host/SelfHostShell.tsx
@@ -344,6 +344,7 @@ const PANEL_STR = {
     inSingleNote: <>Run this on a host that has a working k3s with its kubeconfig at <code>/etc/rancher/k3s/k3s.yaml</code> (the default in the single-node example).</>,
     inOfflineH2: 'Air-gapped: build the image bundle',
     inOfflineP: <>On a connected host, <code>./offline/save-images.sh</code> pulls every first-party and prerequisite image and writes <code>offline/nap-images.tar.gz</code> plus the prereq charts under <code>prereqs/</code>. Move that to the air-gapped side and load it with <code>./offline/load-images.sh --registry &lt;your-registry&gt;</code> (add <code>--insecure-registry</code> for a plain-HTTP registry) — it pushes every image into your registry and prints the <code>values.env</code> overrides to paste. Set those, then <code>./install.sh</code> runs exactly as it does online — it auto-detects the offline prereq bundles and wires the pull secret from <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code>. If a vendor delivered a prebuilt bundle, skip <code>save-images</code> and start at <code>load-images</code>. For a single machine with no external registry, use the <a href="/self-host/single-node/">single-node profile</a> instead.</>,
+    inAppPrefixNote: <><strong>Naming.</strong> Every first-party image carries the <code>values.env</code> <code>APP_PREFIX</code> (default <code>nap</code>, as in <code>nap-cp</code>). A rebranded or migrated deployment that kept a different prefix sets it in <code>values.env</code>; build the bundle with that file, and run <code>load-images.sh --app-prefix &lt;prefix&gt;</code> so it finds and pushes the prefixed images. Never change <code>APP_PREFIX</code> on an existing install — it would rebuild every object under new names.</>,
     // Upgrade
     upPathH2: 'Upgrade',
     upPathP1: <>Upgrading is the same command as a first install. Pin <code>IMAGE_TAG</code> to the new release tag (or keep <code>latest</code>) in your existing <code>values.env</code>, then re-run:</>,
@@ -502,6 +503,7 @@ const PANEL_STR = {
     inSingleNote: <>在一台已经跑好 k3s、kubeconfig 位于 <code>/etc/rancher/k3s/k3s.yaml</code>（single-node 示例中的默认值）的主机上运行。</>,
     inOfflineH2: '隔离网络：构建镜像包',
     inOfflineP: <>在一台联网机器上，<code>./offline/save-images.sh</code> 会拉取全部第一方与前置镜像，产出 <code>offline/nap-images.tar.gz</code> 以及 <code>prereqs/</code> 下的前置 chart。把它拷到隔离侧，用 <code>./offline/load-images.sh --registry &lt;你的仓库&gt;</code> 加载（纯 HTTP 仓库加 <code>--insecure-registry</code>）—— 它会把所有镜像推入你的仓库并打印出需要粘贴的 <code>values.env</code> 覆盖项。设好之后，<code>./install.sh</code> 的运行方式与联网时完全一致 —— 它会自动识别离线前置包，并据 <code>REGISTRY_USERNAME</code> / <code>REGISTRY_PASSWORD</code> 接好 pull secret。若厂商已交付预构建镜像包，跳过 <code>save-images</code>，直接从 <code>load-images</code> 开始。若是单台机器、没有外部仓库，改用 <a href="/self-host/single-node/">单节点 profile</a>。</>,
+    inAppPrefixNote: <><strong>命名</strong>：每个第一方镜像都带 <code>values.env</code> 里的 <code>APP_PREFIX</code>（默认 <code>nap</code>，即 <code>nap-cp</code>）。经过 rebrand 或迁移、沿用其他前缀的部署，在 <code>values.env</code> 里设好它；用该文件构建镜像包，并以 <code>load-images.sh --app-prefix &lt;前缀&gt;</code> 加载，脚本才能找到并推送带前缀的镜像。现有部署<strong>切勿</strong>修改 <code>APP_PREFIX</code> —— 会把所有对象按新名重建。</>,
     // Upgrade
     upPathH2: '升级',
     upPathP1: <>升级与首次安装用的是同一条命令。在现有 <code>values.env</code> 里把 <code>IMAGE_TAG</code> 固定到新的发布 tag（或保持 <code>latest</code>），然后重新运行：</>,
@@ -843,6 +845,7 @@ vi values.env                 # set NAP_HOST + ADMIN_PASSWORD
       <section>
         <h2 id="offline">{t.inOfflineH2}</h2>
         <p class="sh-muted">{t.inOfflineP}</p>
+        <p class="sh-muted">{t.inAppPrefixNote}</p>
       </section>
     </div>
   )

--- a/self-host/offline/load-images.sh
+++ b/self-host/offline/load-images.sh
@@ -31,20 +31,29 @@ fi
 ARCHIVE=""
 TARGET_REGISTRY=""
 INSECURE=false
+# First-party object/image prefix the bundle was built with (values.env
+# APP_PREFIX). Only used to locate the first-party source registry in the loaded
+# images; a deployment built with a non-default prefix passes --app-prefix
+# <prefix> to match.
+APP_PREFIX="${APP_PREFIX:-nap}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --registry)           TARGET_REGISTRY="$2"; shift 2 ;;
     --archive)            ARCHIVE="$2"; shift 2 ;;
+    --app-prefix)         APP_PREFIX="$2"; shift 2 ;;
     --insecure-registry)  INSECURE=true; shift ;;
     *)                    echo "Unknown option: $1"; exit 1 ;;
   esac
 done
 
 if [ -z "$TARGET_REGISTRY" ] || [ -z "$ARCHIVE" ]; then
-  echo "Usage: $0 --registry <target-registry> --archive <tar-file> [--insecure-registry]"
+  echo "Usage: $0 --registry <target-registry> --archive <tar-file> [--app-prefix <prefix>] [--insecure-registry]"
   echo ""
-  echo "  --insecure-registry  push over plain HTTP (registry without TLS)"
+  echo "  --app-prefix <prefix>  first-party image prefix (default: nap). Set this"
+  echo "                         to the values.env APP_PREFIX the bundle was built"
+  echo "                         with, if it was not the default."
+  echo "  --insecure-registry    push over plain HTTP (registry without TLS)"
   echo ""
   echo "Example:"
   echo "  $0 --registry registry.example.com/nap --archive nap-images.tar.gz"
@@ -115,48 +124,37 @@ retag_push() {
 }
 
 # --- First-party images -----------------------------------------------------
-# All under one source registry. Derive it from the loaded */nap-cp image and
-# exclude the target registry: a previous (possibly failed) run leaves retagged
-# ${TARGET_REGISTRY}/nap-cp images in the local store, and matching one of those
-# would make every other first-party image resolve to a nonexistent source tag.
+# Every first-party image (services + agents + chromium-headful) lives under one
+# source registry — the values.env REGISTRY the bundle was built with. Derive it
+# from the loaded ${APP_PREFIX}-cp image (cp is always present, whatever the
+# prefix), excluding the target registry: a previous (possibly failed) run
+# leaves retagged ${TARGET_REGISTRY}/... images in the local store, and matching
+# one of those would point the sweep at the wrong registry.
 SOURCE_REGISTRY=$("$CONTAINER_CLI" images --format '{{.Repository}}' \
-  | grep '/nap-cp$' \
+  | grep -E "/${APP_PREFIX}-cp$" \
   | grep -vF "${TARGET_REGISTRY}/" \
-  | head -1 | sed 's|/nap-cp$||')
+  | head -1 | sed "s|/${APP_PREFIX}-cp$||")
 
 if [ -z "$SOURCE_REGISTRY" ]; then
-  echo "ERROR: could not determine source registry — no nap-cp image found" >&2
-  echo "       in the archive. Is $ARCHIVE the correct image bundle?" >&2
+  echo "ERROR: could not find a '${APP_PREFIX}-cp' image in the loaded bundle." >&2
+  echo "       Is $ARCHIVE the correct bundle, and does its APP_PREFIX match?" >&2
+  echo "       Pass --app-prefix <prefix> if the bundle used a non-default one." >&2
   exit 1
 fi
-echo "==> Source registry: $SOURCE_REGISTRY"
+echo "==> Source registry: $SOURCE_REGISTRY  (app-prefix: $APP_PREFIX)"
 
-# First-party service + agent images live under ${SOURCE_REGISTRY}/<short>.
-# chromium-headful shares the same registry; afs ships from its own repo and is
-# handled in the third-party list below.
-FIRST_PARTY_NAMES=(
-  nap-cp
-  nap-cg
-  nap-scheduler
-  nap-browser
-  nap-sandbox
-  nap-skills-content-service
-  nap-env-runner-k8s
-  nap-memory-fuse
-  chromium-headful
-  nap-agent-claude-code
-  nap-agent-codex
-)
-
+# Push EVERY image under ${SOURCE_REGISTRY}/ — services, agents, chromium-headful,
+# and any future first-party image — to ${TARGET_REGISTRY}/<basename>. Deriving
+# the set from the loaded images (rather than a hard-coded list) keeps it correct
+# across app-prefix changes and as first-party images are added. afs ships from
+# its own repo (ghcr.io/neutree-ai/afs), so it's a third-party entry below.
 echo "==> Retagging and pushing first-party images to ${TARGET_REGISTRY} ..."
-for name in "${FIRST_PARTY_NAMES[@]}"; do
-  # Find whatever tag was bundled for this repo (latest, a release tag, ...).
-  while IFS= read -r local_ref; do
-    [ -n "$local_ref" ] || continue
-    retag_push "$local_ref"
-  done < <("$CONTAINER_CLI" images --format '{{.Repository}}:{{.Tag}}' \
-             | grep -E "^${SOURCE_REGISTRY}/${name}:")
-done
+while IFS= read -r local_ref; do
+  [ -n "$local_ref" ] || continue
+  case "$local_ref" in
+    "${SOURCE_REGISTRY}/"*) retag_push "$local_ref" ;;
+  esac
+done < <("$CONTAINER_CLI" images --format '{{.Repository}}:{{.Tag}}')
 
 # --- Third-party images -----------------------------------------------------
 # Absolute source refs (their registries differ from SOURCE_REGISTRY). registry:2
@@ -189,6 +187,7 @@ echo "==========================================================================
 echo "Paste these into your values.env (uncomment the third-party block):"
 echo "============================================================================"
 echo "REGISTRY=${TARGET_REGISTRY}"
+[ "$APP_PREFIX" != "nap" ] && echo "APP_PREFIX=${APP_PREFIX}"
 echo "POSTGRES_IMAGE=${TARGET_REGISTRY}/cloudnative-pg-postgresql:16"
 echo "GOTENBERG_IMAGE=${TARGET_REGISTRY}/gotenberg:8"
 echo "COTURN_IMAGE=${TARGET_REGISTRY}/coturn:4.6"

--- a/self-host/offline/save-images.sh
+++ b/self-host/offline/save-images.sh
@@ -22,6 +22,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SELF_HOST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RENDERED_DIR="$SELF_HOST_DIR/rendered"
 
+# Load values.env so REGISTRY / APP_PREFIX / IMAGE_TAG below match what the
+# render (install.sh --render-only, which sources the same file) resolves —
+# a deployment with a non-default APP_PREFIX bundles its own prefixed images
+# instead of the nap-* defaults, and the supplement stays in lockstep with the
+# rendered set.
+VALUES_FILE="${VALUES_FILE:-$SELF_HOST_DIR/values.env}"
+if [ -f "$VALUES_FILE" ]; then
+  set -a; source "$VALUES_FILE"; set +a
+fi
+
 OUTPUT="${OUTPUT:-$SCRIPT_DIR/nap-images.tar.gz}"
 
 # First-party image coordinates. Defaults match install.sh; the render below is


### PR DESCRIPTION
## Summary

Follow-up to #133. The offline image scripts hard-coded the default `nap-` first-party prefix, so a deployment built with a non-default `APP_PREFIX` (a rebrand or a migrated install) couldn't save/load its bundle — `load-images.sh` anchored source-registry detection on `nap-cp` and pushed a hard-coded `nap-*` list. `APP_PREFIX` already parameterizes first-party object and image names; the offline path now honors it end to end.

## Changes

- **`load-images.sh`** — adds `--app-prefix` (default `nap`). Detects the source registry from the `${APP_PREFIX}-cp` image and then pushes **every** image found under that registry, derived from the loaded set rather than a hard-coded list — so it's both prefix-agnostic and drift-proof as first-party images are added (this also subsumes the earlier `memory-fuse`-was-missing class of bug). Emits `APP_PREFIX=` in the printed `values.env` hint when non-default.
- **`save-images.sh`** — sources `values.env` so the supplement's `REGISTRY` / `APP_PREFIX` / `IMAGE_TAG` match what `install.sh --render-only` resolves. Without this, a non-default prefix would render prefixed first-party images but supplement the `nap-*` agent/memory-fuse images.
- **docs** — surfaces `APP_PREFIX` as the naming / compatibility knob in the air-gap section of the self-host page (en + zh-CN), including the "never change it on an existing install" caveat.

## Verification

- `bash -n` clean on both scripts; `astro build` succeeds.
- Naming hygiene: no `tos` / `smtx` / internal identifiers (the compat example is neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)