### PR TITLE
fix(mcp): derive platform MCP catalog URL from CP_SERVICE_URL

### DIFF
--- a/control-plane/scripts/seed-mcp-catalog-core.ts
+++ b/control-plane/scripts/seed-mcp-catalog-core.ts
@@ -6,11 +6,17 @@ import { upsertMcpCatalogEntry } from '../src/services/db/mcp-catalog'
  */
 import { initDb, pool } from '../src/services/db/pool'
 
+// The platform MCP server is control-plane's own /mcp endpoint. Derive its host
+// from CP_SERVICE_URL (same env the deployment injects, prefix-aware) so the
+// catalog URL resolves on installs where APP_PREFIX != "nap" (Service is
+// `<prefix>-cp`, not `nap-cp`). Falls back to the default-prefix host.
+const CP_SERVICE_URL = process.env.CP_SERVICE_URL || 'http://nap-cp:3000'
+
 const SEED: Record<string, Parameters<typeof upsertMcpCatalogEntry>[1]> = {
   'tos-platform': {
     label: 'Platform',
     description: 'Memory read/write, cross-workspace agent calls',
-    url: 'http://nap-cp:3000/mcp',
+    url: `${CP_SERVICE_URL}/mcp`,
     saas_url: null,
     group: 'Core',
     ui_panel: null,

--- a/self-host/manifests/seed-mcp-job.yaml
+++ b/self-host/manifests/seed-mcp-job.yaml
@@ -20,3 +20,8 @@ spec:
                   key: password
             - name: DATABASE_URL
               value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+            # Prefix-aware host for the platform MCP catalog URL. Without it the
+            # seed writes http://nap-cp:3000/mcp, which only resolves when
+            # APP_PREFIX is "nap". Keep in sync with control-plane.yaml.
+            - name: CP_SERVICE_URL
+              value: "http://${APP_PREFIX}-cp:3000"

--- a/web/src/components/workspace/ConfigFormFields.tsx
+++ b/web/src/components/workspace/ConfigFormFields.tsx
@@ -78,11 +78,12 @@ export const INITIAL_CONFIG_VALUES: ConfigFormValues = {
   model: '',
   small_model: '',
   prompt_id: '',
-  mcp_config: JSON.stringify({
-    mcpServers: {
-      'tos-platform': { type: 'http', url: 'http://nap-cp:3000/mcp' },
-    },
-  }),
+  // Start with no MCP servers pre-baked. The platform ("tos-platform") server
+  // is a `required` catalog entry, so the MCP editor force-enables it and
+  // writes its URL from the backend catalog (prefix-aware) — hardcoding the
+  // host here would bake a non-default-APP_PREFIX-incompatible `nap-cp` URL
+  // into the web bundle, which can't be overridden at runtime.
+  mcp_config: JSON.stringify({ mcpServers: {} }),
   agent_settings: defaultAgentSettings('claude-code'),
   compute_resources: { ...DEFAULTS },
   skill_ids: [],


### PR DESCRIPTION
## Problem

`#136` — the platform MCP server host was hardcoded as `nap-cp` in two places. On a deployment with a non-default `APP_PREFIX` (Service is `<prefix>-cp`), this host does not resolve, and the workspace config UI shows **Platform MCP (Core / Required) unreachable** (discover ping → 502).

The discover indicator resolves the origin from the **backend `mcp_catalog` entry** (`McpConfigEditor` pings `catalog.servers[*].url`), so the reported symptom is driven by the seeded catalog URL — not by the stored `mcp_config`.

## Changes

- **`control-plane/scripts/seed-mcp-catalog-core.ts`** — derive the `tos-platform` catalog URL from `CP_SERVICE_URL` (prefix-aware, env-overridable), mirroring the pattern already used by `internal/k8s-provider/config.ts`. Falls back to `http://nap-cp:3000` for the default prefix.
- **`self-host/manifests/seed-mcp-job.yaml`** — inject `CP_SERVICE_URL` into the seed Job, same value (`http://${APP_PREFIX}-cp:3000`) the control-plane deployment already uses.
- **`web/src/components/workspace/ConfigFormFields.tsx`** — stop baking the `nap-cp` platform server into `INITIAL_CONFIG_VALUES`. The web bundle is built once and can't be overridden at runtime; since `tos-platform` is a `required` catalog entry, the MCP editor force-enables it and writes the URL from the (now prefix-aware) backend catalog. Agent-side platform MCP is wired by the sidecar regardless, so this entry is display/default-only.

## Notes

- Existing workspaces on non-default-prefix installs keep the stale `nap-cp` URL in their **stored** `mcp_config`, but this is cosmetic: the agent gets platform MCP from the sidecar, and the discover indicator reads the catalog, not stored config. A data migration to rewrite old rows was considered unnecessary.

## Verification

- `tsc --noEmit` clean in both `web/` and `control-plane/`.

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)