### PR TITLE
c8: autoscaler control loop (scale-up)

### DIFF
--- a/control-plane/src/lib/reconcile.ts
+++ b/control-plane/src/lib/reconcile.ts
@@ -12,6 +12,7 @@ import { runIdleWorkspaceGC } from '../services/idle-workspace-gc'
 import * as k8s from '../services/k8s'
 import { refreshReplicaRouter } from '../services/replica-router'
 import { sweepRunningWorkspaces } from '../services/usage/pull'
+import { runAutoscaler } from '../services/workspace-autoscaler'
 import { applyStatusChange } from './workspace-status'
 
 const WATCH_CYCLE_MS = 10 * 60 * 1000 // 10 minutes
@@ -201,6 +202,16 @@ export function startReconcileLoop() {
         '[Reconcile] replica router refresh error:',
         e instanceof Error ? e.message : e,
       ),
+    ),
+  )
+
+  // Autoscaler: size each auto-scaling workspace's replicas to live turn demand.
+  // Same 15s cadence; a no-op while no workspace is auto-scaling. protect:true so
+  // a slow pass never stacks. Runs after the router refresh above so demand is
+  // read against a fresh ready-replica picture.
+  new Cron(ENV_PROJECTION_INTERVAL, { protect: true }, () =>
+    runAutoscaler().catch((e) =>
+      console.error('[Reconcile] autoscaler error:', e instanceof Error ? e.message : e),
     ),
   )
 

--- a/control-plane/src/services/chat/turn-gate.ts
+++ b/control-plane/src/services/chat/turn-gate.ts
@@ -125,6 +125,19 @@ export function acquireTurn(workspaceId: string): Promise<TurnSlot> {
   })
 }
 
+/**
+ * A workspace's current turn demand: turns in flight plus turns waiting for a
+ * slot. This is the one signal the autoscaler scales on — no separate metric.
+ * queued is always 0 for a static workspace (capacity is Infinity, nothing
+ * queues), so a static workspace reads as pure in-flight count.
+ */
+export function turnDemand(workspaceId: string): { active: number; queued: number } {
+  return {
+    active: activeTurns.get(workspaceId) ?? 0,
+    queued: waiters.get(workspaceId)?.length ?? 0,
+  }
+}
+
 /** Test seam: drop all admission state, rejecting any still-pending waiters. */
 export function __resetTurnGate(): void {
   for (const q of waiters.values()) {

--- a/control-plane/src/services/placement.ts
+++ b/control-plane/src/services/placement.ts
@@ -79,6 +79,26 @@ export async function placeWorkspace(
   ])
 }
 
