### PR TITLE
c9: autoscaler scale-down, draining & scale-to-zero

### DIFF
--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -241,6 +241,27 @@ export async function resetAllSessionsIdle(workspaceId: string): Promise<void> {
   )
 }
 
+/**
+ * Whether any session bound to one of the given replica ordinals is mid-turn
+ * (chat_status='agent'). The autoscaler calls this before dropping a draining
+ * replica: a replica with an in-flight turn is held back a round so the turn
+ * isn't killed. Same `chat_status='agent'` signal the rollout sweep uses to
+ * avoid interrupting a live stream. Empty ordinals → false (nothing to check).
+ */
+export async function replicasHaveActiveTurn(
+  workspaceId: string,
+  ordinals: number[],
+): Promise<boolean> {
+  if (ordinals.length === 0) return false
+  const { rows } = await pool.query(
+    `SELECT 1 FROM sessions
+      WHERE workspace_id = $1 AND status = 'active' AND chat_status = 'agent'
+        AND replica_ordinal = ANY($2::int[]) LIMIT 1`,
+    [workspaceId, ordinals],
+  )
+  return rows.length > 0
+}
+
 export async function listActiveSessionIds(workspaceId: string): Promise<string[]> {
   const { rows } = await pool.query(
     "SELECT id FROM sessions WHERE workspace_id = $1 AND status = 'active' AND chat_status = 'agent'",

--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -175,7 +175,10 @@ interface IdleWorkspace {
  * workspace's "last used" is the latest of: any session's last_active_at, any
  * message's created_at, and the workspace's own created_at (the fallback for a
  * workspace created but never chatted). System workspaces are excluded — they
- * are platform infrastructure and must not be GC'd. Ordered oldest-idle first.
+ * are platform infrastructure and must not be GC'd. Auto-scaling workspaces are
+ * excluded too — the autoscaler owns their scale-to-zero, and letting the
+ * day-scale GC also stop them would be double control on the same lifecycle.
+ * Ordered oldest-idle first.
  */
 export async function listIdleRunningWorkspaces(idleDays: number): Promise<IdleWorkspace[]> {
   const { rows } = await pool.query(
@@ -194,6 +197,10 @@ export async function listIdleRunningWorkspaces(idleDays: number): Promise<IdleW
          ) AS last_used
        FROM workspaces w
        WHERE w.status = 'running' AND w.is_system = false
+         AND NOT EXISTS (
+           SELECT 1 FROM workspace_config wc
+            WHERE wc.workspace_id = w.id AND wc.auto_scaling IS NOT NULL
+         )
      )
      SELECT id, name, last_used FROM activity
      WHERE last_used < NOW() - make_interval(days => $1::int)

--- a/control-plane/src/services/replica-router.test.ts
+++ b/control-plane/src/services/replica-router.test.ts
@@ -3,6 +3,8 @@ import {
   __resetReplicaRouter,
   perReplicaCapacity,
   pickReplicaForTurn,
+  readyReplicaIds,
+  setDraining,
   syncReadyReplicas,
 } from './replica-router'
 
@@ -57,6 +59,57 @@ describe('syncReadyReplicas', () => {
   it('treats an empty replica list as no auto-scaling replicas', () => {
     syncReadyReplicas(snapshot({ ws1: [] }))
     expect(pickReplicaForTurn('ws1')).toBeUndefined()
+  })
+})
+
+describe('setDraining', () => {
+  it('steers new picks away from a draining replica', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1, 2] }))
+    setDraining('ws1', [2])
+    // round-robin now spreads over the non-draining pool {0,1} only
+    expect(pickReplicaForTurn('ws1')).toBe(0)
+    expect(pickReplicaForTurn('ws1')).toBe(1)
+    expect(pickReplicaForTurn('ws1')).toBe(0)
+  })
+
+  it('rebinds a session off a replica that started draining', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1, 2] }))
+    expect(pickReplicaForTurn('ws1', 2)).toBe(2) // affinity holds while healthy
+    setDraining('ws1', [2])
+    expect(pickReplicaForTurn('ws1', 2)).not.toBe(2) // now moved off
+  })
+
+  it('falls back to the full set when every ready replica is draining', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1] }))
+    setDraining('ws1', [0, 1])
+    expect([0, 1]).toContain(pickReplicaForTurn('ws1'))
+  })
+
+  it('ignores drain targets that are not in the ready set, and clears on []', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1] }))
+    setDraining('ws1', [9]) // stale ordinal → no effect
+    expect(pickReplicaForTurn('ws1', 1)).toBe(1)
+    setDraining('ws1', [1])
+    expect(pickReplicaForTurn('ws1', 1)).not.toBe(1)
+    setDraining('ws1', []) // clear
+    expect(pickReplicaForTurn('ws1', 1)).toBe(1)
+  })
+
+  it('drops draining marks for replicas that leave the ready set on re-sync', () => {
+    syncReadyReplicas(snapshot({ ws1: [0, 1, 2] }))
+    setDraining('ws1', [2])
+    syncReadyReplicas(snapshot({ ws1: [0, 1] })) // 2 removed
+    // 2 is gone; a later 2 (unlikely, but) would not be treated as draining
+    syncReadyReplicas(snapshot({ ws1: [0, 1, 2] }))
+    expect(pickReplicaForTurn('ws1', 2)).toBe(2)
+  })
+})
+
+describe('readyReplicaIds', () => {
+  it('returns the sorted ready ids, empty for a static workspace', () => {
+    expect(readyReplicaIds('static-ws')).toEqual([])
+    syncReadyReplicas(snapshot({ ws1: [2, 0, 1] }))
+    expect(readyReplicaIds('ws1')).toEqual([0, 1, 2])
   })
 })
 

