### PR TITLE
c4: replica router — session→replica affinity + routing

### DIFF
--- a/control-plane/migrations/124_session_replica_ordinal.sql
+++ b/control-plane/migrations/124_session_replica_ordinal.sql
@@ -1,0 +1,10 @@
+-- Session → replica affinity for auto-scaling workspaces.
+-- When a workspace runs more than one replica (all sharing the same RWX
+-- workspace volume), a session's turns must keep hitting the SAME replica: the
+-- turn is a long-lived SSE to one agent process, and its transcript file must
+-- not be appended by two replicas at once. This pins the session to the
+-- provider-assigned replica id it was routed to.
+-- NULL for every static (single-replica) session — the routing seam resolves a
+-- NULL binding to the workspace's default address, byte-identical to before.
+-- No FK / no default: it is runtime routing state, not a modeled relation.
+ALTER TABLE public.sessions ADD COLUMN IF NOT EXISTS replica_ordinal int;

--- a/control-plane/src/lib/reconcile.ts
+++ b/control-plane/src/lib/reconcile.ts
@@ -10,6 +10,7 @@ import { getWorkspace, listAllWorkspaces, updateWorkspace } from '../services/db
 import { runEnvProjection } from '../services/env-projection'
 import { runIdleWorkspaceGC } from '../services/idle-workspace-gc'
 import * as k8s from '../services/k8s'
+import { refreshReplicaRouter } from '../services/replica-router'
 import { sweepRunningWorkspaces } from '../services/usage/pull'
 import { applyStatusChange } from './workspace-status'
 