+/**
+ * Set an auto-scaling workspace's desired replica count: update just
+ * spec.replicas and bump the spec version so the runner re-applies (scales the
+ * StatefulSet). Deliberately targeted — it does NOT rebuild the rest of the spec
+ * from config, so it can run every autoscaler tick without clobbering anything
+ * else. Only the autoscaler calls this, only for auto-scaling workspaces (whose
+ * spec already carries a replicas field).
+ */
+export async function setDesiredReplicas(workspaceId: string, replicas: number): Promise<void> {
+  await pool.query(
+    `UPDATE workspace_placements
+        SET spec_version = spec_version + 1,
+            spec = jsonb_set(
+              jsonb_set(spec, '{replicas}', to_jsonb($2::int)),
+              '{version}', to_jsonb(spec_version + 1))
+      WHERE workspace_id = $1`,
+    [workspaceId, replicas],
+  )
+}
+
 /** Set the desired phase (running | stopped | deleted). */
 export async function setDesiredPhase(
   workspaceId: string,
@@ -101,6 +121,17 @@ export async function setDesiredPhase(
 export async function bumpWorkspaceSpec(workspaceId: string): Promise<void> {
   const config = await getWorkspaceConfig(workspaceId)
   const spec = buildWorkspaceSpec(config, 0)
+  // The autoscaler owns replicas via setDesiredReplicas; a config-driven rebuild
+  // must not reset that live count back to the creation initial. Only relevant
+  // for auto-scaling (spec.replicas present); static specs have no replicas key.
+  if (spec.replicas !== undefined) {
+    const { rows } = await pool.query(
+      "SELECT (spec->>'replicas')::int AS replicas FROM workspace_placements WHERE workspace_id = $1",
+      [workspaceId],
+    )
+    const live = rows[0]?.replicas
+    if (typeof live === 'number') spec.replicas = live
+  }
   await pool.query(
     `UPDATE workspace_placements
         SET spec_version = spec_version + 1,

--- a/control-plane/src/services/workspace-autoscaler.test.ts
+++ b/control-plane/src/services/workspace-autoscaler.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { desiredReplicas } from './workspace-autoscaler'
+
+// desiredReplicas is the autoscaler's pure core: (active + queued) turns carried
+// at perReplicaCapacity each, clamped to [min, max].
+
+const at = (active: number, queued = 0) => ({ active, queued })
+
+describe('desiredReplicas', () => {
+  it('sizes to cover active + queued turns at capacity each', () => {
+    expect(desiredReplicas(at(6), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(2)
+    expect(desiredReplicas(at(7), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(3) // ceil
+    expect(desiredReplicas(at(3, 4), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(3) // 7/3
+  })
+
+  it('holds the min floor when demand is low (incl. zero)', () => {
+    expect(desiredReplicas(at(0), { perReplicaCapacity: 3, min: 2, max: 10 })).toBe(2)
+    expect(desiredReplicas(at(1), { perReplicaCapacity: 3, min: 2, max: 10 })).toBe(2)
+  })
+
+  it('caps at max under heavy demand', () => {
+    expect(desiredReplicas(at(100), { perReplicaCapacity: 3, min: 1, max: 4 })).toBe(4)
+  })
+
+  it('allows zero when min is zero and there is no demand (scale-to-zero target)', () => {
+    expect(desiredReplicas(at(0), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(0)
+  })
+
+  it('never divides by zero on a bad capacity', () => {
+    expect(desiredReplicas(at(4), { perReplicaCapacity: 0, min: 0, max: 10 })).toBe(4)
+  })
+})

--- a/control-plane/src/services/workspace-autoscaler.ts
+++ b/control-plane/src/services/workspace-autoscaler.ts
@@ -1,0 +1,72 @@
+import { turnDemand } from './chat/turn-gate'
+import { pool } from './db/pool'
+import { setDesiredReplicas } from './placement'
+
+// The workspace autoscaler: a periodic control loop that sizes each auto-scaling
+// workspace's replica count to its live turn demand. It reads the demand signal
+// straight from the turn gate (active + queued turns) — no separate metric — and
+// writes the desired count through the placement queue, which the env-runner
+// converges. Static workspaces are never touched (they have no auto_scaling
+// config, so the query below skips them).
+//
+// This stage does SCALE-UP only: replicas grow to meet demand or the min floor,
+// and never shrink here. Scale-down is delicate (drain live turns off a replica
+// before removing it) and lands in its own stage; until then an auto-scaling
+// workspace that has grown stays grown, which is safe (over-provisioned), just
+// not yet economical.
+
+/**
+ * The replica count a workspace should run for its demand: enough replicas to
+ * carry (active + queued) turns at perReplicaCapacity each, clamped to the
+ * workspace's [min, max]. Pure — the loop's testable core.
+ */
+export function desiredReplicas(
+  demand: { active: number; queued: number },
+  opts: { perReplicaCapacity: number; min: number; max: number },
+): number {
+  const need = Math.ceil((demand.active + demand.queued) / Math.max(opts.perReplicaCapacity, 1))
+  return Math.min(Math.max(need, opts.min), opts.max)
+}
+
+interface AutoScalingRow {
+  workspace_id: string
+  min_replicas: number
+  max_replicas: number
+  max_concurrency: number
+  current_replicas: number
+}
+
+/** Running auto-scaling workspaces with the numbers the loop needs. */
+async function listAutoScalingWorkspaces(): Promise<AutoScalingRow[]> {
+  const { rows } = await pool.query(
+    `SELECT wc.workspace_id,
+            (wc.auto_scaling->>'min_replicas')::int AS min_replicas,
+            (wc.auto_scaling->>'max_replicas')::int AS max_replicas,
+            wc.max_concurrency,
+            COALESCE((wp.spec->>'replicas')::int, 1) AS current_replicas
+       FROM workspace_config wc
+       JOIN workspace_placements wp ON wp.workspace_id = wc.workspace_id
+      WHERE wc.auto_scaling IS NOT NULL
+        AND wp.desired_phase = 'running'`,
+  )
+  return rows
+}
+
+/**
+ * One autoscaler pass. Cheap no-op while no workspace is auto-scaling (the query
+ * returns nothing). Scale-UP only: writes a higher desired count when demand (or
+ * the min floor) calls for it; never reduces.
+ */
+export async function runAutoscaler(): Promise<void> {
+  for (const ws of await listAutoScalingWorkspaces()) {
+    const target = desiredReplicas(turnDemand(ws.workspace_id), {
+      perReplicaCapacity: ws.max_concurrency,
+      min: ws.min_replicas,
+      max: ws.max_replicas,
+    })
+    if (target > ws.current_replicas) {
+      await setDesiredReplicas(ws.workspace_id, target)
+      console.log(`[Autoscaler] scale up ws=${ws.workspace_id} ${ws.current_replicas} → ${target}`)
+    }
+  }
+}


### PR DESCRIPTION
Stage after create-enable (c7). The workspace autoscaler — scale-up half. Dormant while no workspace is auto-scaling.

## What
A 15s control loop that sizes each auto-scaling workspace's replicas to live turn demand.

- **`turnDemand(ws)`** (turn gate) — `{ active, queued }`, the one signal the loop scales on. No new metric.
- **`desiredReplicas(demand, {perReplicaCapacity, min, max})`** (pure) — `clamp(ceil((active+queued) / max_concurrency), min, max)`. The testable core.
- **`setDesiredReplicas(ws, n)`** (placement) — updates **only** `spec.replicas` + the version (no full-spec rebuild), so the runner scales the StatefulSet and a tick never clobbers other spec fields.
- **`runAutoscaler`** — for each running auto-scaling workspace, scale **up** to the target; never shrinks here.

## Scale-up only
Scale-down has to drain live turns off a replica before removing it (highest-ordinal first) — delicate, so it's its own stage. Until then a workspace that grew stays grown: over-provisioned, safe, just not yet economical. The min floor is still enforced via scale-up (demand 0 → target = min).

## bumpWorkspaceSpec preserve
Now that the autoscaler owns the replica count, a config-driven `bumpWorkspaceSpec` preserves the live count instead of resetting to the creation initial (the reset flagged in c6). Static specs (no replicas key) are unaffected.

## Why it's dormant
The loop's query selects only workspaces with `auto_scaling` set and `desired_phase = 'running'` — empty until one is created auto-scaling (c7) and running. Static workspaces are never selected; every existing path is unchanged.

## Tests
`workspace-autoscaler.test.ts`: `desiredReplicas` — sizing/ceil, min floor incl. zero-demand, max cap, zero-target when min 0, divide-by-zero guard. Full cp suite 254 passed, knip + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)