### PR TITLE
c7: create auto-scaling workspaces + capability gate

### DIFF
--- a/control-plane/src/routes/workspaces/write.ts
+++ b/control-plane/src/routes/workspaces/write.ts
@@ -104,7 +104,9 @@ write.openapi(createRouteDef, async (c) => {
       userId: currentUser.sub,
       isSystem,
       requestedEnvironmentId: body.environment_id,
-      required: {},
+      // Auto-scaling needs the environment to advertise multiReplica (a RWX
+      // storage class); a static workspace requires nothing extra.
+      required: { multiReplica: body.auto_scaling ? true : undefined },
     })
     if (!placement.ok) {
       return c.json({ error: placement.error }, 400)
@@ -208,6 +210,19 @@ write.openapi(createRouteDef, async (c) => {
         // still attach a store later via the global Memory app.
         console.error(`[workspace ${workspace.id}] auto-attach memory store failed:`, e.message)
       }
+    }
+
+    // Persist the auto-scaling shape (immutable after creation) before placing,
+    // so the first spec the runner sees already carries runtimeMode + replicas.
+    // Static workspaces skip this and stay a plain single-replica Deployment.
+    if (body.auto_scaling) {
+      await updateWorkspaceConfig(workspace.id, {
+        auto_scaling: {
+          min_replicas: body.auto_scaling.min_replicas,
+          max_replicas: body.auto_scaling.max_replicas,
+          scale_to_zero_idle_seconds: body.auto_scaling.scale_to_zero_idle_seconds ?? null,
+        },
+      })
     }
 
     // Control inversion (P1): record desired state; the env-runner creates the

--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -365,13 +365,15 @@ export async function updateWorkspaceConfig(
     'agent_settings',
     'compute_resources',
     'auto_start',
+    'auto_scaling',
     'template_id',
     'template_version',
   ] as const
+  const jsonbFields: readonly (typeof fields)[number][] = ['compute_resources', 'auto_scaling']
   for (const field of fields) {
     if (updates[field] !== undefined) {
       sets.push(`${field} = $${paramIndex++}`)
-      values.push(field === 'compute_resources' ? JSON.stringify(updates[field]) : updates[field])
+      values.push(jsonbFields.includes(field) ? JSON.stringify(updates[field]) : updates[field])
     }
   }
 

--- a/control-plane/src/services/placement-decision.test.ts
+++ b/control-plane/src/services/placement-decision.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorkspaceCreateBodySchema } from '../../../internal/types/api'
+
+// Built-in advertises multiReplica when cp is deployed with a RWX storage class.
+// Set it before the module (and its defaultCfg) evaluate, via top-level await
+// import so the built-in gate reads `true`.
+process.env.WORKSPACE_MULTI_REPLICA = 'true'
+
+const { getEnvironmentForUserMock } = vi.hoisted(() => ({
+  getEnvironmentForUserMock: vi.fn(),
+}))
+vi.mock('./db/environments', () => ({ getEnvironmentForUser: getEnvironmentForUserMock }))
+
+const { chooseEnvironment } = await import('./placement-decision')
+
+const env = (over: Record<string, unknown>) =>
+  ({ id: 'e1', name: 'Remote', is_builtin: false, status: 'online', ...over }) as any
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('chooseEnvironment — auto-scaling capability gate', () => {
+  it('allows auto-scaling on built-in when cp advertises multiReplica', async () => {
+    getEnvironmentForUserMock.mockResolvedValue(env({ id: 'builtin', is_builtin: true }))
+    const d = await chooseEnvironment({
+      userId: 'u1',
+      isSystem: false,
+      required: { multiReplica: true },
+    })
+    expect(d.ok).toBe(true)
+  })
+
+  it('allows auto-scaling on a remote env that advertises multiReplica', async () => {
+    getEnvironmentForUserMock.mockResolvedValue(env({ capabilities: { multiReplica: true } }))
+    const d = await chooseEnvironment({
+      userId: 'u1',
+      isSystem: false,
+      requestedEnvironmentId: 'e1',
+      required: { multiReplica: true },
+    })
+    expect(d.ok).toBe(true)
+  })
+
+  it('rejects auto-scaling on a remote env that does not advertise multiReplica', async () => {
+    getEnvironmentForUserMock.mockResolvedValue(env({ capabilities: {} }))
+    const d = await chooseEnvironment({
+      userId: 'u1',
+      isSystem: false,
+      requestedEnvironmentId: 'e1',
+      required: { multiReplica: true },
+    })
+    expect(d.ok).toBe(false)
+    if (!d.ok) expect(d.error).toMatch(/auto-scaling/)
+  })
+
+  it('a static workspace (no multiReplica required) places on any online env', async () => {
+    getEnvironmentForUserMock.mockResolvedValue(env({ capabilities: {} }))
+    const d = await chooseEnvironment({
+      userId: 'u1',
+      isSystem: false,
+      requestedEnvironmentId: 'e1',
+      required: {},
+    })
+    expect(d.ok).toBe(true)
+  })
+})
+
+describe('WorkspaceCreateBodySchema — auto_scaling validation', () => {
+  it('accepts a valid auto_scaling block', () => {
+    const r = WorkspaceCreateBodySchema.safeParse({
+      name: 'w',
+      auto_scaling: { min_replicas: 0, max_replicas: 3, scale_to_zero_idle_seconds: 300 },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects min_replicas > max_replicas', () => {
+    const r = WorkspaceCreateBodySchema.safeParse({
+      name: 'w',
+      auto_scaling: { min_replicas: 4, max_replicas: 2 },
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects max_replicas < 1', () => {
+    const r = WorkspaceCreateBodySchema.safeParse({
+      name: 'w',
+      auto_scaling: { min_replicas: 0, max_replicas: 0 },
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('omitting auto_scaling is valid (static workspace)', () => {
+    expect(WorkspaceCreateBodySchema.safeParse({ name: 'w' }).success).toBe(true)
+  })
+})

--- a/control-plane/src/services/placement-decision.ts
+++ b/control-plane/src/services/placement-decision.ts
@@ -1,3 +1,4 @@
+import { defaultCfg } from '../../../internal/k8s-provider'
 import { type EnvironmentWithAccess, getEnvironmentForUser } from './db/environments'
 
 // Placement decision (design §8): choose the environment a new workspace runs
@@ -11,6 +12,14 @@ const BUILTIN_ENV = 'builtin'
 interface RequiredFeatures {
   sharedFs?: boolean
   persistentMemory?: boolean
+  /** Auto-scaling: multiple replicas on one RWX volume (design §7). */
+  multiReplica?: boolean
+}
+
+interface Supports {
+  sharedFs: boolean
+  persistentMemory: boolean
+  multiReplica: boolean
 }
 
 type PlacementDecision =
@@ -18,18 +27,28 @@ type PlacementDecision =
       ok: true
       environmentId: string
       /** What the chosen environment can actually provide (drives opportunistic features). */
-      supports: { sharedFs: boolean; persistentMemory: boolean }
+      supports: Supports
     }
   | { ok: false; error: string }
 
-function envSupports(
-  env: EnvironmentWithAccess,
-  feature: 'sharedFs' | 'persistentMemory',
-): boolean {
-  // The built-in cluster ships afs-fuse + memory-fuse, so it supports everything;
-  // its capabilities row is empty by design. Remote environments must advertise.
-  if (env.is_builtin) return true
+function envSupports(env: EnvironmentWithAccess, feature: keyof Supports): boolean {
+  if (env.is_builtin) {
+    // The built-in cluster ships afs-fuse + memory-fuse unconditionally. But
+    // multiReplica is deploy-gated (it needs a ReadWriteMany storage class), so
+    // read it from cp's own provider config rather than assuming true.
+    if (feature === 'multiReplica') return defaultCfg.multiReplica
+    return true
+  }
+  // Remote environments advertise every capability, multiReplica included.
   return env.capabilities?.[feature] === true
+}
+
+function supportsFor(env: EnvironmentWithAccess): Supports {
+  return {
+    sharedFs: envSupports(env, 'sharedFs'),
+    persistentMemory: envSupports(env, 'persistentMemory'),
+    multiReplica: envSupports(env, 'multiReplica'),
+  }
 }
 
 export async function chooseEnvironment(opts: {
@@ -43,7 +62,7 @@ export async function chooseEnvironment(opts: {
     return {
       ok: true,
       environmentId: BUILTIN_ENV,
-      supports: { sharedFs: true, persistentMemory: true },
+      supports: { sharedFs: true, persistentMemory: true, multiReplica: defaultCfg.multiReplica },
     }
   }
 
@@ -62,15 +81,18 @@ export async function chooseEnvironment(opts: {
   }
 
   // Capability negotiation: every explicitly required feature must be supported.
-  const supports = {
-    sharedFs: envSupports(env, 'sharedFs'),
-    persistentMemory: envSupports(env, 'persistentMemory'),
-  }
+  const supports = supportsFor(env)
   if (opts.required.persistentMemory && !supports.persistentMemory) {
     return { ok: false, error: `Environment '${env.name}' does not support persistent memory` }
   }
   if (opts.required.sharedFs && !supports.sharedFs) {
     return { ok: false, error: `Environment '${env.name}' does not support a shared filesystem` }
+  }
+  if (opts.required.multiReplica && !supports.multiReplica) {
+    return {
+      ok: false,
+      error: `Environment '${env.name}' does not support auto-scaling workspaces`,
+    }
   }
 
   return { ok: true, environmentId: env.id, supports }

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -82,6 +82,20 @@ export const WorkspaceCreateBodySchema = z.object({
   // Recipient consent for template-provided schedules: name → enabled. Absent
   // entries fall back to the template's enabled_default. Both UI and API set this.
   schedule_overrides: z.record(z.string(), z.boolean()).optional(),
+  // Opt into auto-scaling (0..max replicas sharing one RWX volume). Omitted →
+  // a static single-replica workspace. Set only at creation — the runtime shape
+  // is immutable, so this field is deliberately absent from the config-update
+  // schema. Per-replica turn capacity reuses max_concurrency.
+  auto_scaling: z
+    .object({
+      min_replicas: z.number().int().min(0),
+      max_replicas: z.number().int().min(1),
+      scale_to_zero_idle_seconds: z.number().int().positive().nullable().optional(),
+    })
+    .refine((v) => v.min_replicas <= v.max_replicas, {
+      message: 'min_replicas must be <= max_replicas',
+    })
+    .optional(),
 })
 
 export type WorkspaceCreateBody = z.infer<typeof WorkspaceCreateBodySchema>
@@ -1354,7 +1368,7 @@ export const ScheduleCreateBodySchema = z
     path: ['cron'],
   })
   .refine((v) => !v.cron || !hasOutOfRangeCronStep(v.cron), {
-    message: 'cron step exceeds a field\'s valid range (e.g. minute step > 59)',
+    message: "cron step exceeds a field's valid range (e.g. minute step > 59)",
     path: ['cron'],
   })
 
@@ -1373,7 +1387,7 @@ export const ScheduleUpdateBodySchema = z
   })
   .partial()
   .refine((v) => !v.cron || !hasOutOfRangeCronStep(v.cron), {
-    message: 'cron step exceeds a field\'s valid range (e.g. minute step > 59)',
+    message: "cron step exceeds a field's valid range (e.g. minute step > 59)",
     path: ['cron'],
   })
 


### PR DESCRIPTION
Stage after config schema (c6). First stage where an auto-scaling workspace can actually be **created**. Static path unchanged.

## What
- **Create schema** — `WorkspaceCreateBodySchema` gains an optional `auto_scaling` block (`min_replicas`, `max_replicas`, `scale_to_zero_idle_seconds?`), validated app-side (`min ≤ max`, `max ≥ 1`, `min ≥ 0`). On the **create schema only** — the runtime shape is immutable, so the config-update schema (`ApiWorkspaceConfigSchema`) deliberately omits it, making shape unchangeable by omission.
- **Create route** — persists `auto_scaling` to `workspace_config` before `placeWorkspace`, so the first spec the runner sees already carries `runtimeMode` + `replicas` (c6 projection). Static workspaces skip it.
- **Capability gate** — `placement-decision` rejects auto-scaling on an environment that doesn't advertise `multiReplica`: built-in reads it from cp's own provider config (`defaultCfg.multiReplica`, deploy-gated on a RWX storage class), remote advertises via heartbeat. Rejected at create → no orphan row.

## Why it's safe
Every existing create call omits `auto_scaling` → static, `required: {}`, byte-identical. Auto-scaling is fully opt-in and reachable only via a client that sends the block (the UI lands in a later stage; API/manual can drive it now for end-to-end testing).

## Immutability
`auto_scaling` is create-only. The PUT `/:id/config` route validates against `ApiWorkspaceConfigSchema.partial()`, which has no `auto_scaling` field — so the shape can't be flipped or tuned post-create through the normal path. (`updateWorkspaceConfig`'s allow-list does include it, used only by the create route's own explicit write.)

## Tests
`placement-decision.test.ts`: built-in gate (multiReplica on), remote advertises/doesn't, static places anywhere; + `auto_scaling` zod validation (min≤max, max≥1, omitted-is-static). Full cp suite 249 passed, knip + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)