### PR TITLE
c3: per-replica agent address seam

### DIFF
--- a/control-plane/src/lib/workspace-address.test.ts
+++ b/control-plane/src/lib/workspace-address.test.ts
@@ -34,6 +34,12 @@ describe('getWorkspaceAddress', () => {
     expect(getWorkspaceAddress('ws1')).toBe('http://tos-ws1.default.svc.cluster.local:3001')
   })
 
+  it('resolves a specific replica to its per-ordinal headless DNS', () => {
+    expect(getWorkspaceAddress('ws1', 2)).toBe(
+      'http://tos-ws1-2.tos-ws1-hl.default.svc.cluster.local:3001',
+    )
+  })
+
   it('resolves remote workspaces to their localhost forward proxy', () => {
     getRemoteProxyPortMock.mockReturnValue(41234)
     expect(getWorkspaceAddress('ws1')).toBe('http://127.0.0.1:41234')
@@ -41,12 +47,19 @@ describe('getWorkspaceAddress', () => {
 })
 
 describe('resolveAgentAddress', () => {
-  it('matches getWorkspaceAddress for every route context (single-replica invariant)', () => {
+  it('matches the default builtin address when no replica is bound', () => {
     const expected = getWorkspaceAddress('ws1')
     expect(resolveAgentAddress('ws1')).toBe(expected)
     expect(resolveAgentAddress('ws1', {})).toBe(expected)
     expect(resolveAgentAddress('ws1', { sessionId: null })).toBe(expected)
     expect(resolveAgentAddress('ws1', { sessionId: 'sess-1' })).toBe(expected)
+    expect(resolveAgentAddress('ws1', { sessionId: 'sess-1', replicaId: null })).toBe(expected)
+  })
+
+  it('routes a replica-bound session to that replica', () => {
+    expect(resolveAgentAddress('ws1', { sessionId: 'sess-1', replicaId: 0 })).toBe(
+      'http://tos-ws1-0.tos-ws1-hl.default.svc.cluster.local:3001',
+    )
   })
 
   it('follows the remote-proxy path too', () => {

--- a/control-plane/src/lib/workspace-address.ts
+++ b/control-plane/src/lib/workspace-address.ts
@@ -1,39 +1,35 @@
+import { builtinReplicaAddress, defaultCfg } from '../../../internal/k8s-provider'
 import { getRemoteProxyPort } from './remote-proxy'
 
-const NAMESPACE = process.env.K8S_NAMESPACE || 'default'
-const AGENT_PORT = 3001
-
-/** Cluster-DNS address of a workspace on the built-in environment. */
-function builtinAddress(workspaceId: string): string {
-  return `http://tos-${workspaceId}.${NAMESPACE}.svc.cluster.local:${AGENT_PORT}`
-}
-
 /**
- * Resolve the base URL cp uses to reach a workspace's agent.
+ * Resolve the base URL cp uses to reach a workspace's agent, optionally a
+ * specific replica of an auto-scaling workspace.
  *
- * This is the workspace data-plane routing seam (design §6). In v1 every
- * workspace lives on the built-in environment and is reached via cluster DNS —
- * so this stays a synchronous, zero-cost call, identical to before.
+ * This is the workspace data-plane routing seam (design §6). A built-in
+ * workspace is reached via cluster DNS — the k8s address format lives in the
+ * provider package ({@link builtinReplicaAddress}), so cp-core never hardcodes
+ * cluster-DNS shape. `replicaId` omitted → the workspace's own Service
+ * (single-replica / static, byte-identical to before); `replicaId` given → that
+ * StatefulSet pod's stable per-ordinal DNS.
  *
  * A workspace on a remote (BYOI) environment is reached through that
- * environment's tunnel instead of cluster DNS. cp keeps a localhost forward
- * proxy per reachable remote workspace (lib/remote-proxy); this stays a
- * synchronous O(1) map lookup — built-in workspaces are never in the map, so
- * their path is byte-identical (cluster DNS, zero extra cost). The proxy
- * lifecycle (set up on observe-running, torn down on stop) is driven elsewhere.
+ * environment's tunnel instead. cp keeps a localhost forward proxy per
+ * reachable remote workspace (lib/remote-proxy); this stays a synchronous O(1)
+ * map lookup — built-in workspaces are never in the map, so their path is
+ * byte-identical. Per-replica remote addressing (a proxy keyed by (ws, replica),
+ * with the ordinal carried in the tunnel meta) is a later stage, so today the
+ * remote proxy is per-workspace and `replicaId` does not yet reach it.
  */
-export function getWorkspaceAddress(workspaceId: string): string {
+export function getWorkspaceAddress(workspaceId: string, replicaId?: number): string {
   const remotePort = getRemoteProxyPort(workspaceId)
   if (remotePort !== undefined) return `http://127.0.0.1:${remotePort}`
-  return builtinAddress(workspaceId)
+  return builtinReplicaAddress(defaultCfg, workspaceId, replicaId)
 }
 
 /**
- * Why a request is being routed to the workspace's agent. A workspace runs
- * exactly one replica today, so every context resolves to the same address —
- * but call sites that act on behalf of a session declare it here, so that the
- * day a workspace runs more than one replica, session-affine routing is a
- * change to this function only, not to its callers.
+ * Why a request is being routed to the workspace's agent. Call sites that act on
+ * behalf of a session declare it here so session-affine routing is a change to
+ * this seam only, not to its callers.
  */
 interface AgentRouteContext {
   /**
@@ -42,6 +38,14 @@ interface AgentRouteContext {
    * workspace-scoped call — both route to the workspace's default address.
    */
   sessionId?: string | null
+  /**
+   * The replica (auto-scaling workspaces only) this request is bound to — the
+   * session's `replica_ordinal` binding. undefined/null → the workspace's
+   * default address (a static workspace, or a call with no replica affinity).
+   * The binding that fills this comes from the replica router (a later stage);
+   * until then every caller leaves it unset and routing is byte-identical.
+   */
+  replicaId?: number | null
 }
 
 /**
@@ -51,8 +55,8 @@ interface AgentRouteContext {
  * calling {@link getWorkspaceAddress} directly — it is this function's
  * zero-context form.
  */
-export function resolveAgentAddress(workspaceId: string, _ctx: AgentRouteContext = {}): string {
-  return getWorkspaceAddress(workspaceId)
+export function resolveAgentAddress(workspaceId: string, ctx: AgentRouteContext = {}): string {
+  return getWorkspaceAddress(workspaceId, ctx.replicaId ?? undefined)
 }
 
 type ReloadScope = 'config' | 'skills' | 'credentials'

--- a/control-plane/src/services/k8s-deployment-spec.test.ts
+++ b/control-plane/src/services/k8s-deployment-spec.test.ts
@@ -4,6 +4,7 @@ import {
   buildHeadlessServiceSpec,
   buildStatefulSetSpec,
   buildWorkspacePodTemplate,
+  builtinReplicaAddress,
   readyReplicaIdsFromPods,
   resolveStatefulSetStatus,
 } from '../../../internal/k8s-provider'
@@ -240,6 +241,21 @@ describe('buildHeadlessServiceSpec', () => {
     expect(svc.spec?.clusterIP).toBe('None')
     expect(svc.spec?.selector).toEqual(labels)
     expect(svc.spec?.ports?.map((p) => p.port)).toEqual([3001, 9101, 9102])
+  })
+})
+
+describe('builtinReplicaAddress', () => {
+  it('no replica → the workspace Service DNS (static / single-replica path)', () => {
+    expect(builtinReplicaAddress(baseCfg, 'ws1')).toBe('http://nap-ws1.nap.svc.cluster.local:3001')
+  })
+
+  it("a replica id → that pod's per-ordinal headless DNS", () => {
+    expect(builtinReplicaAddress(baseCfg, 'ws1', 0)).toBe(
+      'http://nap-ws1-0.nap-ws1-hl.nap.svc.cluster.local:3001',
+    )
+    expect(builtinReplicaAddress(baseCfg, 'ws1', 2)).toBe(
+      'http://nap-ws1-2.nap-ws1-hl.nap.svc.cluster.local:3001',
+    )
   })
 })
 

--- a/internal/k8s-provider/index.ts
+++ b/internal/k8s-provider/index.ts
@@ -10,15 +10,17 @@
 // This index re-exports the package's public surface; import from here, not
 // from the submodules.
 
-export { type K8sConfig, getAgentImage, isMemoryFuseAvailable } from './config'
+export { type K8sConfig, defaultCfg, getAgentImage, isMemoryFuseAvailable } from './config'
 export { KubernetesProvider, makeDefaultProvider } from './provider'
 export {
+  AGENT_PORT,
   CURRENT_TEMPLATE_VERSION,
   type ReconciledStatus,
   buildDeploymentSpec,
   buildHeadlessServiceSpec,
   buildStatefulSetSpec,
   buildWorkspacePodTemplate,
+  builtinReplicaAddress,
   deploymentTemplateVersion,
   readyReplicaIdsFromPods,
   resolveDeploymentStatus,

--- a/internal/k8s-provider/workspace-spec.ts
+++ b/internal/k8s-provider/workspace-spec.ts
@@ -338,6 +338,39 @@ export function buildHeadlessServiceSpec(
   }
 }
 
+/** The HTTP port a workspace agent serves on (mirrors the pod's `http` port). */
+export const AGENT_PORT = 3001
+
+/**
+ * The in-cluster base URL to reach a workspace's agent on the built-in (k8s)
+ * environment. This is the k8s address format, kept in the provider package so
+ * cp-core never hardcodes cluster-DNS shape — it asks for an address by
+ * (workspace, replica) and gets a URL back.
+ *
+ * - `replicaId` omitted → the workspace's own Service: `<prefix>-<ws>.<ns>.svc`.
+ *   This is the single-replica (static) path and is byte-identical to the
+ *   address cp built inline before this seam existed.
+ * - `replicaId` given → one specific StatefulSet pod of an auto-scaling
+ *   workspace, via its headless Service:
+ *   `<prefix>-<ws>-<id>.<prefix>-<ws>-hl.<ns>.svc`. This is the stable
+ *   per-ordinal DNS {@link buildStatefulSetSpec} exists to provide.
+ *
+ * Pure (config + ids → string): no kube client, so cp can call it synchronously
+ * on the routing hot path without an API round-trip.
+ */
+export function builtinReplicaAddress(
+  cfg: K8sConfig,
+  workspaceId: string,
+  replicaId?: number,
+): string {
+  const base = `${cfg.namePrefix}-${workspaceId}`
+  const host =
+    replicaId === undefined
+      ? `${base}.${cfg.namespace}.svc.cluster.local`
+      : `${base}-${replicaId}.${base}-hl.${cfg.namespace}.svc.cluster.local`
+  return `http://${host}:${AGENT_PORT}`
+}
+
 /**
  * Batch-check K8s deployment statuses for active workspaces.
  * Returns a map of workspaceId → resolved status.


### PR DESCRIPTION
Stage 3 (of the auto-scaling workspaces feature). Bottom-up, dormant, static byte-unchanged.

## What
The address seam beneath the replica router: cp resolves an agent base URL by (workspace, replica) instead of hardcoding cluster-DNS shape.

- **`builtinReplicaAddress(cfg, ws, replicaId?)`** (k8s-provider, pure): no replica id → the workspace's own Service `<prefix>-<ws>.<ns>.svc` (byte-identical to what cp built inline); a replica id → that StatefulSet pod's stable per-ordinal headless DNS `<prefix>-<ws>-<id>.<prefix>-<ws>-hl.<ns>.svc`.
- **`resolveAgentAddress` / `getWorkspaceAddress`** (cp) route through it; `AgentRouteContext` gains `replicaId?` (a session's `replica_ordinal` binding).

## Why it's safe to ship alone
Nothing produces a `replicaId` yet — the replica router that fills it is a later stage. So every current caller resolves `replicaId === undefined` → the exact same address as before, on both the builtin and remote-proxy paths. Remote stays per-workspace; per-(ws, replica) remote addressing via tunnel meta is a later stage.

## Design note
`builtinReplicaAddress` is a pure k8s-provider helper (not an `EnvironmentProvider` method): cp only holds the built-in provider in-process, and a remote environment's addressing is the tunnel + localhost proxy — a different mechanism, not a synchronous provider call. cp-core dispatches builtin → helper / remote → proxy.

## Tests
`workspace-address.test.ts` + `k8s-deployment-spec.test.ts` cover the no-replica (static) and replica-bound (per-ordinal) forms. 41 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)