@@ -186,6 +187,20 @@ export function startReconcileLoop() {
   new Cron(ENV_PROJECTION_INTERVAL, { protect: true }, () =>
     runEnvProjection(ENV_HEARTBEAT_TIMEOUT_SEC).catch((e) =>
       console.error('[Reconcile] env projection error:', e instanceof Error ? e.message : e),
+    ),
+  )
+
+  // Replica-router refresh: rebuild the in-memory ready-replica set of every
+  // auto-scaling workspace from the runner-reported observed endpoint. Same
+  // 15s cadence as the projection; a cheap no-op while no workspace is
+  // auto-scaling (the query returns nothing). protect:true so a slow pass never
+  // stacks.
+  new Cron(ENV_PROJECTION_INTERVAL, { protect: true }, () =>
+    refreshReplicaRouter().catch((e) =>
+      console.error(
+        '[Reconcile] replica router refresh error:',
+        e instanceof Error ? e.message : e,
+      ),
     ),
   )
 

--- a/control-plane/src/lib/sse.ts
+++ b/control-plane/src/lib/sse.ts
@@ -9,6 +9,7 @@ import {
 } from '../services/db/messages'
 import {
   createSession,
+  setSessionReplicaOrdinal,
   transitionSessionStatus,
   updateSessionActivity,
   updateSessionStats,
@@ -377,6 +378,13 @@ interface InterceptedSSEOptions {
    * session→task reverse lookup can succeed on the very first tool call.
    */
   onNewSession?: (sessionId: string) => Promise<void>
+  /**
+   * The auto-scaling replica this turn was routed to, from the replica router.
+   * Persisted onto the session row on `session.started` so the session's next
+   * turns pin to the same replica (shared-volume transcript safety). Undefined
+   * for static single-replica workspaces — the binding stays NULL.
+   */
+  replicaId?: number
 }
 
 export function createInterceptedSSEResponse(
@@ -394,6 +402,7 @@ export function createInterceptedSSEResponse(
     initialAssistant,
     sessionToken,
     onNewSession,
+    replicaId,
   } = opts
   if (!response.body) {
     return new Response(response.body, {
@@ -458,6 +467,7 @@ export function createInterceptedSSEResponse(
     initialAssistant,
     sessionToken,
     onNewSession,
+    replicaId,
   })
   const broadcastPlugin = createBroadcastPlugin({
     workspaceId,
@@ -655,6 +665,12 @@ interface PersistPluginCtx {
    * X-Task-Id header path. Errors are logged but not propagated.
    */
   onNewSession?: (sessionId: string) => Promise<void>
+  /**
+   * The auto-scaling replica this turn was routed to; persisted onto the
+   * session row on `session.started` so subsequent turns pin to it. Undefined
+   * for static workspaces (binding stays NULL).
+   */
+  replicaId?: number
   /**
    * Optional initial assistant-message state. Set on the recovery path
    * (CP restart) so the plugin resumes writing into the existing DB row
@@ -871,6 +887,15 @@ function createPersistMainTurnPlugin(ctx: PersistPluginCtx): TurnPlugin {
               await updateSessionActivity(newSid)
             }
             await transitionSessionStatus(newSid, 'agent')
+            // Pin the session to the replica this turn was routed to (auto-
+            // scaling workspaces only). Written every turn: unchanged while
+            // affinity holds, updated when the router rebound to a healthy
+            // replica. Stays NULL for static workspaces (replicaId undefined).
+            if (ctx.replicaId !== undefined) {
+              await setSessionReplicaOrdinal(newSid, ctx.replicaId).catch((e) => {
+                console.warn(`[SSE] setSessionReplicaOrdinal failed session=${newSid}:`, e)
+              })
+            }
             // Bind the dispatcher-minted token to this session_id once the
             // sessions row exists (FK target satisfied). Idempotent: a
             // reconnect that re-emits session.started for an already-bound

--- a/control-plane/src/services/chat/executeChat.ts
+++ b/control-plane/src/services/chat/executeChat.ts
@@ -11,6 +11,7 @@ import {
 import { addTeamworkSession } from '../db/teamwork'
 import type { Workspace } from '../db/types'
 import { getWorkspace } from '../db/workspaces'
+import { pickReplicaForTurn } from '../replica-router'
 import { WorkspaceStartError, ensureWorkspaceRunning } from '../workspace-autostart'
 import { type ChatImage, buildAgentChatBody, buildUserMessageBlocks } from './request'
 
@@ -81,14 +82,23 @@ export async function executeChat(opts: ExecuteChatOpts): Promise<Response> {
   // this a caller could drive messages belonging to another workspace's
   // session, or create orphan rows with `session_id` pointing at a
   // session that lives under a different workspace_id.
+  let boundReplica: number | undefined
   if (sessionId) {
     const session = await getSession(sessionId)
     if (!session || session.workspace_id !== workspaceId) {
       return jsonError('Session not found for this workspace', 400)
     }
+    boundReplica = session.replica_ordinal ?? undefined
   }
 
-  const address = resolveAgentAddress(workspaceId, { sessionId })
+  // For an auto-scaling workspace, pin this turn to a specific replica: keep the
+  // session's existing binding while its replica is still ready, else rebind /
+  // pick fresh (a new session, or a replica that dropped out). Static workspaces
+  // report no ready set → undefined → the workspace's default address,
+  // byte-identical to before. The chosen id is threaded to the interceptor so
+  // `session.started` persists the binding for the session's next turns.
+  const replicaId = pickReplicaForTurn(workspaceId, boundReplica)
+  const address = resolveAgentAddress(workspaceId, { sessionId, replicaId })
 
   // Mint (or look up) the session_token before dispatching. For a resume
   // the same token follows the session across turns; for a new session we
@@ -202,6 +212,7 @@ export async function executeChat(opts: ExecuteChatOpts): Promise<Response> {
     },
     sessionToken,
     onNewSession,
+    replicaId,
   })
 }
 

--- a/control-plane/src/services/db/env-placements.ts
+++ b/control-plane/src/services/db/env-placements.ts
@@ -85,6 +85,26 @@ export async function writeObservedForEnvironment(
   return (result.rowCount ?? 0) > 0
 }
 
+/**
+ * The runner-reported ready-replica set of every auto-scaling workspace, read
+ * out of the observed endpoint. Only rows whose endpoint actually carries
+ * `readyReplicaIds` are returned (static workspaces never do), so the result is
+ * empty until an auto-scaling workspace is running. Environment-agnostic: the
+ * built-in runner and remote runners all write the same column, so cp gets a
+ * uniform picture from one query. Feeds the in-memory replica router.
+ */
+export async function listWorkspaceReplicaSets(): Promise<
+  { workspace_id: string; ready_replica_ids: number[] }[]
+> {
+  const { rows } = await pool.query(
+    `SELECT workspace_id,
+            endpoint->'readyReplicaIds' AS ready_replica_ids
+       FROM workspace_placements
+      WHERE jsonb_exists(endpoint, 'readyReplicaIds')`,
+  )
+  return rows
+}
+
 /** Remove a placement after destroy, scoped to the environment. */
 export async function deletePlacementForEnvironment(
   environmentId: string,

--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -149,6 +149,22 @@ export async function updateSessionStats(
   ])
 }
 
+/**
+ * Pin a session to a replica of its auto-scaling workspace. Idempotent — the
+ * router writes the same id every turn while affinity holds, and a new id when
+ * it rebinds after the old replica dropped out. NULL for static workspaces
+ * (never called with a replica there).
+ */
+export async function setSessionReplicaOrdinal(
+  sessionId: string,
+  replicaOrdinal: number,
+): Promise<void> {
+  await pool.query('UPDATE sessions SET replica_ordinal = $1 WHERE id = $2', [
+    replicaOrdinal,
+    sessionId,
+  ])
+}
+
 export async function transitionSessionStatus(
   sessionId: string,
   to: 'agent' | 'human' | 'idle',

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -63,6 +63,14 @@ export interface Session {
   caller_user_id: string | null
   /** Calling agent's workspace id when `source = 'agent'`; null otherwise. */
   caller_workspace_id: string | null
+  /**
+   * The replica id this session is pinned to on an auto-scaling workspace, so
+   * every turn hits the same agent process (shared-volume transcript safety).
+   * NULL for static single-replica sessions; the routing seam resolves NULL to
+   * the workspace's default address. Set by the replica router on the session's
+   * first turn.
+   */
+  replica_ordinal: number | null
   pending_message: SessionPendingMessage | null
   /** When the session was starred, or null when it is not starred. */
   starred_at: string | null

--- a/control-plane/src/services/replica-router.test.ts
+++ b/control-plane/src/services/replica-router.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { __resetReplicaRouter, pickReplicaForTurn, syncReadyReplicas } from './replica-router'
+
+// The replica router is pure in-memory state: a ready set fed by observation
+// and a session→replica pick. It must be a no-op (undefined) for any workspace
+// that has never reported replicas, so a static workspace routes to its default
+// address exactly as before.
+
+beforeEach(() => {
+  __resetReplicaRouter()
+})
+
+const snapshot = (entries: Record<string, number[]>) => new Map(Object.entries(entries))
+
+describe('pickReplicaForTurn', () => {
+  it('returns undefined for a workspace with no reported replicas (static)', () => {
+    expect(pickReplicaForTurn('ws1')).toBeUndefined()
+    expect(pickReplicaForTurn('ws1', 0)).toBeUndefined()
+  })
+
+  it('picks a ready replica for a new session, round-robin across replicas', () => {
+    syncReadyReplicas(snapshot({ ws1: [2, 0] })) // stored sorted → [0, 2]
+    expect(pickReplicaForTurn('ws1')).toBe(0)
+    expect(pickReplicaForTurn('ws1')).toBe(2)
+    expect(pickReplicaForTurn('ws1')).toBe(0)
+  })
+
+  it('keeps an existing binding while its replica is still ready (affinity)', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1, 2] }))
+    expect(pickReplicaForTurn('ws1', 2)).toBe(2)
+    expect(pickReplicaForTurn('ws1', 2)).toBe(2)
+  })
+
+  it('rebinds to a fresh replica when the bound one dropped out of the ready set', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1] }))
+    // replica 5 is gone (pod died / scaled away) → pick a healthy one
+    expect(pickReplicaForTurn('ws1', 5)).toBe(0)
+  })
+})
+
+describe('syncReadyReplicas', () => {
+  it('fully replaces the picture — a workspace that stopped reporting falls back to default', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1] }))
+    expect(pickReplicaForTurn('ws1')).toBe(0)
+
+    syncReadyReplicas(snapshot({ ws2: [0] })) // ws1 no longer reported
+    expect(pickReplicaForTurn('ws1')).toBeUndefined()
+    expect(pickReplicaForTurn('ws2')).toBe(0)
+  })
+
+  it('treats an empty replica list as no auto-scaling replicas', () => {
+    syncReadyReplicas(snapshot({ ws1: [] }))
+    expect(pickReplicaForTurn('ws1')).toBeUndefined()
+  })
+})

