### PR TITLE
c6: auto-scaling config + spec projection

### DIFF
--- a/control-plane/migrations/125_auto_scaling_config.sql
+++ b/control-plane/migrations/125_auto_scaling_config.sql
@@ -1,0 +1,19 @@
+-- Auto-scaling runtime configuration, per workspace.
+-- A workspace is either static (this column NULL — today's single fixed replica
+-- on a ReadWriteOnce volume) or auto-scaling (this column set — 0..max replicas
+-- sharing one ReadWriteMany volume, sized by the autoscaler). The PRESENCE of
+-- this object is the shape discriminant: there is no separate runtime_mode flag
+-- to drift out of sync, and a static workspace simply has no replica parameters
+-- to mis-read. Shape is fixed at creation and immutable after.
+--
+-- Shape (all keys present when the object is): {
+--   "min_replicas": int >= 0,            -- may be 0 for scale-to-zero
+--   "max_replicas": int >= 1,            -- min <= max
+--   "scale_to_zero_idle_seconds": int | null  -- null = never scale to zero
+-- }
+-- Per-replica turn capacity reuses the existing workspace_config.max_concurrency
+-- (no key here). Sub-field validation lives in the write path (app-side), the
+-- same as compute_resources — this stays a plain nullable jsonb blob read and
+-- written as a whole. NULL default preserves today's behavior: every existing
+-- workspace is static.
+ALTER TABLE workspace_config ADD COLUMN IF NOT EXISTS auto_scaling jsonb;

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -131,7 +131,25 @@ export interface WorkspaceConfig {
   compute_resources: ComputeResources
   /** When false, a stopped workspace is not auto-started on incoming chat. */
   auto_start: boolean
+  /**
+   * Auto-scaling parameters, or null for a static (single fixed replica)
+   * workspace. Its PRESENCE is the runtime-shape discriminant — there is no
+   * separate mode flag, and a static workspace has no replica parameters to
+   * mis-read. Fixed at creation, immutable after. Per-replica turn capacity
+   * reuses max_concurrency, so it is not part of this object.
+   */
+  auto_scaling: AutoScalingConfig | null
   updated_at: string
+}
+
+/** Replica sizing for an auto-scaling workspace (workspace_config.auto_scaling). */
+interface AutoScalingConfig {
+  /** Lower bound; may be 0 to allow scale-to-zero. */
+  min_replicas: number
+  /** Upper bound; >= 1 and >= min_replicas. */
+  max_replicas: number
+  /** Idle seconds before scaling to zero; null = never. */
+  scale_to_zero_idle_seconds: number | null
 }
 
 type EnvironmentVisibility = 'private' | 'team' | 'public'

--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -304,6 +304,7 @@ export async function getWorkspaceConfig(workspaceId: string): Promise<Workspace
        CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(wc.compute_resources, tv.compute_resources)
             ELSE wc.compute_resources END AS compute_resources,
        wc.auto_start,
+       wc.auto_scaling,
        wc.updated_at,
        CASE WHEN wc.template_id IS NOT NULL
             THEN CASE WHEN wc.prompt_id IS NOT NULL THEN wc.prompt_id

--- a/control-plane/src/services/placement.test.ts
+++ b/control-plane/src/services/placement.test.ts
@@ -36,4 +36,25 @@ describe('buildWorkspaceSpec', () => {
   it('missing compute_resources → {} (never null/undefined on the wire)', () => {
     expect(buildWorkspaceSpec({ agent_type: 'codex' }, 2).resources).toEqual({})
   })
+
+  it('static config (auto_scaling null/absent) projects no auto-scaling fields', () => {
+    expect(buildWorkspaceSpec({ agent_type: 'codex', auto_scaling: null }, 1)).not.toHaveProperty(
+      'runtimeMode',
+    )
+    expect(buildWorkspaceSpec({ agent_type: 'codex' }, 1)).not.toHaveProperty('replicas')
+  })
+
+  it('auto-scaling config carries the shape + an initial replica count', () => {
+    expect(buildWorkspaceSpec({ auto_scaling: { min_replicas: 2 } }, 5)).toEqual({
+      agentType: 'claude-code',
+      resources: {},
+      version: 5,
+      runtimeMode: 'auto-scaling',
+      replicas: 2,
+    })
+  })
+
+  it('auto-scaling with min_replicas 0 (scale-to-zero) still starts runnable at 1', () => {
+    expect(buildWorkspaceSpec({ auto_scaling: { min_replicas: 0 } }, 1).replicas).toBe(1)
+  })
 })

