### PR TITLE
fix(stats): populate matviews non-concurrently on first refresh

### DIFF
--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -333,8 +333,19 @@ function refreshUserDailyInteractions(): void {
   const now = Date.now()
   if (now - lastUserDailyRefresh < 10 * 60 * 1000) return
   lastUserDailyRefresh = now
+  // CONCURRENTLY only once populated: the base schema creates this matview
+  // `WITH NO DATA`, and Postgres rejects `REFRESH ... CONCURRENTLY` on a
+  // never-populated matview — so the first refresh must be plain or it stays
+  // empty forever and reads error with "has not been populated". Mirrors the
+  // guard in scheduler/src/db.ts refreshMatview().
   pool
-    .query('REFRESH MATERIALIZED VIEW CONCURRENTLY user_daily_interactions')
+    .query<{ ispopulated: boolean }>(
+      "SELECT ispopulated FROM pg_matviews WHERE matviewname = 'user_daily_interactions'",
+    )
+    .then((r) => {
+      const concurrently = r.rows[0]?.ispopulated === true ? 'CONCURRENTLY ' : ''
+      return pool.query(`REFRESH MATERIALIZED VIEW ${concurrently}user_daily_interactions`)
+    })
     .catch((e) => console.error('[Stats] user_daily_interactions refresh failed:', e))
 }
 

--- a/scheduler/src/db.ts
+++ b/scheduler/src/db.ts
@@ -334,11 +334,29 @@ export async function cleanupOldThreadSessions(olderThanDays = 7): Promise<numbe
  * lock footprint predictable.
  */
 export async function refreshAdminMatviews(): Promise<void> {
-  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_workspace_stats')
-  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_daily_stats')
-  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_user_stats')
-  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_workspace_stats')
-  await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY admin_token_daily_stats')
+  await refreshMatview('admin_workspace_stats')
+  await refreshMatview('admin_daily_stats')
+  await refreshMatview('admin_token_user_stats')
+  await refreshMatview('admin_token_workspace_stats')
+  await refreshMatview('admin_token_daily_stats')
+}
+
+/**
+ * Refresh one matview, using CONCURRENTLY only once it has been populated.
+ * The base schema creates these matviews `WITH NO DATA`, and Postgres rejects
+ * `REFRESH MATERIALIZED VIEW CONCURRENTLY` on a never-populated matview — so on
+ * a fresh install the first refresh must be plain, or the view stays empty
+ * forever and every read errors with "has not been populated". Once populated,
+ * CONCURRENTLY keeps the dashboard readable during the rebuild. `name` comes
+ * from the fixed caller list above, never user input — safe to interpolate.
+ */
+async function refreshMatview(name: string): Promise<void> {
+  const { rows } = await pool.query<{ ispopulated: boolean }>(
+    'SELECT ispopulated FROM pg_matviews WHERE matviewname = $1',
+    [name],
+  )
+  const concurrently = rows[0]?.ispopulated === true ? 'CONCURRENTLY ' : ''
+  await pool.query(`REFRESH MATERIALIZED VIEW ${concurrently}${name}`)
 }
 
 // --- Session Title Generation ---


### PR DESCRIPTION
## Problem

On a **fresh install**, every Stats endpoint errors with e.g. `{"error":"materialized view \"user_daily_interactions\" has not been populated"}` / `admin_workspace_stats`.

Root cause: the six stats matviews (`admin_workspace_stats`, `admin_daily_stats`, `admin_token_user_stats`, `admin_token_workspace_stats`, `admin_token_daily_stats`, `user_daily_interactions`) are created `WITH NO DATA` in the base schema, but **every refresh path used `REFRESH MATERIALIZED VIEW CONCURRENTLY`**. Postgres rejects `CONCURRENTLY` on a never-populated matview, so the first refresh always failed (the error was caught and only logged) → the views stayed empty forever → every read errored.

Verified on a fresh single-node install: `SELECT matviewname, ispopulated FROM pg_matviews` shows all six `ispopulated = f`.

## Fix

Guard each refresh: check `pg_matviews.ispopulated` and use `CONCURRENTLY` only once the view has data; the first refresh runs plain to populate it. Applied at both refresh sites:
- `control-plane/src/services/db/sessions.ts` — `user_daily_interactions`
- `scheduler/src/db.ts` — the five `admin_*` views (new `refreshMatview` helper)

Matview names are fixed literals from the caller lists, never user input.

**Self-heals** existing unpopulated installs on the next refresh tick — no manual `REFRESH` or migration needed.

## Test

- `tsc --noEmit` clean in both `control-plane` and `scheduler`.
- Manual: on a fresh DB, the first `getUserActivitySummary` / admin-stats-refresh tick now populates the views (plain refresh); subsequent ticks go `CONCURRENTLY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)