--- a/control-plane/src/services/replica-router.ts
+++ b/control-plane/src/services/replica-router.ts
@@ -1,0 +1,97 @@
+// Replica routing for auto-scaling workspaces.
+//
+// An auto-scaling workspace runs 0..N replicas that all mount the same RWX
+// workspace volume. A session's turns must keep hitting the SAME replica (the
+// turn is a long-lived SSE to one agent process, and its transcript file can't
+// be appended by two replicas at once). This module owns that affinity: it
+// tracks which replicas are reachable and picks / keeps a session's replica.
+//
+// It is driven ENTIRELY by the reported ready-replica set, never by a
+// workspace's configured runtime_mode: a static workspace never reports a ready
+// set, so its entry stays absent and every routing call resolves to "no replica"
+// → the workspace's default address, byte-identical to a pre-auto-scaling cp.
+// This keeps the router dormant until an auto-scaling workspace actually reports
+// replicas, with no dependency on the config columns that gate creation.
+//
+// Source of the ready set: cp does NOT observe replicas in-process — the runner
+// (a separate env-runner deployment, built-in and remote alike) writes its
+// observation, including endpoint.readyReplicaIds, to workspace_placements. cp
+// polls that column periodically ({@link refreshReplicaRouter}) and rebuilds
+// this in-memory set. So the set is cp-memory only: it survives cp restart by
+// being rebuilt from the next poll, and a session's chosen replica — the one
+// thing that must persist — lives on sessions.replica_ordinal.
+//
+// The provider-assigned replica id is an opaque int here (k8s: a StatefulSet
+// ordinal); the router assumes nothing about it being contiguous or ordered.
+
+import { listWorkspaceReplicaSets } from './db/env-placements'
+
+/** Ready replica ids per workspace, sorted. Absent = no auto-scaling replicas. */
+const readyReplicas = new Map<string, number[]>()
+/** Round-robin cursor per workspace, so new sessions spread across replicas. */
+const rrCursor = new Map<string, number>()
+
+/**
+ * Replace the whole ready-replica picture from one observation snapshot (every
+ * workspace currently reporting replicas). A full replace, not an upsert, so a
+ * workspace that stopped reporting (scaled to zero, deleted) drops out and its
+ * routing falls back to the default address. Cursors for vanished workspaces are
+ * pruned so the maps can't grow without bound.
+ */
+export function syncReadyReplicas(snapshot: ReadonlyMap<string, number[]>): void {
+  readyReplicas.clear()
+  for (const [workspaceId, ids] of snapshot) {
+    if (ids.length > 0)
+      readyReplicas.set(
+        workspaceId,
+        [...ids].sort((a, b) => a - b),
+      )
+  }
+  for (const workspaceId of rrCursor.keys()) {
+    if (!readyReplicas.has(workspaceId)) rrCursor.delete(workspaceId)
+  }
+}
+
+/**
+ * Poll the runner-reported ready-replica sets out of workspace_placements and
+ * refresh the in-memory picture. Run on a cp cron. Cheap no-op while no
+ * workspace is auto-scaling (the query returns nothing).
+ */
+export async function refreshReplicaRouter(): Promise<void> {
+  const rows = await listWorkspaceReplicaSets()
+  syncReadyReplicas(new Map(rows.map((r) => [r.workspace_id, r.ready_replica_ids])))
+}
+
+/**
+ * Resolve the replica a turn should hit.
+ *
+ * - No ready set (static workspace, or auto-scaling scaled to zero / not yet
+ *   observed) → undefined: the caller routes to the default address.
+ * - A `currentBinding` still in the ready set → keep it (session affinity holds
+ *   across turns, and across a stream drop where the replica stayed alive).
+ * - Otherwise (a new session, or a bound replica that dropped out of the ready
+ *   set — pod died / scaled away) → pick a fresh replica, round-robin so load
+ *   spreads. This is the observe-driven rebind: the session resumes on a healthy
+ *   replica from the shared-volume transcript.
+ *
+ * The load-aware refinement (pick the least-busy replica using live turn counts)
+ * arrives with the turn gate; round-robin is the dormant-stage placeholder.
+ */
+export function pickReplicaForTurn(
+  workspaceId: string,
+  currentBinding?: number,
+): number | undefined {
+  const ready = readyReplicas.get(workspaceId)
+  if (!ready || ready.length === 0) return undefined
+  if (currentBinding !== undefined && ready.includes(currentBinding)) return currentBinding
+
+  const cursor = rrCursor.get(workspaceId) ?? 0
+  rrCursor.set(workspaceId, cursor + 1)
+  return ready[cursor % ready.length]
+}
+
+/** Test seam: forget all in-memory routing state. */
+export function __resetReplicaRouter(): void {
+  readyReplicas.clear()
+  rrCursor.clear()
+}


