### PR TITLE
c2: k8s-provider auto-scaling (StatefulSet) form

### DIFF
--- a/control-plane/src/services/__snapshots__/k8s-deployment-spec.test.ts.snap
+++ b/control-plane/src/services/__snapshots__/k8s-deployment-spec.test.ts.snap
@@ -776,3 +776,129 @@ exports[`buildDeploymentSpec golden master > minimal: afs off, memory off, no no
   },
 }
 `;
+
+exports[`buildStatefulSetSpec > golden master: shared RWX PVC, headless serviceName, parallel mgmt, N replicas 1`] = `
+{
+  "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "annotations": {
+      "agent-platform/workspace-version": "6",
+    },
+    "labels": {
+      "app": "nap",
+      "component": "workspace",
+      "workspace-id": "ws1",
+    },
+    "name": "nap-ws1",
+  },
+  "spec": {
+    "podManagementPolicy": "Parallel",
+    "replicas": 3,
+    "selector": {
+      "matchLabels": {
+        "app": "nap",
+        "component": "workspace",
+        "workspace-id": "ws1",
+      },
+    },
+    "serviceName": "nap-ws1-hl",
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nap",
+          "component": "workspace",
+          "workspace-id": "ws1",
+        },
+      },
+      "spec": {
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "WORKSPACE_DIR",
+                "value": "/workspace",
+              },
+              {
+                "name": "CP_URL",
+                "value": "http://nap-cp:3000",
+              },
+              {
+                "name": "WORKSPACE_ID",
+                "value": "ws1",
+              },
+            ],
+            "image": "nap-agent-claude-code:latest",
+            "livenessProbe": {
+              "failureThreshold": 6,
+              "httpGet": {
+                "path": "/health",
+                "port": 3001,
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 30,
+              "timeoutSeconds": 5,
+            },
+            "name": "agent",
+            "ports": [
+              {
+                "containerPort": 3001,
+                "name": "http",
+              },
+            ],
+            "readinessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/health",
+                "port": 3001,
+              },
+              "initialDelaySeconds": 3,
+              "periodSeconds": 10,
+              "timeoutSeconds": 3,
+            },
+            "resources": {
+              "limits": {
+                "cpu": "500m",
+                "memory": "1Gi",
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "256Mi",
+              },
+            },
+            "startupProbe": {
+              "failureThreshold": 120,
+              "httpGet": {
+                "path": "/health",
+                "port": 3001,
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 5,
+              "timeoutSeconds": 3,
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/workspace",
+                "name": "workspace",
+              },
+            ],
+          },
+        ],
+        "nodeSelector": undefined,
+        "securityContext": {
+          "fsGroup": 1000,
+          "fsGroupChangePolicy": "OnRootMismatch",
+        },
+        "volumes": [
+          {
+            "name": "workspace",
+            "persistentVolumeClaim": {
+              "claimName": "nap-ws1-workspace",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+`;

--- a/control-plane/src/services/env-runner-reconcile.test.ts
+++ b/control-plane/src/services/env-runner-reconcile.test.ts
@@ -285,6 +285,28 @@ describe('reconcileOnce decision table', () => {
     expect(result).toMatchObject({ acted: 0, noop: 1, failed: 0 })
   })
 
+  it('converged auto-scaling (running/running) → writeObserved refreshes the ready-replica set every pass', async () => {
+    // A phase-only gate would let readyReplicaIds go stale: pods die/recover and
+    // scale-up readiness fills in while phase stays 'running'. An observation
+    // carrying readyReplicaIds must be recorded even when phase is unchanged.
+    const provider = new FakeProvider({
+      observeAll: new Map([
+        ['ws1', { phase: 'running', endpoint: { readyReplicaIds: [0, 2], desiredReplicas: 3 } }],
+      ]),
+    })
+    const transport = new FakeTransport([
+      placement({ desired_phase: 'running', observed_phase: 'running' }),
+    ])
+
+    const result = await reconcileOnce(provider, transport)
+
+    expect(provider.count('apply')).toBe(0)
+    expect(transport.count('writeObserved')).toBe(1)
+    expect(transport.writes()[0].endpoint).toEqual({ readyReplicaIds: [0, 2], desiredReplicas: 3 })
+    // Still a no-op action (no mutation) — the write only refreshes observed state.
+    expect(result).toMatchObject({ acted: 0, noop: 1, failed: 0 })
+  })
+
   it('observeAll present → used once, provider.observe never called; placement absent from map treated as phase unknown', async () => {
     // wsA converged/running (present in the batch map, no post-action re-observe);
     // wsB absent from the map → must be treated as 'unknown'. If it were treated

--- a/control-plane/src/services/env-runner-reconcile.test.ts
+++ b/control-plane/src/services/env-runner-reconcile.test.ts
@@ -290,9 +290,7 @@ describe('reconcileOnce decision table', () => {
     // scale-up readiness fills in while phase stays 'running'. An observation
     // carrying readyReplicaIds must be recorded even when phase is unchanged.
     const provider = new FakeProvider({
-      observeAll: new Map([
-        ['ws1', { phase: 'running', endpoint: { readyReplicaIds: [0, 2], desiredReplicas: 3 } }],
-      ]),
+      observeAll: new Map([['ws1', { phase: 'running', endpoint: { readyReplicaIds: [0, 2] } }]]),
     })
     const transport = new FakeTransport([
       placement({ desired_phase: 'running', observed_phase: 'running' }),
@@ -302,7 +300,7 @@ describe('reconcileOnce decision table', () => {
 
     expect(provider.count('apply')).toBe(0)
     expect(transport.count('writeObserved')).toBe(1)
-    expect(transport.writes()[0].endpoint).toEqual({ readyReplicaIds: [0, 2], desiredReplicas: 3 })
+    expect(transport.writes()[0].endpoint).toEqual({ readyReplicaIds: [0, 2] })
     // Still a no-op action (no mutation) — the write only refreshes observed state.
     expect(result).toMatchObject({ acted: 0, noop: 1, failed: 0 })
   })

--- a/control-plane/src/services/k8s-deployment-spec.test.ts
+++ b/control-plane/src/services/k8s-deployment-spec.test.ts
@@ -1,6 +1,12 @@
 import type * as k8s from '@kubernetes/client-node'
 import { describe, expect, it } from 'vitest'
-import { buildWorkspacePodTemplate } from '../../../internal/k8s-provider'
+import {
+  buildHeadlessServiceSpec,
+  buildStatefulSetSpec,
+  buildWorkspacePodTemplate,
+  readyReplicaIdsFromPods,
+  resolveStatefulSetStatus,
+} from '../../../internal/k8s-provider'
 import type { ComputeResources } from '../../../internal/types/api'
 import {
   type K8sConfig,
@@ -25,6 +31,7 @@ const baseCfg: K8sConfig = {
   workspaceStorageSize: '10Gi',
   cpServiceUrl: 'http://nap-cp:3000',
   memoryFuseImage: '',
+  multiReplica: false,
   afs: {
     enabled: false,
     image: '',
@@ -186,5 +193,104 @@ describe('deploymentTemplateVersion', () => {
 
   it('unparseable annotation → null', () => {
     expect(deploymentTemplateVersion(dep({ annotations: { [ANNOTATION]: 'v6' } }))).toBeNull()
+  })
+})
+
+describe('buildStatefulSetSpec', () => {
+  it('golden master: shared RWX PVC, headless serviceName, parallel mgmt, N replicas', () => {
+    expect(buildStatefulSetSpec(...args, 3, undefined, baseCfg)).toMatchSnapshot()
+  })
+
+  it('embeds the same pod template as the Deployment (no template drift)', () => {
+    const sts = buildStatefulSetSpec(...args, 2, undefined, baseCfg)
+    const template = buildWorkspacePodTemplate(
+      labels,
+      'ws1',
+      'claude-code',
+      'nap-ws1-workspace',
+      undefined,
+      baseCfg,
+    )
+    expect(sts.spec?.template).toEqual(template)
+    // The Deployment wraps the identical template, so both workloads run
+    // byte-identical pods.
+    const dep = buildDeploymentSpec(...args, undefined, baseCfg)
+    expect(sts.spec?.template).toEqual(dep.spec?.template)
+  })
+
+  it('uses no volumeClaimTemplates — all replicas share one PVC', () => {
+    const sts = buildStatefulSetSpec(...args, 3, undefined, baseCfg)
+    expect(sts.spec?.volumeClaimTemplates).toBeUndefined()
+    const wsVolume = sts.spec?.template.spec?.volumes?.find((v) => v.name === 'workspace')
+    expect(wsVolume?.persistentVolumeClaim?.claimName).toBe('nap-ws1-workspace')
+  })
+
+  it('serviceName is the headless service; replicas + policy passed through', () => {
+    const sts = buildStatefulSetSpec(...args, 4, undefined, baseCfg)
+    expect(sts.spec?.serviceName).toBe('nap-ws1-hl')
+    expect(sts.spec?.podManagementPolicy).toBe('Parallel')
+    expect(sts.spec?.replicas).toBe(4)
+  })
+})
+
+describe('buildHeadlessServiceSpec', () => {
+  it('is clusterIP:None, named <name>-hl, selects the workspace pods', () => {
+    const svc = buildHeadlessServiceSpec('nap-ws1', labels)
+    expect(svc.metadata?.name).toBe('nap-ws1-hl')
+    expect(svc.spec?.clusterIP).toBe('None')
+    expect(svc.spec?.selector).toEqual(labels)
+    expect(svc.spec?.ports?.map((p) => p.port)).toEqual([3001, 9101, 9102])
+  })
+})
+
+describe('resolveStatefulSetStatus', () => {
+  const sts = (input: { replicas?: number; readyReplicas?: number }): k8s.V1StatefulSet =>
+    ({
+      spec: { replicas: input.replicas },
+      status: { readyReplicas: input.readyReplicas },
+    }) as unknown as k8s.V1StatefulSet
+
+  it('no statefulset → stopped', () => {
+    expect(resolveStatefulSetStatus(undefined)).toBe('stopped')
+  })
+  it('replicas 0 → stopped', () => {
+    expect(resolveStatefulSetStatus(sts({ replicas: 0, readyReplicas: 0 }))).toBe('stopped')
+  })
+  it('at least one ready → running', () => {
+    expect(resolveStatefulSetStatus(sts({ replicas: 3, readyReplicas: 1 }))).toBe('running')
+  })
+  it('desired > 0 but none ready → starting', () => {
+    expect(resolveStatefulSetStatus(sts({ replicas: 2, readyReplicas: 0 }))).toBe('starting')
+  })
+})
+
+describe('readyReplicaIdsFromPods', () => {
+  const pod = (name: string, readies: boolean[]): k8s.V1Pod =>
+    ({
+      metadata: { name },
+      status: { containerStatuses: readies.map((ready) => ({ ready })) },
+    }) as unknown as k8s.V1Pod
+
+  it('returns sorted ordinals of pods whose containers are all ready', () => {
+    const pods = [
+      pod('tos-ws1-2', [true, true]),
+      pod('tos-ws1-0', [true]),
+      pod('tos-ws1-1', [true, false]), // a container not ready → excluded
+    ]
+    expect(readyReplicaIdsFromPods(pods, 'tos-ws1')).toEqual([0, 2])
+  })
+
+  it('ignores pods with no container statuses', () => {
+    expect(readyReplicaIdsFromPods([pod('tos-ws1-0', [])], 'tos-ws1')).toEqual([])
+  })
+
+  it('ignores names that are not <stsName>-<int>', () => {
+    const pods = [
+      pod('tos-ws1-0', [true]),
+      pod('tos-ws1-abc', [true]), // non-numeric suffix
+      pod('other-ws-0', [true]), // a different statefulset
+      pod('tos-ws1', [true]), // no ordinal
+    ]
+    expect(readyReplicaIdsFromPods(pods, 'tos-ws1')).toEqual([0])
   })
 })

--- a/internal/env-runner-core/reconcile.ts
+++ b/internal/env-runner-core/reconcile.ts
@@ -21,20 +21,21 @@ type ReconcileAction = 'apply' | 'start' | 'stop' | 'destroy' | 'none'
  * pass over N converged placements would otherwise issue N no-op DB writes.
  * Two cases warrant a write:
  *   - phase moved; or
- *   - the observation carries a live ready-replica set (auto-scaling): those
- *     ids change while phase stays 'running' (a pod dies/recovers, scale-up
- *     readiness fills in), so a phase-only gate would let cp's routing signal
- *     go stale. This is data-driven, not a runtime-mode branch — a static
- *     workspace never reports readyReplicaIds, so its path stays phase-gated
- *     and issues no extra writes.
+ *   - a RUNNING auto-scaling workspace's ready-replica set may have shifted
+ *     (a pod dies/recovers, scale-up readiness fills in) while phase stays
+ *     'running', so a phase-only gate would let cp's routing signal go stale.
+ *     This is data-driven, not a runtime-mode branch — a static workspace never
+ *     reports readyReplicaIds. Gated on 'running' so a stopped/idle set (empty,
+ *     byte-identical every pass) collapses back to the phase-gated path.
  */
 async function recordIfChanged(
   transport: PlacementTransport,
   p: PlacementRow,
   current: ObservedState,
 ): Promise<void> {
-  const carriesReplicaReadiness = current.endpoint?.readyReplicaIds !== undefined
-  if (current.phase !== p.observed_phase || carriesReplicaReadiness) {
+  const readySetMayHaveShifted =
+    current.phase === 'running' && current.endpoint?.readyReplicaIds !== undefined
+  if (current.phase !== p.observed_phase || readySetMayHaveShifted) {
     await transport.writeObserved(p.workspace_id, {
       phase: current.phase,
       endpoint: current.endpoint,

--- a/internal/env-runner-core/reconcile.ts
+++ b/internal/env-runner-core/reconcile.ts
@@ -17,18 +17,24 @@ import type { PlacementRow, PlacementTransport } from './transport'
 type ReconcileAction = 'apply' | 'start' | 'stop' | 'destroy' | 'none'
 
 /**
- * Write observed state back only when the phase actually moved. A steady-state
- * pass over N converged placements would otherwise issue N DB writes per pass
- * for no change; this keeps it to writes that carry information. endpoint is
- * derived deterministically per workspace (cluster DNS / route key), so phase
- * is the only mutable field on the no-op path.
+ * Write observed state back only when it carries information a steady-state
+ * pass over N converged placements would otherwise issue N no-op DB writes.
+ * Two cases warrant a write:
+ *   - phase moved; or
+ *   - the observation carries a live ready-replica set (auto-scaling): those
+ *     ids change while phase stays 'running' (a pod dies/recovers, scale-up
+ *     readiness fills in), so a phase-only gate would let cp's routing signal
+ *     go stale. This is data-driven, not a runtime-mode branch — a static
+ *     workspace never reports readyReplicaIds, so its path stays phase-gated
+ *     and issues no extra writes.
  */
 async function recordIfChanged(
   transport: PlacementTransport,
   p: PlacementRow,
   current: ObservedState,
 ): Promise<void> {
-  if (current.phase !== p.observed_phase) {
+  const carriesReplicaReadiness = current.endpoint?.readyReplicaIds !== undefined
+  if (current.phase !== p.observed_phase || carriesReplicaReadiness) {
     await transport.writeObserved(p.workspace_id, {
       phase: current.phase,
       endpoint: current.endpoint,

--- a/internal/k8s-provider/auto-scaling-workload.ts
+++ b/internal/k8s-provider/auto-scaling-workload.ts
@@ -1,0 +1,247 @@
+import * as k8s from '@kubernetes/client-node'
+import type { ObservedState, WorkspaceSpec } from '../types/environments'
+import type { K8sConfig } from './config'
+import {
+  createOrAdopt,
+  expandWorkspacePvc,
+  resourceName,
+  swallow404,
+  workspaceLabels,
+} from './support'
+import {
+  CURRENT_TEMPLATE_VERSION,
+  TEMPLATE_VERSION_ANNOTATION,
+  buildHeadlessServiceSpec,
+  buildStatefulSetSpec,
+  readyReplicaIdsFromPods,
+  resolveStatefulSetStatus,
+} from './workspace-spec'
+
+/**
+ * The auto-scaling workload shape: a StatefulSet + headless Service + one shared
+ * ReadWriteMany PVC. A sibling to the static (Deployment) shape;
+ * {@link KubernetesProvider} dispatches to whichever a workspace is — runtime
+ * mode is immutable, so a workspace is only ever one. Self-contained over
+ * injected api clients + config so it can be unit-tested with fakes. The pod
+ * template is byte-identical to the static form (buildWorkspacePodTemplate) —
+ * only the surrounding workload / service / PVC differ; StatefulSet is used
+ * purely for stable per-ordinal DNS + ordered scale-down.
+ */
+export class AutoScalingWorkload {
+  constructor(
+    private readonly appsApi: k8s.AppsV1Api,
+    private readonly coreApi: k8s.CoreV1Api,
+    private readonly cfg: K8sConfig,
+  ) {}
+
+  private async getStatefulSet(workspaceId: string): Promise<k8s.V1StatefulSet | null> {
+    const name = resourceName(this.cfg, workspaceId)
+    try {
+      return (await this.appsApi.readNamespacedStatefulSet(name, this.cfg.namespace)).body
+    } catch (e: any) {
+      if (e.response?.statusCode === 404) return null
+      throw e
+    }
+  }
+
+  /** Whether this workspace is backed by a StatefulSet (i.e. is auto-scaling). */
+  async exists(workspaceId: string): Promise<boolean> {
+    return (await this.getStatefulSet(workspaceId)) !== null
+  }
+
+  /** Create-or-converge the StatefulSet, headless Service and shared RWX PVC. */
+  async apply(workspaceId: string, spec: WorkspaceSpec): Promise<void> {
+    const name = resourceName(this.cfg, workspaceId)
+    const labels = workspaceLabels(this.cfg, workspaceId)
+    const pvcName = `${name}-workspace`
+    const replicas = spec.replicas ?? 1
+    const storageSize = spec.resources?.storage || this.cfg.workspaceStorageSize
+
+    // Shared workspace volume: ReadWriteMany so every replica mounts it at once.
+    // Created once — runtime_mode is immutable, so the access mode never changes.
+    await createOrAdopt(() =>
+      this.coreApi.createNamespacedPersistentVolumeClaim(this.cfg.namespace, {
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: { name: pvcName, labels },
+        spec: {
+          accessModes: ['ReadWriteMany'],
+          storageClassName: this.cfg.storageClass,
+          resources: { requests: { storage: storageSize } },
+        },
+      }),
+    )
+
+    // Headless Service for stable per-ordinal DNS (no ClusterIP — a VIP would
+    // round-robin across replicas and defeat session affinity).
+    await createOrAdopt(() =>
+      this.coreApi.createNamespacedService(
+        this.cfg.namespace,
+        buildHeadlessServiceSpec(name, labels),
+      ),
+    )
+
+    const desired = buildStatefulSetSpec(
+      name,
+      labels,
+      workspaceId,
+      spec.agentType,
+      pvcName,
+      replicas,
+      spec.resources,
+      this.cfg,
+    )
+    const existing = await this.getStatefulSet(workspaceId)
+    if (!existing) {
+      await createOrAdopt(() =>
+        this.appsApi.createNamespacedStatefulSet(this.cfg.namespace, desired),
+      )
+    } else {
+      // Converge in place — never delete+recreate, which would take every
+      // replica down at once. Strategic-merge the pod template (a rolling update
+      // reconciles image/resources) and set the replica count.
+      await this.appsApi.patchNamespacedStatefulSet(
+        name,
+        this.cfg.namespace,
+        {
+          metadata: {
+            annotations: {
+              [TEMPLATE_VERSION_ANNOTATION]: String(CURRENT_TEMPLATE_VERSION),
+            },
+          },
+          spec: { replicas, template: desired.spec?.template },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          headers: { 'Content-Type': 'application/strategic-merge-patch+json' },
+        },
+      )
+    }
+
+    if (spec.resources?.storage) {
+      await expandWorkspacePvc(this.coreApi, this.cfg, pvcName, spec.resources.storage)
+    }
+  }
+
+  /** Scale the StatefulSet; 404-tolerant (false when it doesn't exist). */
+  async scale(workspaceId: string, replicas: number): Promise<boolean> {
+    const name = resourceName(this.cfg, workspaceId)
+    try {
+      await this.appsApi.patchNamespacedStatefulSetScale(
+        name,
+        this.cfg.namespace,
+        { spec: { replicas } },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: { 'Content-Type': 'application/merge-patch+json' } },
+      )
+      return true
+    } catch (e: any) {
+      if (e.response?.statusCode === 404) return false
+      throw e
+    }
+  }
+
+  /**
+   * Wake the StatefulSet to a floor of 1 replica; the autoscaler reconciles to
+   * the true desired on its next tick. (The primary wake path is apply() with
+   * spec.replicas — this covers a bare stopped→running phase flip with no spec
+   * bump.)
+   */
+  async start(workspaceId: string): Promise<void> {
+    await this.scale(workspaceId, 1)
+  }
+
+  async stop(workspaceId: string): Promise<void> {
+    await this.scale(workspaceId, 0)
+  }
+
+  async destroy(workspaceId: string): Promise<void> {
+    const name = resourceName(this.cfg, workspaceId)
+    await Promise.all([
+      this.appsApi.deleteNamespacedStatefulSet(name, this.cfg.namespace).catch(swallow404),
+      this.coreApi.deleteNamespacedService(`${name}-hl`, this.cfg.namespace).catch(swallow404),
+      this.coreApi
+        .deleteNamespacedPersistentVolumeClaim(`${name}-workspace`, this.cfg.namespace)
+        .catch(swallow404),
+    ])
+  }
+
+  /** Observe one workspace: phase + ready replica set (on the endpoint). */
+  async observe(workspaceId: string): Promise<ObservedState> {
+    const name = resourceName(this.cfg, workspaceId)
+    const sts = await this.getStatefulSet(workspaceId)
+    if (!sts) return { phase: 'unknown' }
+
+    const pods = await this.coreApi.listNamespacedPod(
+      this.cfg.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `app=${this.cfg.namePrefix},workspace-id=${workspaceId}`,
+    )
+    return {
+      phase: resolveStatefulSetStatus(sts),
+      endpoint: {
+        address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
+        readyReplicaIds: readyReplicaIdsFromPods(pods.body.items, name),
+        desiredReplicas: sts.spec?.replicas ?? 0,
+      },
+    }
+  }
+
+  /** Batch counterpart: every StatefulSet-backed (auto-scaling) workspace. */
+  async observeAll(): Promise<Map<string, ObservedState>> {
+    const res = await this.appsApi.listNamespacedStatefulSet(
+      this.cfg.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `app=${this.cfg.namePrefix},component=workspace`,
+    )
+    const sets = res.body.items.filter((s) => s.metadata?.labels?.['workspace-id'])
+    const out = new Map<string, ObservedState>()
+    if (sets.length === 0) return out
+
+    // One pod LIST across all auto-scaling workspaces, bucketed by workspace-id.
+    const pods = await this.coreApi.listNamespacedPod(
+      this.cfg.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `app=${this.cfg.namePrefix},component=workspace`,
+    )
+    const podsByWs = new Map<string, k8s.V1Pod[]>()
+    for (const pod of pods.body.items) {
+      const wsId = pod.metadata?.labels?.['workspace-id']
+      if (!wsId) continue
+      const list = podsByWs.get(wsId)
+      if (list) list.push(pod)
+      else podsByWs.set(wsId, [pod])
+    }
+
+    for (const sts of sets) {
+      const wsId = sts.metadata?.labels?.['workspace-id'] as string
+      const name = resourceName(this.cfg, wsId)
+      out.set(wsId, {
+        phase: resolveStatefulSetStatus(sts),
+        endpoint: {
+          address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
+          readyReplicaIds: readyReplicaIdsFromPods(podsByWs.get(wsId) ?? [], name),
+          desiredReplicas: sts.spec?.replicas ?? 0,
+        },
+      })
+    }
+    return out
+  }
+}

--- a/internal/k8s-provider/auto-scaling-workload.ts
+++ b/internal/k8s-provider/auto-scaling-workload.ts
@@ -7,6 +7,7 @@ import {
   resourceName,
   swallow404,
   workspaceLabels,
+  workspacePvcName,
 } from './support'
 import {
   CURRENT_TEMPLATE_VERSION,
@@ -53,7 +54,7 @@ export class AutoScalingWorkload {
   async apply(workspaceId: string, spec: WorkspaceSpec): Promise<void> {
     const name = resourceName(this.cfg, workspaceId)
     const labels = workspaceLabels(this.cfg, workspaceId)
-    const pvcName = `${name}-workspace`
+    const pvcName = workspacePvcName(this.cfg, workspaceId)
     const replicas = spec.replicas ?? 1
     const storageSize = spec.resources?.storage || this.cfg.workspaceStorageSize
 
@@ -169,9 +170,23 @@ export class AutoScalingWorkload {
       this.appsApi.deleteNamespacedStatefulSet(name, this.cfg.namespace).catch(swallow404),
       this.coreApi.deleteNamespacedService(`${name}-hl`, this.cfg.namespace).catch(swallow404),
       this.coreApi
-        .deleteNamespacedPersistentVolumeClaim(`${name}-workspace`, this.cfg.namespace)
+        .deleteNamespacedPersistentVolumeClaim(
+          workspacePvcName(this.cfg, workspaceId),
+          this.cfg.namespace,
+        )
         .catch(swallow404),
     ])
+  }
+
+  /** The observed state (phase + ready replica set on the endpoint) for a set. */
+  private observed(name: string, sts: k8s.V1StatefulSet, pods: k8s.V1Pod[]): ObservedState {
+    return {
+      phase: resolveStatefulSetStatus(sts),
+      endpoint: {
+        address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
+        readyReplicaIds: readyReplicaIdsFromPods(pods, name),
+      },
+    }
   }
 
   /** Observe one workspace: phase + ready replica set (on the endpoint). */
@@ -188,18 +203,16 @@ export class AutoScalingWorkload {
       undefined,
       `app=${this.cfg.namePrefix},workspace-id=${workspaceId}`,
     )
-    return {
-      phase: resolveStatefulSetStatus(sts),
-      endpoint: {
-        address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
-        readyReplicaIds: readyReplicaIdsFromPods(pods.body.items, name),
-        desiredReplicas: sts.spec?.replicas ?? 0,
-      },
-    }
+    return this.observed(name, sts, pods.body.items)
   }
 
   /** Batch counterpart: every StatefulSet-backed (auto-scaling) workspace. */
   async observeAll(): Promise<Map<string, ObservedState>> {
+    const out = new Map<string, ObservedState>()
+    // Environments that can't host the shape have provably zero StatefulSets —
+    // skip the LIST entirely rather than pay it every reconcile pass.
+    if (!this.cfg.multiReplica) return out
+
     const res = await this.appsApi.listNamespacedStatefulSet(
       this.cfg.namespace,
       undefined,
@@ -209,7 +222,6 @@ export class AutoScalingWorkload {
       `app=${this.cfg.namePrefix},component=workspace`,
     )
     const sets = res.body.items.filter((s) => s.metadata?.labels?.['workspace-id'])
-    const out = new Map<string, ObservedState>()
     if (sets.length === 0) return out
 
     // One pod LIST across all auto-scaling workspaces, bucketed by workspace-id.
@@ -225,22 +237,14 @@ export class AutoScalingWorkload {
     for (const pod of pods.body.items) {
       const wsId = pod.metadata?.labels?.['workspace-id']
       if (!wsId) continue
-      const list = podsByWs.get(wsId)
-      if (list) list.push(pod)
-      else podsByWs.set(wsId, [pod])
+      const list = podsByWs.get(wsId) ?? []
+      list.push(pod)
+      podsByWs.set(wsId, list)
     }
 
     for (const sts of sets) {
       const wsId = sts.metadata?.labels?.['workspace-id'] as string
-      const name = resourceName(this.cfg, wsId)
-      out.set(wsId, {
-        phase: resolveStatefulSetStatus(sts),
-        endpoint: {
-          address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
-          readyReplicaIds: readyReplicaIdsFromPods(podsByWs.get(wsId) ?? [], name),
-          desiredReplicas: sts.spec?.replicas ?? 0,
-        },
-      })
+      out.set(wsId, this.observed(resourceName(this.cfg, wsId), sts, podsByWs.get(wsId) ?? []))
     }
     return out
   }

--- a/internal/k8s-provider/config.ts
+++ b/internal/k8s-provider/config.ts
@@ -37,6 +37,13 @@ export function getAgentImage(agentType: string): string {
 const WORKSPACE_STORAGE_SIZE = process.env.WORKSPACE_STORAGE_SIZE || '10Gi'
 const NAME_PREFIX = 'tos'
 
+// Whether this environment may host auto-scaling (multi-replica) workspaces.
+// Gated on the storage class supporting ReadWriteMany (all replicas share one
+// RWX workspace PVC), which is a deploy-time property, so it is an explicit
+// opt-in env rather than inferred. Default off → the environment advertises no
+// multiReplica capability and placement rejects auto-scaling there.
+const WORKSPACE_MULTI_REPLICA = process.env.WORKSPACE_MULTI_REPLICA === 'true'
+
 /**
  * All infra config a `buildDeploymentSpec` / provider instance needs,
  * captured explicitly instead of read from module-level env at call time. This
@@ -55,6 +62,8 @@ export interface K8sConfig {
   workspaceStorageSize: string
   cpServiceUrl: string
   memoryFuseImage: string
+  /** This environment may host auto-scaling workspaces (RWX storage available). */
+  multiReplica: boolean
   afs: {
     enabled: boolean
     image: string
@@ -78,6 +87,7 @@ function defaultK8sConfig(): K8sConfig {
     workspaceStorageSize: WORKSPACE_STORAGE_SIZE,
     cpServiceUrl: process.env.CP_SERVICE_URL || 'http://nap-cp:3000',
     memoryFuseImage: MEMORY_FUSE_IMAGE,
+    multiReplica: WORKSPACE_MULTI_REPLICA,
     afs: {
       enabled: AFS_ENABLED,
       image: AFS_IMAGE,

--- a/internal/k8s-provider/index.ts
+++ b/internal/k8s-provider/index.ts
@@ -16,7 +16,11 @@ export {
   CURRENT_TEMPLATE_VERSION,
   type ReconciledStatus,
   buildDeploymentSpec,
+  buildHeadlessServiceSpec,
+  buildStatefulSetSpec,
   buildWorkspacePodTemplate,
   deploymentTemplateVersion,
+  readyReplicaIdsFromPods,
   resolveDeploymentStatus,
+  resolveStatefulSetStatus,
 } from './workspace-spec'

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -827,9 +827,11 @@ export class KubernetesProvider implements EnvironmentProvider {
     )
     return {
       phase: resolveStatefulSetStatus(sts),
-      endpoint: { address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001` },
-      replicas: { desired: sts.spec?.replicas ?? 0, ready: sts.status?.readyReplicas ?? 0 },
-      readyReplicaIds: readyReplicaIdsFromPods(pods.body.items, name),
+      endpoint: {
+        address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
+        readyReplicaIds: readyReplicaIdsFromPods(pods.body.items, name),
+        desiredReplicas: sts.spec?.replicas ?? 0,
+      },
     }
   }
 
@@ -870,9 +872,11 @@ export class KubernetesProvider implements EnvironmentProvider {
       const name = this.getResourceName(wsId)
       out.set(wsId, {
         phase: resolveStatefulSetStatus(sts),
-        endpoint: { address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001` },
-        replicas: { desired: sts.spec?.replicas ?? 0, ready: sts.status?.readyReplicas ?? 0 },
-        readyReplicaIds: readyReplicaIdsFromPods(podsByWs.get(wsId) ?? [], name),
+        endpoint: {
+          address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
+          readyReplicaIds: readyReplicaIdsFromPods(podsByWs.get(wsId) ?? [], name),
+          desiredReplicas: sts.spec?.replicas ?? 0,
+        },
       })
     }
     return out

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -918,7 +918,18 @@ export class KubernetesProvider implements EnvironmentProvider {
   }
 
   async start(workspaceId: string): Promise<void> {
-    await this.startInstance(workspaceId)
+    // Detect the shape by what exists (no spec here). A static workspace scales
+    // its Deployment 0→1; startInstance returns false (404) when there is none,
+    // i.e. an auto-scaling workspace, whose StatefulSet we wake instead.
+    const started = await this.startInstance(workspaceId)
+    if (!started) {
+      // Wake the StatefulSet to a floor of 1 replica; the autoscaler reconciles
+      // to the true desired on its next tick. (The primary wake path is apply()
+      // with spec.replicas — this covers a bare stopped→running phase flip with
+      // no spec bump.) scaleStatefulSet is 404-tolerant, so a workspace with
+      // neither shape is a no-op, exactly as before.
+      await this.scaleStatefulSet(workspaceId, 1)
+    }
   }
 
   async stop(workspaceId: string): Promise<void> {

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -8,11 +8,19 @@ import type {
 } from '../types/environments'
 import { AutoScalingWorkload } from './auto-scaling-workload'
 import { type K8sConfig, defaultCfg } from './config'
-import { createOrAdopt, expandWorkspacePvc, resourceName, workspaceLabels } from './support'
+import {
+  createOrAdopt,
+  expandWorkspacePvc,
+  isPodReady,
+  resourceName,
+  workspaceLabels,
+  workspacePvcName,
+} from './support'
 import {
   MEMORY_FUSE_CONTAINER_NAME,
   type ReconciledStatus,
   TEMPLATE_VERSION_ANNOTATION,
+  WORKSPACE_SERVICE_PORTS,
   buildDeploymentSpec,
   resolveDeploymentStatus,
 } from './workspace-spec'
@@ -80,7 +88,7 @@ export class KubernetesProvider implements EnvironmentProvider {
   ): Promise<K8sInstance> {
     const name = this.getResourceName(workspaceId)
     const labels = this.getLabels(workspaceId)
-    const pvcName = `${name}-workspace`
+    const pvcName = workspacePvcName(this.cfg, workspaceId)
 
     // Create PVC for workspace persistent storage
     const storageSize = resources?.storage || this.cfg.workspaceStorageSize
@@ -116,11 +124,7 @@ export class KubernetesProvider implements EnvironmentProvider {
         metadata: { name, labels },
         spec: {
           selector: labels,
-          ports: [
-            { port: 3001, targetPort: 3001 as any, name: 'http' },
-            { port: 9101, targetPort: 9101 as any, name: 'afs-fuse' },
-            { port: 9102, targetPort: 9102 as any, name: 'memory-fuse' },
-          ],
+          ports: WORKSPACE_SERVICE_PORTS,
           type: 'ClusterIP',
         },
       }),
@@ -293,7 +297,7 @@ export class KubernetesProvider implements EnvironmentProvider {
   ): Promise<void> {
     const name = this.getResourceName(workspaceId)
     const labels = this.getLabels(workspaceId)
-    const pvcName = `${name}-workspace`
+    const pvcName = workspacePvcName(this.cfg, workspaceId)
 
     // Delete existing deployment
     try {
@@ -361,7 +365,7 @@ export class KubernetesProvider implements EnvironmentProvider {
 
   /** Expand PVC storage (grow-only, 404/shrink-tolerant). See expandWorkspacePvc. */
   async expandInstanceStorage(workspaceId: string, newSize: string): Promise<boolean> {
-    const pvcName = `${this.getResourceName(workspaceId)}-workspace`
+    const pvcName = workspacePvcName(this.cfg, workspaceId)
     return expandWorkspacePvc(this.coreApi, this.cfg, pvcName, newSize)
   }
 
@@ -384,7 +388,7 @@ export class KubernetesProvider implements EnvironmentProvider {
       conditions: [],
     }
 
-    const pvcName = `${name}-workspace`
+    const pvcName = workspacePvcName(this.cfg, workspaceId)
 
     // Query all resources concurrently
     const [depResult, svcResult, pvcResult, podsResult] = await Promise.allSettled([
@@ -480,11 +484,8 @@ export class KubernetesProvider implements EnvironmentProvider {
         const podName = pod.metadata?.name || ''
         podNames.push(podName)
 
-        const containerStatuses = pod.status?.containerStatuses || []
-        const allReady = containerStatuses.length > 0 && containerStatuses.every((c) => c.ready)
-
         result.pods.total++
-        if (allReady) result.pods.ready++
+        if (isPodReady(pod)) result.pods.ready++
       }
 
       // Fetch events for all pods concurrently
@@ -607,7 +608,10 @@ export class KubernetesProvider implements EnvironmentProvider {
       await Promise.all([
         this.appsApi.deleteNamespacedDeployment(name, this.cfg.namespace),
         this.coreApi.deleteNamespacedService(name, this.cfg.namespace),
-        this.coreApi.deleteNamespacedPersistentVolumeClaim(`${name}-workspace`, this.cfg.namespace),
+        this.coreApi.deleteNamespacedPersistentVolumeClaim(
+          workspacePvcName(this.cfg, workspaceId),
+          this.cfg.namespace,
+        ),
       ])
       return true
     } catch (e: any) {
@@ -648,11 +652,9 @@ export class KubernetesProvider implements EnvironmentProvider {
   async start(workspaceId: string): Promise<void> {
     // Detect the shape by what exists (no spec here). A static workspace scales
     // its Deployment 0→1; startInstance returns false (404) when there is none,
-    // i.e. an auto-scaling workspace, whose StatefulSet we wake instead.
+    // i.e. an auto-scaling workspace, whose StatefulSet we wake instead (also a
+    // no-op if it has neither shape).
     const started = await this.startInstance(workspaceId)
-    // startInstance returns false (404) when there is no Deployment, i.e. an
-    // auto-scaling workspace — wake its StatefulSet instead (also a no-op if it
-    // has neither shape).
     if (!started) await this.autoScaling.start(workspaceId)
   }
 

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -8,12 +8,22 @@ import type {
 } from '../types/environments'
 import { type K8sConfig, defaultCfg } from './config'
 import {
+  CURRENT_TEMPLATE_VERSION,
   MEMORY_FUSE_CONTAINER_NAME,
   type ReconciledStatus,
   TEMPLATE_VERSION_ANNOTATION,
   buildDeploymentSpec,
+  buildHeadlessServiceSpec,
+  buildStatefulSetSpec,
+  readyReplicaIdsFromPods,
   resolveDeploymentStatus,
+  resolveStatefulSetStatus,
 } from './workspace-spec'
+
+/** A delete/read whose 404 means "already gone" = success; rethrow the rest. */
+function swallow404(e: any): void {
+  if (e.response?.statusCode !== 404) throw e
+}
 
 const STORAGE_UNITS: Record<string, number> = {
   Ki: 2 ** 10,
@@ -686,6 +696,200 @@ export class KubernetesProvider implements EnvironmentProvider {
     }
   }
 
+  // ── Auto-scaling (StatefulSet) form ──
+  // A workspace with runtimeMode 'auto-scaling' is backed by a StatefulSet +
+  // headless Service + one shared RWX PVC, instead of a Deployment + ClusterIP
+  // Service + RWO PVC. runtime_mode is immutable, so a given workspace is only
+  // ever one shape; these private methods handle the auto-scaling shape and the
+  // facade below dispatches to them (detecting the shape from what exists, since
+  // observe/stop/destroy aren't handed the spec). The pod template is identical
+  // to the static form — only the surrounding workload/service/PVC differ.
+
+  private async getStatefulSet(workspaceId: string): Promise<k8s.V1StatefulSet | null> {
+    const name = this.getResourceName(workspaceId)
+    try {
+      return (await this.appsApi.readNamespacedStatefulSet(name, this.cfg.namespace)).body
+    } catch (e: any) {
+      if (e.response?.statusCode === 404) return null
+      throw e
+    }
+  }
+
+  /** Create-or-converge the StatefulSet, headless Service and shared RWX PVC. */
+  private async applyStatefulSet(workspaceId: string, spec: WorkspaceSpec): Promise<void> {
+    const name = this.getResourceName(workspaceId)
+    const labels = this.getLabels(workspaceId)
+    const pvcName = `${name}-workspace`
+    const replicas = spec.replicas ?? 1
+    const storageSize = spec.resources?.storage || this.cfg.workspaceStorageSize
+
+    // Shared workspace volume: ReadWriteMany so every replica mounts it at once.
+    // Created once — runtime_mode is immutable, so the access mode never changes.
+    await this.createOrAdopt(() =>
+      this.coreApi.createNamespacedPersistentVolumeClaim(this.cfg.namespace, {
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: { name: pvcName, labels },
+        spec: {
+          accessModes: ['ReadWriteMany'],
+          storageClassName: this.cfg.storageClass,
+          resources: { requests: { storage: storageSize } },
+        },
+      }),
+    )
+
+    // Headless Service for stable per-ordinal DNS (no ClusterIP — a VIP would
+    // round-robin across replicas and defeat session affinity).
+    await this.createOrAdopt(() =>
+      this.coreApi.createNamespacedService(
+        this.cfg.namespace,
+        buildHeadlessServiceSpec(name, labels),
+      ),
+    )
+
+    const desired = buildStatefulSetSpec(
+      name,
+      labels,
+      workspaceId,
+      spec.agentType,
+      pvcName,
+      replicas,
+      spec.resources,
+      this.cfg,
+    )
+    const existing = await this.getStatefulSet(workspaceId)
+    if (!existing) {
+      await this.createOrAdopt(() =>
+        this.appsApi.createNamespacedStatefulSet(this.cfg.namespace, desired),
+      )
+    } else {
+      // Converge in place — never delete+recreate, which would take every
+      // replica down at once. Strategic-merge the pod template (a rolling
+      // update reconciles image/resources) and set the replica count.
+      await this.appsApi.patchNamespacedStatefulSet(
+        name,
+        this.cfg.namespace,
+        {
+          metadata: {
+            annotations: { [TEMPLATE_VERSION_ANNOTATION]: String(CURRENT_TEMPLATE_VERSION) },
+          },
+          spec: { replicas, template: desired.spec?.template },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+      )
+    }
+
+    if (spec.resources?.storage) {
+      await this.expandInstanceStorage(workspaceId, spec.resources.storage)
+    }
+  }
+
+  /** Scale a StatefulSet workspace; 404-tolerant (false when it doesn't exist). */
+  private async scaleStatefulSet(workspaceId: string, replicas: number): Promise<boolean> {
+    const name = this.getResourceName(workspaceId)
+    try {
+      await this.appsApi.patchNamespacedStatefulSetScale(
+        name,
+        this.cfg.namespace,
+        { spec: { replicas } },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: { 'Content-Type': 'application/merge-patch+json' } },
+      )
+      return true
+    } catch (e: any) {
+      if (e.response?.statusCode === 404) return false
+      throw e
+    }
+  }
+
+  /** Observe one StatefulSet workspace: phase + replica counts + ready ids. */
+  private async observeStatefulSet(workspaceId: string): Promise<ObservedState> {
+    const name = this.getResourceName(workspaceId)
+    const sts = await this.getStatefulSet(workspaceId)
+    if (!sts) return { phase: 'unknown' }
+
+    const pods = await this.coreApi.listNamespacedPod(
+      this.cfg.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `app=${this.cfg.namePrefix},workspace-id=${workspaceId}`,
+    )
+    return {
+      phase: resolveStatefulSetStatus(sts),
+      endpoint: { address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001` },
+      replicas: { desired: sts.spec?.replicas ?? 0, ready: sts.status?.readyReplicas ?? 0 },
+      readyReplicaIds: readyReplicaIdsFromPods(pods.body.items, name),
+    }
+  }
+
+  /** Batch counterpart: every StatefulSet-backed (auto-scaling) workspace. */
+  private async observeAllStatefulSets(): Promise<Map<string, ObservedState>> {
+    const res = await this.appsApi.listNamespacedStatefulSet(
+      this.cfg.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `app=${this.cfg.namePrefix},component=workspace`,
+    )
+    const sets = res.body.items.filter((s) => s.metadata?.labels?.['workspace-id'])
+    const out = new Map<string, ObservedState>()
+    if (sets.length === 0) return out
+
+    // One pod LIST across all auto-scaling workspaces, bucketed by workspace-id.
+    const pods = await this.coreApi.listNamespacedPod(
+      this.cfg.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `app=${this.cfg.namePrefix},component=workspace`,
+    )
+    const podsByWs = new Map<string, k8s.V1Pod[]>()
+    for (const pod of pods.body.items) {
+      const wsId = pod.metadata?.labels?.['workspace-id']
+      if (!wsId) continue
+      const list = podsByWs.get(wsId)
+      if (list) list.push(pod)
+      else podsByWs.set(wsId, [pod])
+    }
+
+    for (const sts of sets) {
+      const wsId = sts.metadata?.labels?.['workspace-id'] as string
+      const name = this.getResourceName(wsId)
+      out.set(wsId, {
+        phase: resolveStatefulSetStatus(sts),
+        endpoint: { address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001` },
+        replicas: { desired: sts.spec?.replicas ?? 0, ready: sts.status?.readyReplicas ?? 0 },
+        readyReplicaIds: readyReplicaIdsFromPods(podsByWs.get(wsId) ?? [], name),
+      })
+    }
+    return out
+  }
+
+  /** Delete a StatefulSet workspace's resources (StatefulSet + headless svc + PVC). */
+  private async deleteStatefulSetInstance(workspaceId: string): Promise<void> {
+    const name = this.getResourceName(workspaceId)
+    await Promise.all([
+      this.appsApi.deleteNamespacedStatefulSet(name, this.cfg.namespace).catch(swallow404),
+      this.coreApi.deleteNamespacedService(`${name}-hl`, this.cfg.namespace).catch(swallow404),
+      this.coreApi
+        .deleteNamespacedPersistentVolumeClaim(`${name}-workspace`, this.cfg.namespace)
+        .catch(swallow404),
+    ])
+  }
+
   // ── EnvironmentProvider interface ──
   // Infra-agnostic facade over the methods above, consumed by the runner. The
   // legacy methods stay (their callers are unchanged); these adapt signatures
@@ -695,6 +899,10 @@ export class KubernetesProvider implements EnvironmentProvider {
 
   /** Create if absent, else rebuild to converge (v1: cp bumps version → rebuild). */
   async apply(workspaceId: string, spec: WorkspaceSpec): Promise<void> {
+    if (spec.runtimeMode === 'auto-scaling') {
+      await this.applyStatefulSet(workspaceId, spec)
+      return
+    }
     const existing = await this.getInstance(workspaceId)
     if (existing) {
       // rebuild swaps the Deployment (new container resources/image) but
@@ -714,11 +922,19 @@ export class KubernetesProvider implements EnvironmentProvider {
   }
 
   async stop(workspaceId: string): Promise<void> {
-    await this.stopInstance(workspaceId)
+    // runtime_mode isn't passed here — detect the form by what exists. A static
+    // workspace scales its Deployment; stopInstance returns false (404) when
+    // there is none, i.e. an auto-scaling workspace, whose StatefulSet we scale.
+    const scaled = await this.stopInstance(workspaceId)
+    if (!scaled) await this.scaleStatefulSet(workspaceId, 0)
   }
 
   async destroy(workspaceId: string): Promise<void> {
-    await this.deleteInstance(workspaceId)
+    // A StatefulSet-backed workspace has no Deployment/ClusterIP Service to
+    // delete; route teardown by the shape that actually exists.
+    const sts = await this.getStatefulSet(workspaceId)
+    if (sts) await this.deleteStatefulSetInstance(workspaceId)
+    else await this.deleteInstance(workspaceId)
   }
 
   async resize(workspaceId: string, resources: ComputeResources): Promise<void> {
@@ -746,7 +962,8 @@ export class KubernetesProvider implements EnvironmentProvider {
       }
     } catch (e: any) {
       if (e.response?.statusCode === 404) {
-        return { phase: 'unknown' }
+        // No Deployment — maybe an auto-scaling (StatefulSet) workspace.
+        return this.observeStatefulSet(workspaceId)
       }
       throw e
     }
@@ -771,6 +988,11 @@ export class KubernetesProvider implements EnvironmentProvider {
         },
       })
     }
+    // Merge in auto-scaling (StatefulSet) workspaces. A workspace is only ever
+    // one shape, so keys never collide.
+    for (const [wsId, state] of await this.observeAllStatefulSets()) {
+      out.set(wsId, state)
+    }
     return out
   }
 
@@ -778,6 +1000,7 @@ export class KubernetesProvider implements EnvironmentProvider {
     return {
       sharedFs: this.cfg.afs.enabled,
       persistentMemory: this.cfg.memoryFuseImage !== '',
+      multiReplica: this.cfg.multiReplica,
     }
   }
 }

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -6,49 +6,16 @@ import type {
   ObservedState,
   WorkspaceSpec,
 } from '../types/environments'
+import { AutoScalingWorkload } from './auto-scaling-workload'
 import { type K8sConfig, defaultCfg } from './config'
+import { createOrAdopt, expandWorkspacePvc, resourceName, workspaceLabels } from './support'
 import {
-  CURRENT_TEMPLATE_VERSION,
   MEMORY_FUSE_CONTAINER_NAME,
   type ReconciledStatus,
   TEMPLATE_VERSION_ANNOTATION,
   buildDeploymentSpec,
-  buildHeadlessServiceSpec,
-  buildStatefulSetSpec,
-  readyReplicaIdsFromPods,
   resolveDeploymentStatus,
-  resolveStatefulSetStatus,
 } from './workspace-spec'
-
-/** A delete/read whose 404 means "already gone" = success; rethrow the rest. */
-function swallow404(e: any): void {
-  if (e.response?.statusCode !== 404) throw e
-}
-
-const STORAGE_UNITS: Record<string, number> = {
-  Ki: 2 ** 10,
-  Mi: 2 ** 20,
-  Gi: 2 ** 30,
-  Ti: 2 ** 40,
-  Pi: 2 ** 50,
-  Ei: 2 ** 60,
-  K: 1e3,
-  M: 1e6,
-  G: 1e9,
-  T: 1e12,
-  P: 1e15,
-  E: 1e18,
-}
-
-/** Parse a k8s resource quantity string (e.g. "50Gi", "100000000") into bytes. */
-function parseStorageQuantity(quantity: string): number {
-  const match = quantity.match(/^([0-9.]+)([A-Za-z]*)$/)
-  if (!match) throw new Error(`Unparseable storage quantity: ${quantity}`)
-  const [, num, unit] = match
-  const multiplier = unit ? STORAGE_UNITS[unit] : 1
-  if (multiplier === undefined) throw new Error(`Unknown storage unit: ${unit}`)
-  return Number(num) * multiplier
-}
 
 interface K8sInstance {
   workspaceId: string
@@ -85,38 +52,24 @@ interface InstanceSpecMarkers {
  * default instance so existing call sites stay unchanged.
  */
 export class KubernetesProvider implements EnvironmentProvider {
+  /** The auto-scaling (StatefulSet) workload shape; the facade dispatches here. */
+  private readonly autoScaling: AutoScalingWorkload
+
   constructor(
     private readonly appsApi: k8s.AppsV1Api,
     private readonly coreApi: k8s.CoreV1Api,
     private readonly kc: k8s.KubeConfig,
     private readonly cfg: K8sConfig,
-  ) {}
+  ) {
+    this.autoScaling = new AutoScalingWorkload(appsApi, coreApi, cfg)
+  }
 
   private getResourceName(workspaceId: string): string {
-    return `${this.cfg.namePrefix}-${workspaceId}`
+    return resourceName(this.cfg, workspaceId)
   }
 
   private getLabels(workspaceId: string): Record<string, string> {
-    return {
-      app: this.cfg.namePrefix,
-      component: 'workspace',
-      'workspace-id': workspaceId,
-    }
-  }
-
-  /**
-   * Run a create call, adopting an already-existing object instead of failing.
-   * createInstance must be idempotent: the reconcile loop re-enters it every
-   * tick while a workspace is unconverged, and the PVC/Service deliberately
-   * outlive the Deployment (rebuildInstance, manual Deployment deletion). A
-   * bare create would 409 on the survivors forever and deadlock the reconcile.
-   */
-  private async createOrAdopt(create: () => Promise<unknown>): Promise<void> {
-    try {
-      await create()
-    } catch (e: any) {
-      if (e.response?.statusCode !== 409) throw e
-    }
+    return workspaceLabels(this.cfg, workspaceId)
   }
 
   /** Create K8s resources for a workspace */
@@ -131,7 +84,7 @@ export class KubernetesProvider implements EnvironmentProvider {
 
     // Create PVC for workspace persistent storage
     const storageSize = resources?.storage || this.cfg.workspaceStorageSize
-    await this.createOrAdopt(() =>
+    await createOrAdopt(() =>
       this.coreApi.createNamespacedPersistentVolumeClaim(this.cfg.namespace, {
         apiVersion: 'v1',
         kind: 'PersistentVolumeClaim',
@@ -147,7 +100,7 @@ export class KubernetesProvider implements EnvironmentProvider {
     // Create Deployment. A 409 here can only be a race with a concurrent
     // create building the same fresh spec (a pre-existing Deployment routes
     // apply() to rebuildInstance instead), so adopting is safe.
-    await this.createOrAdopt(() =>
+    await createOrAdopt(() =>
       this.appsApi.createNamespacedDeployment(
         this.cfg.namespace,
         buildDeploymentSpec(name, labels, workspaceId, agentType, pvcName, resources, this.cfg),
@@ -156,7 +109,7 @@ export class KubernetesProvider implements EnvironmentProvider {
 
     // Create Service (ClusterIP — agents are reached via cluster DNS at
     // <prefix>-<wsId>.<ns>.svc:3001; afs-fuse via :9101)
-    await this.createOrAdopt(() =>
+    await createOrAdopt(() =>
       this.coreApi.createNamespacedService(this.cfg.namespace, {
         apiVersion: 'v1',
         kind: 'Service',
@@ -293,7 +246,9 @@ export class KubernetesProvider implements EnvironmentProvider {
         undefined,
         undefined,
         undefined,
-        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+        {
+          headers: { 'Content-Type': 'application/strategic-merge-patch+json' },
+        },
       )
       return true
     } catch (e: any) {
@@ -393,7 +348,9 @@ export class KubernetesProvider implements EnvironmentProvider {
         undefined,
         undefined,
         undefined,
-        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+        {
+          headers: { 'Content-Type': 'application/strategic-merge-patch+json' },
+        },
       )
       return true
     } catch (e: any) {
@@ -402,50 +359,10 @@ export class KubernetesProvider implements EnvironmentProvider {
     }
   }
 
-  /**
-   * Expand PVC storage. K8s only ever allows a PVC to grow, never shrink —
-   * patching a smaller size is rejected by the API. A desired spec asking for
-   * less than what's provisioned (e.g. a stale/lowered compute_resources
-   * value) is treated as a no-op here rather than an error, so it can't block
-   * spec convergence for every other field forever (see incident: apply()
-   * threw on this every reconcile pass, tearing down and recreating the
-   * Deployment before the new pod could ever pass its startup probe).
-   */
+  /** Expand PVC storage (grow-only, 404/shrink-tolerant). See expandWorkspacePvc. */
   async expandInstanceStorage(workspaceId: string, newSize: string): Promise<boolean> {
-    const name = this.getResourceName(workspaceId)
-    const pvcName = `${name}-workspace`
-
-    try {
-      const current = await this.coreApi.readNamespacedPersistentVolumeClaim(
-        pvcName,
-        this.cfg.namespace,
-      )
-      const currentSize = current.body.spec?.resources?.requests?.storage
-      if (currentSize && parseStorageQuantity(newSize) <= parseStorageQuantity(currentSize)) {
-        return true
-      }
-    } catch (e: any) {
-      if (e.response?.statusCode === 404) return false
-      throw e
-    }
-
-    try {
-      await this.coreApi.patchNamespacedPersistentVolumeClaim(
-        pvcName,
-        this.cfg.namespace,
-        { spec: { resources: { requests: { storage: newSize } } } },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'Content-Type': 'application/merge-patch+json' } },
-      )
-      return true
-    } catch (e: any) {
-      if (e.response?.statusCode === 404) return false
-      throw e
-    }
+    const pvcName = `${this.getResourceName(workspaceId)}-workspace`
+    return expandWorkspacePvc(this.coreApi, this.cfg, pvcName, newSize)
   }
 
   /** Get detailed K8s resource status for a workspace */
@@ -454,7 +371,12 @@ export class KubernetesProvider implements EnvironmentProvider {
     const labelSelector = `app=${this.cfg.namePrefix},workspace-id=${workspaceId}`
 
     const result: K8sResourceStatus = {
-      deployment: { exists: false, ready: false, replicas: 0, readyReplicas: 0 },
+      deployment: {
+        exists: false,
+        ready: false,
+        replicas: 0,
+        readyReplicas: 0,
+      },
       service: { exists: false },
       pvc: { exists: false },
       pods: { total: 0, ready: 0 },
@@ -696,204 +618,6 @@ export class KubernetesProvider implements EnvironmentProvider {
     }
   }
 
-  // ── Auto-scaling (StatefulSet) form ──
-  // A workspace with runtimeMode 'auto-scaling' is backed by a StatefulSet +
-  // headless Service + one shared RWX PVC, instead of a Deployment + ClusterIP
-  // Service + RWO PVC. runtime_mode is immutable, so a given workspace is only
-  // ever one shape; these private methods handle the auto-scaling shape and the
-  // facade below dispatches to them (detecting the shape from what exists, since
-  // observe/stop/destroy aren't handed the spec). The pod template is identical
-  // to the static form — only the surrounding workload/service/PVC differ.
-
-  private async getStatefulSet(workspaceId: string): Promise<k8s.V1StatefulSet | null> {
-    const name = this.getResourceName(workspaceId)
-    try {
-      return (await this.appsApi.readNamespacedStatefulSet(name, this.cfg.namespace)).body
-    } catch (e: any) {
-      if (e.response?.statusCode === 404) return null
-      throw e
-    }
-  }
-
-  /** Create-or-converge the StatefulSet, headless Service and shared RWX PVC. */
-  private async applyStatefulSet(workspaceId: string, spec: WorkspaceSpec): Promise<void> {
-    const name = this.getResourceName(workspaceId)
-    const labels = this.getLabels(workspaceId)
-    const pvcName = `${name}-workspace`
-    const replicas = spec.replicas ?? 1
-    const storageSize = spec.resources?.storage || this.cfg.workspaceStorageSize
-
-    // Shared workspace volume: ReadWriteMany so every replica mounts it at once.
-    // Created once — runtime_mode is immutable, so the access mode never changes.
-    await this.createOrAdopt(() =>
-      this.coreApi.createNamespacedPersistentVolumeClaim(this.cfg.namespace, {
-        apiVersion: 'v1',
-        kind: 'PersistentVolumeClaim',
-        metadata: { name: pvcName, labels },
-        spec: {
-          accessModes: ['ReadWriteMany'],
-          storageClassName: this.cfg.storageClass,
-          resources: { requests: { storage: storageSize } },
-        },
-      }),
-    )
-
-    // Headless Service for stable per-ordinal DNS (no ClusterIP — a VIP would
-    // round-robin across replicas and defeat session affinity).
-    await this.createOrAdopt(() =>
-      this.coreApi.createNamespacedService(
-        this.cfg.namespace,
-        buildHeadlessServiceSpec(name, labels),
-      ),
-    )
-
-    const desired = buildStatefulSetSpec(
-      name,
-      labels,
-      workspaceId,
-      spec.agentType,
-      pvcName,
-      replicas,
-      spec.resources,
-      this.cfg,
-    )
-    const existing = await this.getStatefulSet(workspaceId)
-    if (!existing) {
-      await this.createOrAdopt(() =>
-        this.appsApi.createNamespacedStatefulSet(this.cfg.namespace, desired),
-      )
-    } else {
-      // Converge in place — never delete+recreate, which would take every
-      // replica down at once. Strategic-merge the pod template (a rolling
-      // update reconciles image/resources) and set the replica count.
-      await this.appsApi.patchNamespacedStatefulSet(
-        name,
-        this.cfg.namespace,
-        {
-          metadata: {
-            annotations: { [TEMPLATE_VERSION_ANNOTATION]: String(CURRENT_TEMPLATE_VERSION) },
-          },
-          spec: { replicas, template: desired.spec?.template },
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
-      )
-    }
-
-    if (spec.resources?.storage) {
-      await this.expandInstanceStorage(workspaceId, spec.resources.storage)
-    }
-  }
-
-  /** Scale a StatefulSet workspace; 404-tolerant (false when it doesn't exist). */
-  private async scaleStatefulSet(workspaceId: string, replicas: number): Promise<boolean> {
-    const name = this.getResourceName(workspaceId)
-    try {
-      await this.appsApi.patchNamespacedStatefulSetScale(
-        name,
-        this.cfg.namespace,
-        { spec: { replicas } },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'Content-Type': 'application/merge-patch+json' } },
-      )
-      return true
-    } catch (e: any) {
-      if (e.response?.statusCode === 404) return false
-      throw e
-    }
-  }
-
-  /** Observe one StatefulSet workspace: phase + replica counts + ready ids. */
-  private async observeStatefulSet(workspaceId: string): Promise<ObservedState> {
-    const name = this.getResourceName(workspaceId)
-    const sts = await this.getStatefulSet(workspaceId)
-    if (!sts) return { phase: 'unknown' }
-
-    const pods = await this.coreApi.listNamespacedPod(
-      this.cfg.namespace,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      `app=${this.cfg.namePrefix},workspace-id=${workspaceId}`,
-    )
-    return {
-      phase: resolveStatefulSetStatus(sts),
-      endpoint: {
-        address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
-        readyReplicaIds: readyReplicaIdsFromPods(pods.body.items, name),
-        desiredReplicas: sts.spec?.replicas ?? 0,
-      },
-    }
-  }
-
-  /** Batch counterpart: every StatefulSet-backed (auto-scaling) workspace. */
-  private async observeAllStatefulSets(): Promise<Map<string, ObservedState>> {
-    const res = await this.appsApi.listNamespacedStatefulSet(
-      this.cfg.namespace,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      `app=${this.cfg.namePrefix},component=workspace`,
-    )
-    const sets = res.body.items.filter((s) => s.metadata?.labels?.['workspace-id'])
-    const out = new Map<string, ObservedState>()
-    if (sets.length === 0) return out
-
-    // One pod LIST across all auto-scaling workspaces, bucketed by workspace-id.
-    const pods = await this.coreApi.listNamespacedPod(
-      this.cfg.namespace,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      `app=${this.cfg.namePrefix},component=workspace`,
-    )
-    const podsByWs = new Map<string, k8s.V1Pod[]>()
-    for (const pod of pods.body.items) {
-      const wsId = pod.metadata?.labels?.['workspace-id']
-      if (!wsId) continue
-      const list = podsByWs.get(wsId)
-      if (list) list.push(pod)
-      else podsByWs.set(wsId, [pod])
-    }
-
-    for (const sts of sets) {
-      const wsId = sts.metadata?.labels?.['workspace-id'] as string
-      const name = this.getResourceName(wsId)
-      out.set(wsId, {
-        phase: resolveStatefulSetStatus(sts),
-        endpoint: {
-          address: `${name}-hl.${this.cfg.namespace}.svc.cluster.local:3001`,
-          readyReplicaIds: readyReplicaIdsFromPods(podsByWs.get(wsId) ?? [], name),
-          desiredReplicas: sts.spec?.replicas ?? 0,
-        },
-      })
-    }
-    return out
-  }
-
-  /** Delete a StatefulSet workspace's resources (StatefulSet + headless svc + PVC). */
-  private async deleteStatefulSetInstance(workspaceId: string): Promise<void> {
-    const name = this.getResourceName(workspaceId)
-    await Promise.all([
-      this.appsApi.deleteNamespacedStatefulSet(name, this.cfg.namespace).catch(swallow404),
-      this.coreApi.deleteNamespacedService(`${name}-hl`, this.cfg.namespace).catch(swallow404),
-      this.coreApi
-        .deleteNamespacedPersistentVolumeClaim(`${name}-workspace`, this.cfg.namespace)
-        .catch(swallow404),
-    ])
-  }
-
   // ── EnvironmentProvider interface ──
   // Infra-agnostic facade over the methods above, consumed by the runner. The
   // legacy methods stay (their callers are unchanged); these adapt signatures
@@ -904,7 +628,7 @@ export class KubernetesProvider implements EnvironmentProvider {
   /** Create if absent, else rebuild to converge (v1: cp bumps version → rebuild). */
   async apply(workspaceId: string, spec: WorkspaceSpec): Promise<void> {
     if (spec.runtimeMode === 'auto-scaling') {
-      await this.applyStatefulSet(workspaceId, spec)
+      await this.autoScaling.apply(workspaceId, spec)
       return
     }
     const existing = await this.getInstance(workspaceId)
@@ -926,14 +650,10 @@ export class KubernetesProvider implements EnvironmentProvider {
     // its Deployment 0→1; startInstance returns false (404) when there is none,
     // i.e. an auto-scaling workspace, whose StatefulSet we wake instead.
     const started = await this.startInstance(workspaceId)
-    if (!started) {
-      // Wake the StatefulSet to a floor of 1 replica; the autoscaler reconciles
-      // to the true desired on its next tick. (The primary wake path is apply()
-      // with spec.replicas — this covers a bare stopped→running phase flip with
-      // no spec bump.) scaleStatefulSet is 404-tolerant, so a workspace with
-      // neither shape is a no-op, exactly as before.
-      await this.scaleStatefulSet(workspaceId, 1)
-    }
+    // startInstance returns false (404) when there is no Deployment, i.e. an
+    // auto-scaling workspace — wake its StatefulSet instead (also a no-op if it
+    // has neither shape).
+    if (!started) await this.autoScaling.start(workspaceId)
   }
 
   async stop(workspaceId: string): Promise<void> {
@@ -941,14 +661,13 @@ export class KubernetesProvider implements EnvironmentProvider {
     // workspace scales its Deployment; stopInstance returns false (404) when
     // there is none, i.e. an auto-scaling workspace, whose StatefulSet we scale.
     const scaled = await this.stopInstance(workspaceId)
-    if (!scaled) await this.scaleStatefulSet(workspaceId, 0)
+    if (!scaled) await this.autoScaling.stop(workspaceId)
   }
 
   async destroy(workspaceId: string): Promise<void> {
     // A StatefulSet-backed workspace has no Deployment/ClusterIP Service to
     // delete; route teardown by the shape that actually exists.
-    const sts = await this.getStatefulSet(workspaceId)
-    if (sts) await this.deleteStatefulSetInstance(workspaceId)
+    if (await this.autoScaling.exists(workspaceId)) await this.autoScaling.destroy(workspaceId)
     else await this.deleteInstance(workspaceId)
   }
 
@@ -978,7 +697,7 @@ export class KubernetesProvider implements EnvironmentProvider {
     } catch (e: any) {
       if (e.response?.statusCode === 404) {
         // No Deployment — maybe an auto-scaling (StatefulSet) workspace.
-        return this.observeStatefulSet(workspaceId)
+        return this.autoScaling.observe(workspaceId)
       }
       throw e
     }
@@ -1005,7 +724,7 @@ export class KubernetesProvider implements EnvironmentProvider {
     }
     // Merge in auto-scaling (StatefulSet) workspaces. A workspace is only ever
     // one shape, so keys never collide.
-    for (const [wsId, state] of await this.observeAllStatefulSets()) {
+    for (const [wsId, state] of await this.autoScaling.observeAll()) {
       out.set(wsId, state)
     }
     return out

--- a/internal/k8s-provider/support.ts
+++ b/internal/k8s-provider/support.ts
@@ -1,0 +1,112 @@
+import type * as k8s from '@kubernetes/client-node'
+import type { K8sConfig } from './config'
+
+// Shared helpers used by both workload shapes (the static Deployment path on
+// KubernetesProvider and the AutoScalingWorkload StatefulSet path). Pure /
+// stateless over injected api clients + config, so neither shape depends on the
+// other.
+
+/** A delete/read whose 404 means "already gone" = success; rethrow the rest. */
+export function swallow404(e: any): void {
+  if (e.response?.statusCode !== 404) throw e
+}
+
+/**
+ * Run a create call, adopting an already-existing object instead of failing.
+ * Provisioning must be idempotent: the reconcile loop re-enters it every tick
+ * while a workspace is unconverged, and the PVC/Service deliberately outlive the
+ * workload (rebuild, manual deletion). A bare create would 409 on the survivors
+ * forever and deadlock the reconcile.
+ */
+export async function createOrAdopt(create: () => Promise<unknown>): Promise<void> {
+  try {
+    await create()
+  } catch (e: any) {
+    if (e.response?.statusCode !== 409) throw e
+  }
+}
+
+/** The k8s object name for a workspace's resources (`<prefix>-<wsId>`). */
+export function resourceName(cfg: K8sConfig, workspaceId: string): string {
+  return `${cfg.namePrefix}-${workspaceId}`
+}
+
+/** Common labels / selector for a workspace's resources. */
+export function workspaceLabels(cfg: K8sConfig, workspaceId: string): Record<string, string> {
+  return {
+    app: cfg.namePrefix,
+    component: 'workspace',
+    'workspace-id': workspaceId,
+  }
+}
+
+const STORAGE_UNITS: Record<string, number> = {
+  Ki: 2 ** 10,
+  Mi: 2 ** 20,
+  Gi: 2 ** 30,
+  Ti: 2 ** 40,
+  Pi: 2 ** 50,
+  Ei: 2 ** 60,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+}
+
+/** Parse a k8s resource quantity string (e.g. "50Gi", "100000000") into bytes. */
+function parseStorageQuantity(quantity: string): number {
+  const match = quantity.match(/^([0-9.]+)([A-Za-z]*)$/)
+  if (!match) throw new Error(`Unparseable storage quantity: ${quantity}`)
+  const [, num, unit] = match
+  const multiplier = unit ? STORAGE_UNITS[unit] : 1
+  if (multiplier === undefined) throw new Error(`Unknown storage unit: ${unit}`)
+  return Number(num) * multiplier
+}
+
+/**
+ * Expand a workspace PVC. K8s only ever allows a PVC to grow, never shrink —
+ * patching a smaller size is rejected by the API. A desired spec asking for
+ * less than what's provisioned (e.g. a stale/lowered compute_resources value)
+ * is treated as a no-op here rather than an error, so it can't block spec
+ * convergence for every other field forever (see incident: apply() threw on
+ * this every reconcile pass, tearing down and recreating the workload before
+ * the new pod could ever pass its startup probe). 404-tolerant: false when the
+ * PVC doesn't exist.
+ */
+export async function expandWorkspacePvc(
+  coreApi: k8s.CoreV1Api,
+  cfg: K8sConfig,
+  pvcName: string,
+  newSize: string,
+): Promise<boolean> {
+  try {
+    const current = await coreApi.readNamespacedPersistentVolumeClaim(pvcName, cfg.namespace)
+    const currentSize = current.body.spec?.resources?.requests?.storage
+    if (currentSize && parseStorageQuantity(newSize) <= parseStorageQuantity(currentSize)) {
+      return true
+    }
+  } catch (e: any) {
+    if (e.response?.statusCode === 404) return false
+    throw e
+  }
+
+  try {
+    await coreApi.patchNamespacedPersistentVolumeClaim(
+      pvcName,
+      cfg.namespace,
+      { spec: { resources: { requests: { storage: newSize } } } },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { headers: { 'Content-Type': 'application/merge-patch+json' } },
+    )
+    return true
+  } catch (e: any) {
+    if (e.response?.statusCode === 404) return false
+    throw e
+  }
+}

--- a/internal/k8s-provider/support.ts
+++ b/internal/k8s-provider/support.ts
@@ -40,6 +40,17 @@ export function workspaceLabels(cfg: K8sConfig, workspaceId: string): Record<str
   }
 }
 
+/** The workspace's persistent-volume-claim name. */
+export function workspacePvcName(cfg: K8sConfig, workspaceId: string): string {
+  return `${resourceName(cfg, workspaceId)}-workspace`
+}
+
+/** A pod is Ready when it has container statuses and all of them are ready. */
+export function isPodReady(pod: k8s.V1Pod): boolean {
+  const statuses = pod.status?.containerStatuses ?? []
+  return statuses.length > 0 && statuses.every((c) => c.ready)
+}
+
 const STORAGE_UNITS: Record<string, number> = {
   Ki: 2 ** 10,
   Mi: 2 ** 20,

--- a/internal/k8s-provider/workspace-spec.ts
+++ b/internal/k8s-provider/workspace-spec.ts
@@ -260,6 +260,77 @@ export function buildDeploymentSpec(
 }
 
 /**
+ * The auto-scaling workload form: a StatefulSet whose pods all mount the SAME
+ * shared ReadWriteMany workspace PVC (via the pod template's `workspace`
+ * volume) — deliberately NOT volumeClaimTemplates. StatefulSet is used only for
+ * its stable per-ordinal identity: stable DNS (`<name>-<n>.<name>-hl`) so cp
+ * routing is stateless, and ordered scale-down (highest ordinal first) so
+ * draining has a determinate target. The pod template is byte-identical to the
+ * Deployment's — same container/sidecar/volume layout via
+ * {@link buildWorkspacePodTemplate} — so there is no second template to drift.
+ */
+export function buildStatefulSetSpec(
+  name: string,
+  labels: Record<string, string>,
+  workspaceId: string,
+  agentType: string,
+  pvcName: string,
+  replicas: number,
+  resources?: ComputeResources,
+  cfg: K8sConfig = defaultCfg,
+): k8s.V1StatefulSet {
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'StatefulSet',
+    metadata: {
+      name,
+      labels,
+      annotations: { [TEMPLATE_VERSION_ANNOTATION]: String(CURRENT_TEMPLATE_VERSION) },
+    },
+    spec: {
+      serviceName: `${name}-hl`,
+      replicas,
+      // Bring all replicas up/down at once — replicas share the workspace
+      // volume and have no inter-pod handshake, so OrderedReady's one-at-a-time
+      // gating would only make scale-up needlessly slow. Scale-DOWN still
+      // removes the highest ordinal first regardless of this policy.
+      podManagementPolicy: 'Parallel',
+      selector: { matchLabels: labels },
+      template: buildWorkspacePodTemplate(labels, workspaceId, agentType, pvcName, resources, cfg),
+      // No volumeClaimTemplates: every pod mounts the one shared RWX PVC named
+      // in the pod template. See the function doc.
+    },
+  }
+}
+
+/**
+ * The headless Service backing a StatefulSet workspace: `clusterIP: None`, so
+ * each pod gets a stable DNS name (`<name>-<ordinal>.<name>-hl.<ns>.svc`) that
+ * cp routes to per replica. No ClusterIP Service is created for an auto-scaling
+ * workspace — a VIP would round-robin across replicas and defeat session
+ * affinity.
+ */
+export function buildHeadlessServiceSpec(
+  name: string,
+  labels: Record<string, string>,
+): k8s.V1Service {
+  return {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: { name: `${name}-hl`, labels },
+    spec: {
+      clusterIP: 'None',
+      selector: labels,
+      ports: [
+        { port: 3001, targetPort: 3001 as any, name: 'http' },
+        { port: 9101, targetPort: 9101 as any, name: 'afs-fuse' },
+        { port: 9102, targetPort: 9102 as any, name: 'memory-fuse' },
+      ],
+    },
+  }
+}
+
+/**
  * Batch-check K8s deployment statuses for active workspaces.
  * Returns a map of workspaceId → resolved status.
  * Uses a single listNamespacedDeployment call (O(1) K8s API).
@@ -291,4 +362,43 @@ export function deploymentTemplateVersion(dep: k8s.V1Deployment | undefined): nu
   if (raw === undefined) return null
   const n = Number(raw)
   return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Resolve a StatefulSet to a workspace status. Unlike a Deployment there is no
+ * Progressing condition to read, so a not-yet-ready set is always 'starting'
+ * (the pod's 600s startupProbe grace covers a slow boot); the autoscaler and
+ * per-replica readiness live in {@link readyReplicaIdsFromPods}, not here.
+ */
+export function resolveStatefulSetStatus(
+  sts: k8s.V1StatefulSet | undefined,
+): ReconciledStatus {
+  const desired = sts?.spec?.replicas ?? 0
+  if (!sts || desired === 0) return 'stopped'
+  const ready = sts.status?.readyReplicas ?? 0
+  return ready >= 1 ? 'running' : 'starting'
+}
+
+/** Parse the ordinal (replica id) out of a StatefulSet pod name, or null. */
+function podReplicaOrdinal(podName: string, stsName: string): number | null {
+  const prefix = `${stsName}-`
+  if (!podName.startsWith(prefix)) return null
+  const suffix = podName.slice(prefix.length)
+  return /^\d+$/.test(suffix) ? Number(suffix) : null
+}
+
+/**
+ * The replica ids of the Ready pods of a StatefulSet — the readiness signal cp
+ * routes on (reported via ObservedState.readyReplicaIds). A pod is Ready when
+ * it has container statuses and all of them are ready. Returned sorted.
+ */
+export function readyReplicaIdsFromPods(pods: k8s.V1Pod[], stsName: string): number[] {
+  const ids: number[] = []
+  for (const pod of pods) {
+    const ordinal = podReplicaOrdinal(pod.metadata?.name ?? '', stsName)
+    if (ordinal === null) continue
+    const statuses = pod.status?.containerStatuses ?? []
+    if (statuses.length > 0 && statuses.every((c) => c.ready)) ids.push(ordinal)
+  }
+  return ids.sort((a, b) => a - b)
 }

--- a/internal/k8s-provider/workspace-spec.ts
+++ b/internal/k8s-provider/workspace-spec.ts
@@ -1,6 +1,7 @@
 import type * as k8s from '@kubernetes/client-node'
 import type { ComputeResources } from '../types/api'
 import { type K8sConfig, agentImageFor, defaultCfg } from './config'
+import { isPodReady } from './support'
 
 // Workspace pod/deployment spec construction, plus the pure status/annotation
 // readers the reconcile paths share. Split from the provider so the pod
@@ -304,6 +305,17 @@ export function buildStatefulSetSpec(
 }
 
 /**
+ * Ports every workspace Service exposes: the agent (http), afs-fuse and
+ * memory-fuse sidecars. Shared by the static ClusterIP Service and the
+ * auto-scaling headless Service so the two shapes can't drift.
+ */
+export const WORKSPACE_SERVICE_PORTS: k8s.V1ServicePort[] = [
+  { port: 3001, targetPort: 3001 as any, name: 'http' },
+  { port: 9101, targetPort: 9101 as any, name: 'afs-fuse' },
+  { port: 9102, targetPort: 9102 as any, name: 'memory-fuse' },
+]
+
+/**
  * The headless Service backing a StatefulSet workspace: `clusterIP: None`, so
  * each pod gets a stable DNS name (`<name>-<ordinal>.<name>-hl.<ns>.svc`) that
  * cp routes to per replica. No ClusterIP Service is created for an auto-scaling
@@ -321,11 +333,7 @@ export function buildHeadlessServiceSpec(
     spec: {
       clusterIP: 'None',
       selector: labels,
-      ports: [
-        { port: 3001, targetPort: 3001 as any, name: 'http' },
-        { port: 9101, targetPort: 9101 as any, name: 'afs-fuse' },
-        { port: 9102, targetPort: 9102 as any, name: 'memory-fuse' },
-      ],
+      ports: WORKSPACE_SERVICE_PORTS,
     },
   }
 }
@@ -370,9 +378,7 @@ export function deploymentTemplateVersion(dep: k8s.V1Deployment | undefined): nu
  * (the pod's 600s startupProbe grace covers a slow boot); the autoscaler and
  * per-replica readiness live in {@link readyReplicaIdsFromPods}, not here.
  */
-export function resolveStatefulSetStatus(
-  sts: k8s.V1StatefulSet | undefined,
-): ReconciledStatus {
+export function resolveStatefulSetStatus(sts: k8s.V1StatefulSet | undefined): ReconciledStatus {
   const desired = sts?.spec?.replicas ?? 0
   if (!sts || desired === 0) return 'stopped'
   const ready = sts.status?.readyReplicas ?? 0
@@ -389,16 +395,13 @@ function podReplicaOrdinal(podName: string, stsName: string): number | null {
 
 /**
  * The replica ids of the Ready pods of a StatefulSet — the readiness signal cp
- * routes on (reported via ObservedState.readyReplicaIds). A pod is Ready when
- * it has container statuses and all of them are ready. Returned sorted.
+ * routes on (reported via the endpoint's readyReplicaIds). Returned sorted.
  */
 export function readyReplicaIdsFromPods(pods: k8s.V1Pod[], stsName: string): number[] {
   const ids: number[] = []
   for (const pod of pods) {
     const ordinal = podReplicaOrdinal(pod.metadata?.name ?? '', stsName)
-    if (ordinal === null) continue
-    const statuses = pod.status?.containerStatuses ?? []
-    if (statuses.length > 0 && statuses.every((c) => c.ready)) ids.push(ordinal)
+    if (ordinal !== null && isPodReady(pod)) ids.push(ordinal)
   }
   return ids.sort((a, b) => a - b)
 }

--- a/internal/types/environments.ts
+++ b/internal/types/environments.ts
@@ -121,16 +121,13 @@ export interface EnvironmentEndpoint {
   routeKey?: string
   /**
    * For an auto-scaling workspace: the provider-assigned ids of the Ready
-   * replicas (a subset of `[0, desiredReplicas)`). This is the readiness signal
-   * cp routes on — the replicas reachable right now. It rides on the endpoint
-   * (not a separate observed field) because for a multi-replica workspace the
-   * ready set IS its reachability; it therefore flows to cp through the existing
-   * observed-endpoint channel with no extra plumbing. Omitted for single-replica
-   * (static) workspaces.
+   * replicas. This is the readiness signal cp routes on — the replicas reachable
+   * right now. It rides on the endpoint (not a separate observed field) because
+   * for a multi-replica workspace the ready set IS its reachability; it therefore
+   * flows to cp through the existing observed-endpoint channel with no extra
+   * plumbing. Omitted for single-replica (static) workspaces.
    */
   readyReplicaIds?: number[]
-  /** Desired replica count for an auto-scaling workspace (status display). */
-  desiredReplicas?: number
 }
 
 /** The runner's observation of a single workspace, written back to cp. */

--- a/internal/types/environments.ts
+++ b/internal/types/environments.ts
@@ -119,6 +119,18 @@ export interface EnvironmentEndpoint {
   address?: string
   /** Tunnel routing key for remote environments (P2). */
   routeKey?: string
+  /**
+   * For an auto-scaling workspace: the provider-assigned ids of the Ready
+   * replicas (a subset of `[0, desiredReplicas)`). This is the readiness signal
+   * cp routes on — the replicas reachable right now. It rides on the endpoint
+   * (not a separate observed field) because for a multi-replica workspace the
+   * ready set IS its reachability; it therefore flows to cp through the existing
+   * observed-endpoint channel with no extra plumbing. Omitted for single-replica
+   * (static) workspaces.
+   */
+  readyReplicaIds?: number[]
+  /** Desired replica count for an auto-scaling workspace (status display). */
+  desiredReplicas?: number
 }
 
 /** The runner's observation of a single workspace, written back to cp. */
@@ -126,20 +138,10 @@ export interface ObservedState {
   phase: ObservedPhase
   /** The spec version the runner has converged to. */
   version?: number
+  // Reachability, incl. the ready replica set for auto-scaling workspaces
+  // (endpoint.readyReplicaIds) — the readiness signal cp routes on.
   endpoint?: EnvironmentEndpoint
   message?: string
-  /**
-   * Replica counts for an `'auto-scaling'` workspace: how many the runner wants
-   * (`desired`) and how many are Ready. Omitted for single-replica (`'static'`)
-   * workspaces, which report liveness through `phase` alone.
-   */
-  replicas?: { desired: number; ready: number }
-  /**
-   * Provider-assigned ids of the Ready replicas (a subset of `[0, desired)`).
-   * This is the sole readiness signal the control plane routes on — cp does not
-   * probe replicas itself. Omitted for single-replica workspaces.
-   */
-  readyReplicaIds?: number[]
 }
 
 /** A handle returned by {@link EnvironmentProvider.watch} to stop watching. */


### PR DESCRIPTION
**Stage 2 of the auto-scaling workspaces stack** → merges into `feat/auto-scaling-workspaces` (integration PR #143), not `main`.

Implements the multi-replica workload shape behind the existing `EnvironmentProvider` seam. **Dormant**: nothing sets `runtimeMode: 'auto-scaling'` yet (no DB column feeds it until stage 4), so every static workspace is byte-identical and the static Deployment path is untouched.

### What

- **`workspace-spec.ts`**
  - `buildStatefulSetSpec` + `buildHeadlessServiceSpec` — reuse `buildWorkspacePodTemplate` **verbatim**. All replicas mount **one shared RWX PVC** (no `volumeClaimTemplates`); StatefulSet is used only for stable per-ordinal DNS (`<name>-<n>.<name>-hl`) + ordered scale-down. Headless Service only — no ClusterIP (a VIP would round-robin and defeat affinity).
  - `resolveStatefulSetStatus`, `readyReplicaIdsFromPods` — pure readers (ordinal parsed from pod name; ready = all containers ready; sorted).
- **`provider.ts`**
  - `apply()` forks on `runtimeMode === 'auto-scaling'`.
  - `observe` / `stop` / `destroy` **detect the shape from what exists** (they aren't handed the spec), so the static single-call path stays identical; `observeAll` merges a StatefulSet LIST.
  - Converge is **in-place** (strategic-merge patch, never delete+recreate — that would take all replicas down); RWX PVC.
  - `capabilities()` advertises `multiReplica` (env-gated `WORKSPACE_MULTI_REPLICA`, **default off**).
- **`config.ts`** — `WORKSPACE_MULTI_REPLICA` gate.
- **tests** — StatefulSet golden master, template-embedding equality vs the Deployment, status/readiness reader tables.

### Verification
- cp + env-runner-k8s `tsc --noEmit`: clean
- cp unit suite: 219 passed (12 files)
- knip + biome (control-plane): pass

### Notes / for review
- **Naming**: `multiReplica` (not `sharedFs`) carries the "N replicas + shared RWX volume" semantic — `sharedFs` already means the cross-workspace AgentFS sidecar.
- Template-drift convergence for auto-scaling uses a strategic-merge patch of the pod template (rolling update). A sidecar *removed* between versions wouldn't be pruned by strategic merge — acceptable for preview, flagged for a later hardening pass.
- `addressFor` / `nextRemovedReplicaIds` provider methods are **not** here — they land in their consuming stages (routing / autoscaler) where the cp-side-vs-runner-side seam shape is settled.