### PR TITLE
fix(agent-skills): snapshot skill dir before packing

### DIFF
--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -140,7 +140,10 @@ describe('SkillManager', () => {
   const SKILLS_DIR = '/workspace/.claude/skills'
   const LOCAL_BASE = '/tmp'
 
-  function createManager(fetchImpl: (url: string) => Promise<FetchResponse>) {
+  function createManager(
+    fetchImpl: (url: string) => Promise<FetchResponse>,
+    overrides: { draftBase?: string } = {},
+  ) {
     return new SkillManager({
       cpUrl: 'http://cp:3000',
       workspaceId: 'ws-1',
@@ -150,6 +153,7 @@ describe('SkillManager', () => {
       fetch: fetchImpl,
       fs,
       shell,
+      ...overrides,
     })
   }
 
@@ -436,6 +440,62 @@ describe('SkillManager', () => {
 
       // Temp tar file should be cleaned up
       expect(fs.files.has('/tmp/skill-pkg-publish.tar.gz')).toBe(false)
+    })
+
+    test('tars a local snapshot, not the (possibly NFS) source dir', async () => {
+      fs.dirs.add('/workspace/.skills-draft/skill-pkg')
+      fs.files.set('/workspace/.skills-draft/skill-pkg/SKILL.md', '# test')
+
+      const mgr = createManager(async () => { throw new Error('no fetch') }, {
+        draftBase: '/workspace/.skills-draft',
+      })
+
+      const origExec = shell.exec.bind(shell)
+      shell.exec = async (cmd, args) => {
+        await origExec(cmd, args)
+        if (cmd === 'tar' && args[0] === 'czf') {
+          fs.files.set(args[1], Buffer.from('packed-content'))
+        }
+      }
+
+      const buf = await mgr.pack('pkg')
+      expect(buf.toString()).toBe('packed-content')
+
+      // cp -a copies the draft dir contents into a tmpfs snapshot...
+      const cpCall = shell.calls.find(c => c.cmd === 'cp')
+      expect(cpCall).toBeTruthy()
+      expect(cpCall!.args[1]).toBe('/workspace/.skills-draft/skill-pkg/.')
+      const snapshot = cpCall!.args[2]
+      expect(snapshot.startsWith('/tmp/skill-pkg.pack-')).toBe(true)
+
+      // ...and tar reads that snapshot, never the draft dir itself.
+      const tarCall = shell.calls.find(c => c.cmd === 'tar' && c.args[0] === 'czf')
+      expect(tarCall!.args[tarCall!.args.indexOf('-C') + 1]).toBe(snapshot)
+
+      // Snapshot is cleaned up.
+      expect(fs.dirs.has(snapshot)).toBe(false)
+    })
+
+    test('sweeps snapshot dirs leaked by a crashed pack', async () => {
+      fs.dirs.add('/tmp/skill-pkg')
+      fs.files.set('/tmp/skill-pkg/SKILL.md', '# test')
+      fs.dirs.add('/tmp/skill-pkg.pack-999-1')
+      fs.dirs.add('/tmp/skill-pkg.pack-999-2')
+
+      const mgr = createManager(async () => { throw new Error('no fetch') })
+      const origExec = shell.exec.bind(shell)
+      shell.exec = async (cmd, args) => {
+        await origExec(cmd, args)
+        if (cmd === 'tar' && args[0] === 'czf') {
+          fs.files.set(args[1], Buffer.from('packed-content'))
+        }
+      }
+
+      await mgr.pack('pkg')
+
+      expect(fs.dirs.has('/tmp/skill-pkg.pack-999-1')).toBe(false)
+      expect(fs.dirs.has('/tmp/skill-pkg.pack-999-2')).toBe(false)
+      expect(fs.dirs.has('/tmp/skill-pkg')).toBe(true)
     })
 
     test('throws if skill not found', async () => {

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -574,6 +574,25 @@ export class SkillManager {
   }
 
   /**
+   * Remove every localBase entry starting with `prefix`. Temp dirs carry a
+   * unique pid/timestamp suffix, so a plain rm of the current name never
+   * catches siblings left behind by a crashed or concurrent run — they
+   * accumulated in localBase (hundreds were observed in prod). Best-effort.
+   */
+  private async sweepTemp(prefix: string): Promise<void> {
+    try {
+      const entries = await this.fs.readdir(this.localBase)
+      await Promise.all(
+        entries
+          .filter((e) => e.startsWith(prefix))
+          .map((e) => this.fs.rm(`${this.localBase}/${e}`)),
+      )
+    } catch {
+      // Best-effort
+    }
+  }
+
+  /**
    * Extract tar.gz into a staging dir, then atomically swap into localDir.
    * On any failure (tar error, swap error) the existing localDir is
    * preserved — caller treats this as a per-skill failure.
@@ -588,17 +607,7 @@ export class SkillManager {
     // current name never caught siblings left behind by a crashed or concurrent
     // extract — they accumulated in localBase (hundreds were observed in prod).
     // Clear them all, then stage fresh.
-    try {
-      const prefix = `skill-${name}.staging-`
-      const entries = await this.fs.readdir(this.localBase)
-      await Promise.all(
-        entries
-          .filter((e) => e.startsWith(prefix))
-          .map((e) => this.fs.rm(`${this.localBase}/${e}`)),
-      )
-    } catch {
-      // Best-effort
-    }
+    await this.sweepTemp(`skill-${name}.staging-`)
     await this.fs.mkdir(staging)
     const tmpFile = `${staging}/.skill.tar.gz`
     try {
@@ -797,11 +806,24 @@ export class SkillManager {
       }
 
       const tarFile = `${this.localBase}/skill-${name}-publish.tar.gz`
+      // Snapshot before tarring. Drafts live on the workspace volume (NFS),
+      // where tar's post-read stat can disagree with the pre-read one — either
+      // from attribute-cache/clock skew or from the agent writing SKILL.md
+      // moments before publishing. Either way tar prints "file changed as we
+      // read it" and exits 1, and Shell.exec has no way to tell that warning
+      // apart from a real failure, so the whole publish dies. cp doesn't care
+      // if a file shifts under it, and the snapshot lands on tmpfs, so tar
+      // then reads a directory nothing else is touching. The name lock can't
+      // cover this: it only serializes pack against load.
+      const snapshot = `${this.localBase}/skill-${name}.pack-${process.pid}-${Date.now()}`
       try {
         await this.fs.rm(tarFile)
+        await this.sweepTemp(`skill-${name}.pack-`)
+        await this.fs.mkdir(snapshot)
+        await this.shell.exec('cp', ['-a', `${local}/.`, snapshot])
         await this.shell.exec('tar', [
           'czf', tarFile,
-          '-C', local,
+          '-C', snapshot,
           '--exclude', LOCK_FILE,
           '--exclude', '.skill.tar.gz',
           '.',
@@ -809,6 +831,7 @@ export class SkillManager {
         return await this.fs.readFile(tarFile)
       } finally {
         try { await this.fs.rm(tarFile) } catch {}
+        try { await this.fs.rm(snapshot) } catch {}
       }
     })
   }


### PR DESCRIPTION
## Problem

`skill_publish` fails during packing:

```
Error: Failed to pack skill: Command failed: tar czf /tmp/skill-<name>-publish.tar.gz \
  -C /workspace/.skills-draft/skill-<name> --exclude .editing --exclude .skill.tar.gz .
tar: ./SKILL.md: file changed as we read it
```

## Cause

Drafts live on the workspace volume (NFS) and `pack()` ran tar directly against that directory. GNU tar re-stats each file after reading it; if the post-read stat disagrees with the pre-read one it emits `file changed as we read it` and exits 1. `Shell.exec` only models success/failure, so that warning was indistinguishable from a real error and aborted the publish.

Two ways the stat disagrees:

1. NFS attribute-cache / clock-granularity skew — a false alarm, the archive is intact;
2. the agent writing `SKILL.md` moments before calling `skill_publish` — a genuine overlap.

The per-name lock added earlier covers neither: it only serializes `pack` against `load`, not against the agent's own writes or NFS attribute jitter.

## Fix

Copy the skill directory to a tmpfs snapshot (`cp -a`), then tar the snapshot. `cp` doesn't mind a file shifting under it, and tar ends up reading a directory nothing else touches — both triggers go away without changing the `Shell` interface or having to distinguish tar's exit codes.

Also factors the leaked-staging-dir sweep out of `extractAtomic` into `sweepTemp()` and reuses it for snapshot dirs, which carry the same pid/timestamp suffix and can leak the same way if the process dies mid-pack. (Leaked staging dirs previously accumulated into the hundreds in prod.)

## Test

`internal/agent-skills` — 33 passed, 2 new:

- draft-mode pack: `cp` sources the draft dir, tar's `-C` points at the tmpfs snapshot rather than the draft dir, snapshot cleaned up afterwards;
- leaked `.pack-*` dirs are swept while the skill's own dir is left alone.