### PR DESCRIPTION
Stage (of the auto-scaling workspaces feature) after the address seam (c3). First stage that *consumes* per-replica addressing. Bottom-up, dormant, static byte-unchanged.

## What
Session→replica affinity for auto-scaling workspaces, and the turn path that routes on it.

- **`replica-router.ts`** — in-memory ready-replica set per workspace + `pickReplicaForTurn(ws, currentBinding?)`. Keeps a session's replica while it's ready; else picks round-robin (a new session, or an observe-driven rebind after the bound replica dropped out). Round-robin is a placeholder — load-aware selection arrives with the turn gate.
- **Producer** — cp does *not* observe replicas in-process (the built-in runner is a separate deployment). Both built-in and remote observations land in one place: `workspace_placements.endpoint.readyReplicaIds`. A 15s cron (`listWorkspaceReplicaSets` → `syncReadyReplicas`) rebuilds the in-memory picture uniformly.
- **Binding** — `sessions.replica_ordinal` (migration 124), durable. `executeChat` picks the replica and resolves its address; the id is threaded to the SSE interceptor, which persists it on `session.started`.

## Why it's driven by the ready set, not runtime_mode
A static workspace never reports `readyReplicaIds`, so its router entry stays absent, `pickReplicaForTurn` returns `undefined`, the address is the default one, and no `replica_ordinal` is written. This decouples the router from the config columns (runtime_mode etc.) that gate creation — those land in a later stage — so c4 is fully dormant: nothing can report a ready set yet.

## Deferred to later stages
Live-turn reconnect-vs-rebind distinction (needs the forward-hard-failed signal from the turn path — turn gate), load-aware selection, draining (autoscaler), fan-out. Also: an auto-scaling workspace that is running but whose ready set hasn't been polled yet would fall back to the (nonexistent) default ClusterIP address — the readiness-gate for that lives in the autostart/turn-gate stage, and can't trigger today.

## Tests
`replica-router.test.ts` covers static no-op, round-robin spread, affinity, rebind, and full-snapshot replace. Full cp suite 230 passed, knip + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)