--- a/control-plane/src/services/placement.ts
+++ b/control-plane/src/services/placement.ts
@@ -15,13 +15,37 @@ const BUILTIN_ENV = 'builtin'
  * means adding a field here (and a column migration), not editing callers.
  */
 export function buildWorkspaceSpec(
-  config: { agent_type?: string | null; compute_resources?: unknown } | null,
+  config: {
+    agent_type?: string | null
+    compute_resources?: unknown
+    auto_scaling?: { min_replicas: number } | null
+  } | null,
   version: number,
-): { agentType: string; resources: unknown; version: number } {
-  return {
+): {
+  agentType: string
+  resources: unknown
+  version: number
+  runtimeMode?: 'auto-scaling'
+  replicas?: number
+} {
+  const base = {
     agentType: config?.agent_type || 'claude-code',
     resources: config?.compute_resources ?? {},
     version,
+  }
+  // The presence of auto_scaling is the shape discriminant: absent → static,
+  // which projects byte-identically (no new fields, so the Deployment it becomes
+  // is unchanged) and, by construction, cannot read a replica count. An
+  // auto-scaling workspace carries the shape and an initial count:
+  // max(min_replicas, 1) so a freshly-created one is runnable before the
+  // autoscaler's first pass (and before scale-to-zero can apply). Once the
+  // autoscaler exists it owns the count via setDesiredReplicas, and a config
+  // bump must preserve it there.
+  if (!config?.auto_scaling) return base
+  return {
+    ...base,
+    runtimeMode: 'auto-scaling',
+    replicas: Math.max(config.auto_scaling.min_replicas, 1),
   }
 }
 


### PR DESCRIPTION
Stage after the turn gate (c5). Bottom-up, dormant, static byte-unchanged.

## What
The config → spec data plumbing that lets a workspace *be* auto-scaling.

- **Migration 125** — a single nullable jsonb column `workspace_config.auto_scaling` = `{ min_replicas, max_replicas, scale_to_zero_idle_seconds }`, null for static. Its **presence is the shape discriminant**: no separate `runtime_mode` flag to drift out of sync, and a static workspace has no replica parameters to mis-read. The type is `AutoScalingConfig | null`, so a shape check is forced before any count is read. Mirrors the existing `compute_resources` blob (read/written as a unit); sub-field validation lives in the write path. Per-replica turn capacity reuses the existing `max_concurrency` — no key for it here.
- **`buildWorkspaceSpec` projection** — `auto_scaling` present → `runtimeMode: 'auto-scaling'` + initial `replicas = max(min_replicas, 1)` (runnable before the autoscaler's first pass). Absent → **byte-identical** static spec, unchanged Deployment (existing golden tests pass untouched).

## Schema note
An earlier revision used flat columns (`runtime_mode` + `min/max_replicas`). Switched to the single jsonb aggregate so static vs auto-scaling is a real discriminated union end-to-end — you can't accidentally read a replica count on a static workspace.

## Why it's dormant
Nothing sets `auto_scaling` yet — the create/update write path + the placement-decision capability gate (`multiReplica`) land next. Every workspace stays static; every spec is unchanged. Manual end-to-end testing on built-in can set `auto_scaling` directly in the DB and bump the placement to watch the StatefulSet path (c2) light up through routing (c3/c4) and the gate (c5).

## Deferred (next stages)
Create/update API accept + validation + capability gate → c7; the autoscaler control loop (`setDesiredReplicas`, `nextRemovedReplicaIds`, `turnDemand`, scale-to-zero) → c8; UI → c9. Note: once the autoscaler owns the replica count, a config bump must **preserve** it rather than reset to the initial — flagged in a code comment for that stage.

## Tests
`placement.test.ts`: static-projects-nothing, auto-scaling-carries-shape, min_replicas-0-starts-at-1. Full cp suite 241 passed, knip + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)