### PR TITLE
agents: resolve gh CLI version via releases redirect, not api.github.com

### DIFF
--- a/agents/claude-code/Dockerfile
+++ b/agents/claude-code/Dockerfile
@@ -60,8 +60,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Ret
 RUN curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
     | tar xz -C /usr/local/bin gog
 
-# gh CLI (latest)
-RUN GH_VER=$(curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name|ltrimstr("v")') \
+# gh CLI (latest) — resolve the version from the releases-page redirect
+# instead of api.github.com, whose anonymous rate limit 403s on shared IPs.
+RUN GH_VER=$(curl -fsSLI --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{url_effective}' https://github.com/cli/cli/releases/latest | sed 's|.*/tag/v||') \
     && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
     | tar xz --strip-components=1 -C /usr/local
 

--- a/agents/codex/Dockerfile
+++ b/agents/codex/Dockerfile
@@ -64,8 +64,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Ret
 RUN curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${TARGETARCH}.tar.gz \
     | tar xz -C /usr/local/bin gog
 
-# gh CLI (latest)
-RUN GH_VER=$(curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name|ltrimstr("v")') \
+# gh CLI (latest) — resolve the version from the releases-page redirect
+# instead of api.github.com, whose anonymous rate limit 403s on shared IPs.
+RUN GH_VER=$(curl -fsSLI --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{url_effective}' https://github.com/cli/cli/releases/latest | sed 's|.*/tag/v||') \
     && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/cli/cli/releases/latest/download/gh_${GH_VER}_linux_${TARGETARCH}.tar.gz \
     | tar xz --strip-components=1 -C /usr/local
 


### PR DESCRIPTION
## Problem

The `claude-code` and `codex` agent images install the `gh` CLI by first calling `api.github.com/repos/cli/cli/releases/latest` to read the latest version. That endpoint's anonymous rate limit (60 requests/hour/IP) returns **403** on shared build-host IPs. When it does, `GH_VER` comes back empty, the subsequent release-asset URL becomes `gh__linux_<arch>.tar.gz`, which **404s**, and the image build fails.

This surfaces when building both agents back-to-back on one host: the first run exhausts the anonymous quota, the second 403s.

## Fix

Resolve the version from the releases-page redirect (`.../releases/latest` → `.../tag/vX.Y.Z`) via a `HEAD` request, which is not rate-limited. The `goose` image already does exactly this — this brings `claude-code` and `codex` in line.

## Test

Verified on a build host whose IP was already 403-blocked on `api.github.com`: `GH_VER` resolves to the current version and the gh asset download proceeds (302 → 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)