--- a/control-plane/src/services/replica-router.ts
+++ b/control-plane/src/services/replica-router.ts
@@ -44,6 +44,14 @@ const readyReplicas = new Map<string, number[]>()
 const perReplicaCap = new Map<string, number>()
 /** Round-robin cursor per workspace, so new sessions spread across replicas. */
 const rrCursor = new Map<string, number>()
+/**
+ * Draining replica ids per workspace: the ones the autoscaler is about to remove
+ * (scale-down). They still serve the turns already bound to them, but take no NEW
+ * session — pickReplicaForTurn steers new picks (and rebinds) away — so they go
+ * turn-free and can be dropped. Kept intersected with the ready set on every sync,
+ * so a replica that has actually left ready also leaves draining.
+ */
+const drainingReplicas = new Map<string, Set<number>>()
 
 /**
  * Replace the whole ready-replica picture from one observation snapshot (every
@@ -66,6 +74,18 @@ export function syncReadyReplicas(snapshot: ReadonlyMap<string, ReplicaSnapshot>
   }
   for (const workspaceId of rrCursor.keys()) {
     if (!readyReplicas.has(workspaceId)) rrCursor.delete(workspaceId)
+  }
+  // Keep draining marks pinned to replicas that still exist: a drained replica
+  // that has left the ready set is gone, so its mark is meaningless; and a
+  // workspace that stopped reporting drops its whole draining set.
+  for (const [workspaceId, ids] of drainingReplicas) {
+    const ready = readyReplicas.get(workspaceId)
+    if (!ready) {
+      drainingReplicas.delete(workspaceId)
+      continue
+    }
+    for (const id of ids) if (!ready.includes(id)) ids.delete(id)
+    if (ids.size === 0) drainingReplicas.delete(workspaceId)
   }
 }
 
@@ -91,12 +111,14 @@ export async function refreshReplicaRouter(): Promise<void> {
  *
  * - No ready set (static workspace, or auto-scaling scaled to zero / not yet
  *   observed) → undefined: the caller routes to the default address.
- * - A `currentBinding` still in the ready set → keep it (session affinity holds
- *   across turns, and across a stream drop where the replica stayed alive).
- * - Otherwise (a new session, or a bound replica that dropped out of the ready
- *   set — pod died / scaled away) → pick a fresh replica, round-robin so load
- *   spreads. This is the observe-driven rebind: the session resumes on a healthy
- *   replica from the shared-volume transcript.
+ * - A `currentBinding` still in the ready set and NOT draining → keep it (session
+ *   affinity holds across turns, and across a stream drop where the replica
+ *   stayed alive).
+ * - Otherwise (a new session; a bound replica that dropped out of the ready set —
+ *   pod died / scaled away; or a bound replica now draining) → pick a fresh
+ *   replica, round-robin over the non-draining ready set so load spreads and the
+ *   draining replica sheds its sessions. This is the observe-driven rebind: the
+ *   session resumes on a healthy replica from the shared-volume transcript.
  *
  * The load-aware refinement (pick the least-busy replica using live turn counts)
  * arrives with the turn gate; round-robin is the dormant-stage placeholder.
@@ -107,11 +129,49 @@ export function pickReplicaForTurn(
 ): number | undefined {
   const ready = readyReplicas.get(workspaceId)
   if (!ready || ready.length === 0) return undefined
-  if (currentBinding !== undefined && ready.includes(currentBinding)) return currentBinding
+  const draining = drainingReplicas.get(workspaceId)
+  if (
+    currentBinding !== undefined &&
+    ready.includes(currentBinding) &&
+    !draining?.has(currentBinding)
+  )
+    return currentBinding
 
+  // Prefer non-draining replicas; fall back to the full set only in the corner
+  // case where every ready replica is draining (a workspace on its way to zero),
+  // so a turn that must run still lands somewhere.
+  const pickable = draining ? ready.filter((id) => !draining.has(id)) : ready
+  const pool = pickable.length > 0 ? pickable : ready
   const cursor = rrCursor.get(workspaceId) ?? 0
   rrCursor.set(workspaceId, cursor + 1)
-  return ready[cursor % ready.length]
+  return pool[cursor % pool.length]
+}
+
+/**
+ * Mark exactly `ids` as the draining set of a workspace (a full replace, so `[]`
+ * clears it). The autoscaler calls this when it decides which replicas a pending
+ * scale-down will remove: they keep serving bound turns but take no new session,
+ * so they drain to turn-free and can be dropped. Only ids currently in the ready
+ * set are retained — a stale drain target is silently ignored.
+ */
+export function setDraining(workspaceId: string, ids: number[]): void {
+  if (ids.length === 0) {
+    drainingReplicas.delete(workspaceId)
+    return
+  }
+  const ready = readyReplicas.get(workspaceId)
+  const set = new Set(ready ? ids.filter((id) => ready.includes(id)) : [])
+  if (set.size === 0) drainingReplicas.delete(workspaceId)
+  else drainingReplicas.set(workspaceId, set)
+}
+
+/**
+ * The ready replica ids of a workspace, sorted ascending (empty for a static or
+ * scaled-to-zero workspace). The autoscaler reads this to compute which ordinals
+ * a scale-down would remove.
+ */
+export function readyReplicaIds(workspaceId: string): readonly number[] {
+  return readyReplicas.get(workspaceId) ?? []
 }
 
 /**
@@ -138,4 +198,5 @@ export function __resetReplicaRouter(): void {
   readyReplicas.clear()
   perReplicaCap.clear()
   rrCursor.clear()
+  drainingReplicas.clear()
 }

--- a/control-plane/src/services/workspace-autoscaler.test.ts
+++ b/control-plane/src/services/workspace-autoscaler.test.ts
@@ -1,32 +1,159 @@
-import { describe, expect, it } from 'vitest'
-import { desiredReplicas } from './workspace-autoscaler'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// desiredReplicas is the autoscaler's pure core: (active + queued) turns carried
-// at perReplicaCapacity each, clamped to [min, max].
+vi.mock('./db/pool', () => ({ pool: { query: vi.fn() } }))
+vi.mock('./chat/turn-gate', () => ({ turnDemand: vi.fn() }))
+vi.mock('./replica-router', () => ({ readyReplicaIds: vi.fn(), setDraining: vi.fn() }))
+vi.mock('./db/sessions', () => ({ replicasHaveActiveTurn: vi.fn() }))
+vi.mock('./placement', () => ({ setDesiredReplicas: vi.fn(), setDesiredPhase: vi.fn() }))
 
-const at = (active: number, queued = 0) => ({ active, queued })
+import { turnDemand } from './chat/turn-gate'
+import { pool } from './db/pool'
+import { replicasHaveActiveTurn } from './db/sessions'
+import { setDesiredPhase, setDesiredReplicas } from './placement'
+import { readyReplicaIds, setDraining } from './replica-router'
+import {
+  __resetAutoscaler,
+  desiredReplicas,
+  replicasToRemove,
+  runAutoscaler,
+} from './workspace-autoscaler'
+
+const q = vi.mocked(pool.query)
+const demand = vi.mocked(turnDemand)
+const ready = vi.mocked(readyReplicaIds)
+const draining = vi.mocked(setDraining)
+const activeTurn = vi.mocked(replicasHaveActiveTurn)
+const setReplicas = vi.mocked(setDesiredReplicas)
+const setPhase = vi.mocked(setDesiredPhase)
+
+const WS = 'ws1'
+type Row = {
+  min_replicas: number
+  max_replicas: number
+  scale_to_zero_idle_seconds: number | null
+  max_concurrency: number
+  current_replicas: number
+}
+const defaults: Row = {
+  min_replicas: 1,
+  max_replicas: 10,
+  scale_to_zero_idle_seconds: null,
+  max_concurrency: 3,
+  current_replicas: 3,
+}
+
+/** Arrange one running auto-scaling workspace for the next runAutoscaler pass. */
+function arrange(
+  row: Partial<Row>,
+  d: { active: number; queued: number },
+  opts: { ready?: number[]; hasTurn?: boolean } = {},
+) {
+  q.mockResolvedValue({ rows: [{ workspace_id: WS, ...defaults, ...row }] } as never)
+  demand.mockReturnValue(d)
+  ready.mockReturnValue(opts.ready ?? [0, 1, 2])
+  activeTurn.mockResolvedValue(opts.hasTurn ?? false)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetAutoscaler()
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+})
+afterEach(() => vi.useRealTimers())
+
+describe('replicasToRemove', () => {
+  it('removes the highest ordinals (>= desired), sorted', () => {
+    expect(replicasToRemove([0, 1, 2], 2)).toEqual([2])
+    expect(replicasToRemove([0, 1, 2, 3], 2)).toEqual([2, 3])
+    expect(replicasToRemove([2, 0, 1], 1)).toEqual([1, 2])
+  })
+  it('removes nothing when the ready set is already at/below desired', () => {
+    expect(replicasToRemove([0, 1], 2)).toEqual([])
+    expect(replicasToRemove([], 0)).toEqual([])
+  })
+})
 
 describe('desiredReplicas', () => {
-  it('sizes to cover active + queued turns at capacity each', () => {
-    expect(desiredReplicas(at(6), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(2)
-    expect(desiredReplicas(at(7), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(3) // ceil
-    expect(desiredReplicas(at(3, 4), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(3) // 7/3
+  it('sizes to (active+queued)/capacity, clamped to [min,max]', () => {
+    expect(
+      desiredReplicas({ active: 7, queued: 0 }, { perReplicaCapacity: 3, min: 0, max: 10 }),
+    ).toBe(3)
+    expect(
+      desiredReplicas({ active: 0, queued: 0 }, { perReplicaCapacity: 3, min: 0, max: 10 }),
+    ).toBe(0)
+  })
+})
+
+describe('runAutoscaler scale-up', () => {
+  it('raises desired to meet demand immediately', async () => {
+    arrange({ current_replicas: 1 }, { active: 6, queued: 0 })
+    await runAutoscaler()
+    expect(setReplicas).toHaveBeenCalledWith(WS, 2)
+    expect(draining).toHaveBeenCalledWith(WS, [])
+  })
+})
+
+describe('runAutoscaler scale-down', () => {
+  it('waits SCALE_DOWN_ROUNDS low rounds before removing a replica', async () => {
+    // current 3, demand fits 1 replica → target 1 < 3.
+    arrange({ current_replicas: 3 }, { active: 3, queued: 0 })
+    await runAutoscaler()
+    await runAutoscaler()
+    expect(setReplicas).not.toHaveBeenCalled()
+    await runAutoscaler() // 3rd low round
+    expect(setReplicas).toHaveBeenCalledWith(WS, 2)
+    expect(draining).toHaveBeenLastCalledWith(WS, [2]) // highest ordinal drained
   })
 
-  it('holds the min floor when demand is low (incl. zero)', () => {
-    expect(desiredReplicas(at(0), { perReplicaCapacity: 3, min: 2, max: 10 })).toBe(2)
-    expect(desiredReplicas(at(1), { perReplicaCapacity: 3, min: 2, max: 10 })).toBe(2)
+  it('holds the step while the draining replica still has an in-flight turn', async () => {
+    arrange({ current_replicas: 3 }, { active: 3, queued: 0 }, { hasTurn: true })
+    await runAutoscaler()
+    await runAutoscaler()
+    await runAutoscaler()
+    expect(draining).toHaveBeenLastCalledWith(WS, [2]) // marked draining
+    expect(setReplicas).not.toHaveBeenCalled() // but not removed — turn in flight
   })
 
-  it('caps at max under heavy demand', () => {
-    expect(desiredReplicas(at(100), { perReplicaCapacity: 3, min: 1, max: 4 })).toBe(4)
+  it('cancels a pending scale-down when demand climbs back to the current count', async () => {
+    arrange({ current_replicas: 3 }, { active: 3, queued: 0 })
+    await runAutoscaler() // low round 1
+    // demand rises to exactly fit 3 replicas (cap 3 → 9) — steady
+    demand.mockReturnValue({ active: 9, queued: 0 })
+    await runAutoscaler()
+    demand.mockReturnValue({ active: 3, queued: 0 })
+    await runAutoscaler() // counter was reset → only low round 1 again
+    expect(setReplicas).not.toHaveBeenCalled()
+  })
+})
+
+describe('runAutoscaler scale-to-zero', () => {
+  it('stops a workspace idle past its threshold, on a later pass', async () => {
+    arrange({ current_replicas: 2, scale_to_zero_idle_seconds: 300 }, { active: 0, queued: 0 })
+    await runAutoscaler() // t=0: idle clock starts
+    expect(setPhase).not.toHaveBeenCalled()
+    vi.setSystemTime(301_000)
+    await runAutoscaler()
+    expect(setPhase).toHaveBeenCalledWith(WS, 'stopped')
   })
 
-  it('allows zero when min is zero and there is no demand (scale-to-zero target)', () => {
-    expect(desiredReplicas(at(0), { perReplicaCapacity: 3, min: 0, max: 10 })).toBe(0)
+  it('never stops when scale-to-zero is disabled', async () => {
+    arrange({ current_replicas: 2, scale_to_zero_idle_seconds: null }, { active: 0, queued: 0 })
+    await runAutoscaler()
+    vi.setSystemTime(10_000_000)
+    await runAutoscaler()
+    expect(setPhase).not.toHaveBeenCalled()
   })
 
-  it('never divides by zero on a bad capacity', () => {
-    expect(desiredReplicas(at(4), { perReplicaCapacity: 0, min: 0, max: 10 })).toBe(4)
+  it('resets the idle clock when demand reappears', async () => {
+    arrange({ current_replicas: 2, scale_to_zero_idle_seconds: 300 }, { active: 0, queued: 0 })
+    await runAutoscaler() // idle clock starts at t=0
+    demand.mockReturnValue({ active: 1, queued: 0 }) // busy again
+    vi.setSystemTime(200_000)
+    await runAutoscaler() // clock cleared
+    demand.mockReturnValue({ active: 0, queued: 0 }) // idle again
+    vi.setSystemTime(400_000)
+    await runAutoscaler() // clock restarts here, < threshold since
+    expect(setPhase).not.toHaveBeenCalled()
   })
 })

--- a/control-plane/src/services/workspace-autoscaler.ts
+++ b/control-plane/src/services/workspace-autoscaler.ts
@@ -1,6 +1,8 @@
 import { turnDemand } from './chat/turn-gate'
 import { pool } from './db/pool'
-import { setDesiredReplicas } from './placement'
+import { replicasHaveActiveTurn } from './db/sessions'
+import { setDesiredPhase, setDesiredReplicas } from './placement'
+import { readyReplicaIds, setDraining } from './replica-router'
 
 // The workspace autoscaler: a periodic control loop that sizes each auto-scaling
 // workspace's replica count to its live turn demand. It reads the demand signal
@@ -9,11 +11,19 @@ import { setDesiredReplicas } from './placement'
 // converges. Static workspaces are never touched (they have no auto_scaling
 // config, so the query below skips them).
 //
-// This stage does SCALE-UP only: replicas grow to meet demand or the min floor,
-// and never shrink here. Scale-down is delicate (drain live turns off a replica
-// before removing it) and lands in its own stage; until then an auto-scaling
-// workspace that has grown stays grown, which is safe (over-provisioned), just
-// not yet economical.
+// Scale-up is immediate (over-provisioning is safe). Scale-down is deliberate:
+// it waits SCALE_DOWN_ROUNDS consecutive low rounds, then removes one replica at
+// a time — and only a replica the router has drained to turn-free, so no live
+// turn is killed. Scale-to-zero stops an idle workspace outright (reversible: the
+// next turn auto-starts it), independent of the replica floor.
+
+/** Consecutive low rounds required before a scale-down step (~3 × 15s ≈ 45s). */
+const SCALE_DOWN_ROUNDS = Number(process.env.AUTOSCALER_SCALE_DOWN_ROUNDS) || 3
+
+/** Consecutive-low-round counter per workspace, for scale-down hysteresis. */
+const lowRounds = new Map<string, number>()
+/** When a workspace first went fully idle (ms), for scale-to-zero timing. */
+const idleSince = new Map<string, number>()
 
 /**
  * The replica count a workspace should run for its demand: enough replicas to
@@ -28,10 +38,23 @@ export function desiredReplicas(
   return Math.min(Math.max(need, opts.min), opts.max)
 }
 
+/**
+ * Which ready ordinals a scale-down to `desired` removes. Encodes the k8s
+ * StatefulSet convention directly — scaling to N keeps ordinals 0..N-1 and drops
+ * the rest — because cp can't call a remote provider's nextRemovedReplicaIds
+ * across the tunnel (design §7). A non-k8s provider with a different removal
+ * order would need this convention taught per-provider; today every provider is
+ * k8s, so the assumption holds. Pure.
+ */
+export function replicasToRemove(readyIds: readonly number[], desired: number): number[] {
+  return readyIds.filter((id) => id >= desired).sort((a, b) => a - b)
+}
+
 interface AutoScalingRow {
   workspace_id: string
   min_replicas: number
   max_replicas: number
+  scale_to_zero_idle_seconds: number | null
   max_concurrency: number
   current_replicas: number
 }
@@ -42,6 +65,7 @@ async function listAutoScalingWorkspaces(): Promise<AutoScalingRow[]> {
     `SELECT wc.workspace_id,
             (wc.auto_scaling->>'min_replicas')::int AS min_replicas,
             (wc.auto_scaling->>'max_replicas')::int AS max_replicas,
+            (wc.auto_scaling->>'scale_to_zero_idle_seconds')::int AS scale_to_zero_idle_seconds,
             wc.max_concurrency,
             COALESCE((wp.spec->>'replicas')::int, 1) AS current_replicas
        FROM workspace_config wc
@@ -53,20 +77,103 @@ async function listAutoScalingWorkspaces(): Promise<AutoScalingRow[]> {
 }
 
 /**
+ * Stop a fully-idle workspace once it has been idle past its configured
+ * threshold. Returns true if it acted (so the caller skips replica scaling this
+ * round). Idle = no active and no queued turns; the idle clock is kept in memory
+ * and reset the moment any demand appears. A stopped workspace drops out of the
+ * running query and auto-starts on its next turn (data is on the shared volume,
+ * so this is lossless). No-op when scale_to_zero_idle_seconds is unset.
+ */
+async function maybeScaleToZero(ws: AutoScalingRow): Promise<boolean> {
+  const demand = turnDemand(ws.workspace_id)
+  const idle = demand.active === 0 && demand.queued === 0
+  if (!idle) {
+    idleSince.delete(ws.workspace_id)
+    return false
+  }
+  if (ws.scale_to_zero_idle_seconds == null) return false
+  const since = idleSince.get(ws.workspace_id)
+  if (since === undefined) {
+    idleSince.set(ws.workspace_id, Date.now())
+    return false
+  }
+  if (Date.now() - since < ws.scale_to_zero_idle_seconds * 1000) return false
+  await setDesiredPhase(ws.workspace_id, 'stopped')
+  idleSince.delete(ws.workspace_id)
+  lowRounds.delete(ws.workspace_id)
+  setDraining(ws.workspace_id, [])
+  console.log(
+    `[Autoscaler] scale to zero ws=${ws.workspace_id} (idle > ${ws.scale_to_zero_idle_seconds}s)`,
+  )
+  return true
+}
+
+/**
+ * Take one replica off a workspace, safely. Marks the ordinals the provider will
+ * remove as draining (so the router steers new sessions away), then reduces the
+ * desired count only once those ordinals carry no in-flight turn. If one still
+ * does, it holds — the ordinals stay draining and it retries next round.
+ */
+async function tryScaleDownOne(ws: AutoScalingRow): Promise<void> {
+  const newDesired = ws.current_replicas - 1
+  const removing = replicasToRemove(readyReplicaIds(ws.workspace_id), newDesired)
+  setDraining(ws.workspace_id, removing)
+  // Observed set already at/below the new target (still converging up, or nothing
+  // ready ≥ newDesired) — nothing to drain, just write the lower desired.
+  if (removing.length === 0) {
+    await setDesiredReplicas(ws.workspace_id, newDesired)
+    lowRounds.delete(ws.workspace_id)
+    return
+  }
+  if (await replicasHaveActiveTurn(ws.workspace_id, removing)) return
+  await setDesiredReplicas(ws.workspace_id, newDesired)
+  lowRounds.delete(ws.workspace_id)
+  console.log(
+    `[Autoscaler] scale down ws=${ws.workspace_id} ${ws.current_replicas} → ${newDesired}`,
+  )
+}
+
+/**
  * One autoscaler pass. Cheap no-op while no workspace is auto-scaling (the query
- * returns nothing). Scale-UP only: writes a higher desired count when demand (or
- * the min floor) calls for it; never reduces.
+ * returns nothing). Per workspace: scale to zero if idle; else scale up on demand
+ * immediately, or scale down by one after SCALE_DOWN_ROUNDS consecutive low
+ * rounds.
  */
 export async function runAutoscaler(): Promise<void> {
+  const seen = new Set<string>()
   for (const ws of await listAutoScalingWorkspaces()) {
+    seen.add(ws.workspace_id)
+    if (await maybeScaleToZero(ws)) continue
+
     const target = desiredReplicas(turnDemand(ws.workspace_id), {
       perReplicaCapacity: ws.max_concurrency,
       min: ws.min_replicas,
       max: ws.max_replicas,
     })
+
     if (target > ws.current_replicas) {
       await setDesiredReplicas(ws.workspace_id, target)
+      setDraining(ws.workspace_id, [])
+      lowRounds.delete(ws.workspace_id)
       console.log(`[Autoscaler] scale up ws=${ws.workspace_id} ${ws.current_replicas} → ${target}`)
+    } else if (target < ws.current_replicas) {
+      const rounds = (lowRounds.get(ws.workspace_id) ?? 0) + 1
+      lowRounds.set(ws.workspace_id, rounds)
+      if (rounds >= SCALE_DOWN_ROUNDS) await tryScaleDownOne(ws)
+    } else {
+      // Demand matches the current count — cancel any pending scale-down.
+      lowRounds.delete(ws.workspace_id)
+      setDraining(ws.workspace_id, [])
     }
   }
+  // Drop in-memory hysteresis for workspaces no longer running/auto-scaling, so
+  // the maps can't grow without bound.
+  for (const k of lowRounds.keys()) if (!seen.has(k)) lowRounds.delete(k)
+  for (const k of idleSince.keys()) if (!seen.has(k)) idleSince.delete(k)
+}
+
+/** Test seam: forget all in-memory scaling hysteresis. */
+export function __resetAutoscaler(): void {
+  lowRounds.clear()
+  idleSince.clear()
 }


### PR DESCRIPTION
Stage c9 of the auto-scaling workspaces series (→ `feat/auto-scaling-workspaces`, not main). Completes the autoscaler's other half: turn-safe reductions.

## What
- **replica-router** — per-workspace **draining set**. `setDraining()` marks the ordinals a pending scale-down will remove; they keep serving bound turns but `pickReplicaForTurn` steers new sessions away and rebinds sessions off a draining replica so it drains to turn-free. Draining ∩ ready is kept on every sync. `readyReplicaIds()` exposes the sorted ready set.
- **sessions** — `replicasHaveActiveTurn(ws, ordinals)`: any bound session mid-turn (`chat_status='agent'`, same signal rollout uses).
- **workspace-autoscaler**
  - **scale-down** after `SCALE_DOWN_ROUNDS` (=3, env-tunable) consecutive low rounds, one replica/step; drains the removed ordinals and only lowers desired once they're turn-free (else holds, retries).
  - `replicasToRemove()` — pure helper encoding the k8s "remove highest ordinals" convention (cp can't call a remote provider's `nextRemovedReplicaIds` across the tunnel — design §7).
  - **scale-to-zero** — idle (no active/queued) past `scale_to_zero_idle_seconds` → `setDesiredPhase('stopped')` (reversible; next turn auto-starts). Independent of the replica floor.
- **idle-workspace GC** now skips auto-scaling workspaces (autoscaler owns their scale-to-zero — no double control).

## Dormant / safe
Query filters `auto_scaling IS NOT NULL AND desired_phase='running'`; every new router/session export no-ops for a static workspace. Static paths byte-unchanged.

## Tests
`workspace-autoscaler.test.ts` (scale-up/down hysteresis, turn-free hold, draining target, scale-to-zero timing + idle-clock reset) and `replica-router.test.ts` (draining routing, rebind-off-draining, full-drain fallback, stale-target ignore, sync pruning). Full cp unit suite: 265 passing. tsc + knip + biome clean.