### PR TITLE
s3: per-replica tunnel addressing (remote auto-scaling)

### DIFF
--- a/control-plane/src/lib/remote-proxy.ts
+++ b/control-plane/src/lib/remote-proxy.ts
@@ -10,34 +10,68 @@ import { openForwardStream } from '../services/env-gateway/registry'
 // 127.0.0.1:<port>. Built-in workspaces never enter this map, so their path
 // stays byte-identical (the red line). The proxy is set up when cp observes a
 // remote workspace reachable (wired by projection, P2-D) and torn down on stop.
+//
+// An auto-scaling remote workspace has 0..N replicas behind a headless Service,
+// each reachable per-ordinal. So a remote workspace keeps not one proxy but a
+// set, keyed by replica ordinal: a per-ordinal proxy whose tunnel meta carries
+// the ordinal (`fwd:<ws>:<id>:<port>`, resolved to the pod's headless DNS on the
+// runner), plus — for a static workspace — a single ordinal-less proxy
+// (`fwd:<ws>:<port>`, the workspace's Service). Routing (getRemoteProxyPort)
+// asks for a specific replica; a workspace-scoped call with no replica affinity
+// takes the static proxy, or any replica (shared volume — reads are uniform).
 
 interface RemoteProxy {
   port: number
   server: net.Server
 }
 
-const proxies = new Map<string, RemoteProxy>()
+// Inner-map key for the ordinal-less (static / workspace-scoped) proxy. Real
+// replica ordinals are >= 0, so -1 can't collide.
+const STATIC_KEY = -1
 
-/** Local proxy port for a remote workspace, or undefined if it has none. */
-export function getRemoteProxyPort(workspaceId: string): number | undefined {
-  return proxies.get(workspaceId)?.port
+/** workspaceId → (replica ordinal | STATIC_KEY) → its localhost proxy. */
+const proxies = new Map<string, Map<number, RemoteProxy>>()
+
+/**
+ * Local proxy port for a remote workspace. With a `replicaId`, the port of that
+ * replica's proxy (undefined if it has none — the caller then fails fast rather
+ * than mis-routing a session's turn to the wrong replica). Without one, a
+ * workspace-scoped lookup: the static proxy if present, else any replica's (a
+ * remote auto-scaling workspace has no static proxy, and its replicas share one
+ * volume, so any ready replica answers a workspace-scoped read).
+ */
+export function getRemoteProxyPort(workspaceId: string, replicaId?: number): number | undefined {
+  const inner = proxies.get(workspaceId)
+  if (!inner) return undefined
+  if (replicaId !== undefined) return inner.get(replicaId)?.port
+  const staticProxy = inner.get(STATIC_KEY)
+  if (staticProxy) return staticProxy.port
+  for (const p of inner.values()) return p.port
+  return undefined
 }
 
 /**
- * Ensure a localhost forward proxy exists for a remote workspace; returns its
- * base URL. Idempotent. Each inbound connection opens a fresh tunnel stream to
- * the workspace's agent port.
+ * Open one localhost forward proxy for a workspace (or a replica of it), keyed
+ * by ordinal. Idempotent per key. Each inbound connection opens a fresh tunnel
+ * stream tagged with the forward meta the runner resolves to a pod address.
  */
-export async function ensureRemoteProxy(
+async function openProxy(
   workspaceId: string,
   environmentId: string,
-  targetPort = 3001,
-): Promise<string> {
-  const existing = proxies.get(workspaceId)
-  if (existing) return `http://127.0.0.1:${existing.port}`
+  replicaId: number | undefined,
+  targetPort: number,
+): Promise<void> {
+  const inner = proxies.get(workspaceId) ?? new Map<number, RemoteProxy>()
+  proxies.set(workspaceId, inner)
+  const key = replicaId ?? STATIC_KEY
+  if (inner.has(key)) return
+  const meta =
+    replicaId === undefined
+      ? `fwd:${workspaceId}:${targetPort}`
+      : `fwd:${workspaceId}:${replicaId}:${targetPort}`
 
   const server = net.createServer((socket) => {
-    const stream = openForwardStream(environmentId, `fwd:${workspaceId}:${targetPort}`)
+    const stream = openForwardStream(environmentId, meta)
     if (!stream) {
       socket.destroy()
       return
@@ -52,15 +86,55 @@ export async function ensureRemoteProxy(
   })
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
   const port = (server.address() as net.AddressInfo).port
-  proxies.set(workspaceId, { port, server })
+  inner.set(key, { port, server })
+}
+
+/**
+ * Ensure the static (single-Service) forward proxy for a remote workspace;
+ * returns its base URL. Idempotent. This is the static-workspace path, unchanged.
+ */
+export async function ensureRemoteProxy(
+  workspaceId: string,
+  environmentId: string,
+  targetPort = 3001,
+): Promise<string> {
+  const existing = proxies.get(workspaceId)?.get(STATIC_KEY)
+  if (existing) return `http://127.0.0.1:${existing.port}`
+  await openProxy(workspaceId, environmentId, undefined, targetPort)
+  const port = proxies.get(workspaceId)?.get(STATIC_KEY)?.port
   return `http://127.0.0.1:${port}`
 }
 
-/** Tear down a remote workspace's proxy (on stop / destroy / env offline). */
-export function dropRemoteProxy(workspaceId: string): void {
-  const p = proxies.get(workspaceId)
-  if (p) {
-    p.server.close()
-    proxies.delete(workspaceId)
+/**
+ * Reconcile a remote auto-scaling workspace's per-replica proxies to `readyIds`:
+ * open a proxy for each ready ordinal, and close any proxy that is no longer in
+ * the set — including a stale static proxy, should the workspace have briefly
+ * looked ordinal-less before its first replica observation. Idempotent.
+ */
+export async function syncReplicaProxies(
+  workspaceId: string,
+  environmentId: string,
+  readyIds: number[],
+  targetPort = 3001,
+): Promise<void> {
+  const desired = new Set(readyIds)
+  const inner = proxies.get(workspaceId)
+  if (inner) {
+    for (const [key, p] of inner) {
+      if (key === STATIC_KEY || !desired.has(key)) {
+        p.server.close()
+        inner.delete(key)
+      }
+    }
   }
+  for (const id of readyIds) await openProxy(workspaceId, environmentId, id, targetPort)
+  if (proxies.get(workspaceId)?.size === 0) proxies.delete(workspaceId)
+}
+
+/** Tear down all of a remote workspace's proxies (on stop / destroy / env offline). */
+export function dropRemoteProxy(workspaceId: string): void {
+  const inner = proxies.get(workspaceId)
+  if (!inner) return
+  for (const p of inner.values()) p.server.close()
+  proxies.delete(workspaceId)
 }

--- a/control-plane/src/lib/workspace-address.test.ts
+++ b/control-plane/src/lib/workspace-address.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // every route context while workspaces are single-replica.
 
 const { getRemoteProxyPortMock } = vi.hoisted(() => ({
-  getRemoteProxyPortMock: vi.fn<(workspaceId: string) => number | undefined>(),
+  getRemoteProxyPortMock: vi.fn<(workspaceId: string, replicaId?: number) => number | undefined>(),
 }))
 
 vi.mock('./remote-proxy', () => ({
@@ -65,6 +65,15 @@ describe('resolveAgentAddress', () => {
   it('follows the remote-proxy path too', () => {
     getRemoteProxyPortMock.mockReturnValue(41234)
     expect(resolveAgentAddress('ws1', { sessionId: 'sess-1' })).toBe('http://127.0.0.1:41234')
+  })
+
+  it('routes a replica-bound remote session to that replica’s proxy', () => {
+    // proxy exists only for replica 2 → a turn bound to 2 reaches it, others miss
+    getRemoteProxyPortMock.mockImplementation((_ws, id) => (id === 2 ? 41250 : undefined))
+    expect(resolveAgentAddress('ws1', { sessionId: 'sess-1', replicaId: 2 })).toBe(
+      'http://127.0.0.1:41250',
+    )
+    expect(getRemoteProxyPortMock).toHaveBeenCalledWith('ws1', 2)
   })
 })
 

--- a/control-plane/src/lib/workspace-address.ts
+++ b/control-plane/src/lib/workspace-address.ts
@@ -13,15 +13,17 @@ import { getRemoteProxyPort } from './remote-proxy'
  * StatefulSet pod's stable per-ordinal DNS.
  *
  * A workspace on a remote (BYOI) environment is reached through that
- * environment's tunnel instead. cp keeps a localhost forward proxy per
- * reachable remote workspace (lib/remote-proxy); this stays a synchronous O(1)
- * map lookup — built-in workspaces are never in the map, so their path is
- * byte-identical. Per-replica remote addressing (a proxy keyed by (ws, replica),
- * with the ordinal carried in the tunnel meta) is a later stage, so today the
- * remote proxy is per-workspace and `replicaId` does not yet reach it.
+ * environment's tunnel instead. cp keeps localhost forward proxies per reachable
+ * remote workspace (lib/remote-proxy) — one per replica for an auto-scaling
+ * workspace, carrying the ordinal in the tunnel meta so the runner dials the
+ * right pod. This stays a synchronous O(1) map lookup — built-in workspaces are
+ * never in the map, so their path is byte-identical. `replicaId` is threaded
+ * through so a session-bound turn reaches its own replica; if that replica's
+ * proxy isn't up yet (observe lag), the lookup misses and we fall through, which
+ * fails fast rather than mis-routing the turn to another replica.
  */
 export function getWorkspaceAddress(workspaceId: string, replicaId?: number): string {
-  const remotePort = getRemoteProxyPort(workspaceId)
+  const remotePort = getRemoteProxyPort(workspaceId, replicaId)
   if (remotePort !== undefined) return `http://127.0.0.1:${remotePort}`
   return builtinReplicaAddress(defaultCfg, workspaceId, replicaId)
 }

--- a/control-plane/src/services/db/environments.ts
+++ b/control-plane/src/services/db/environments.ts
@@ -131,6 +131,13 @@ interface RemoteObservation {
   observed_phase: string | null
   /** True when the environment has no live runner (offline/pending/stale beat). */
   env_offline: boolean
+  /**
+   * Ready replica ordinals the runner reported (auto-scaling workspaces only);
+   * null for a static workspace, which never carries the field. Drives the
+   * per-replica forward proxies the projection keeps for a remote auto-scaling
+   * workspace.
+   */
+  ready_replica_ids: number[] | null
 }
 
 /**
@@ -147,7 +154,8 @@ export async function listRemoteWorkspaceObservations(
               e.status = 'online'
               AND e.last_heartbeat_at IS NOT NULL
               AND e.last_heartbeat_at >= now() - make_interval(secs => $1)
-            ) AS env_offline
+            ) AS env_offline,
+            p.endpoint->'readyReplicaIds' AS ready_replica_ids
        FROM workspace_placements p
        JOIN environments e ON e.id = p.environment_id
       WHERE e.is_builtin = false

--- a/control-plane/src/services/env-projection.ts
+++ b/control-plane/src/services/env-projection.ts
@@ -1,4 +1,4 @@
-import { dropRemoteProxy, ensureRemoteProxy } from '../lib/remote-proxy'
+import { dropRemoteProxy, ensureRemoteProxy, syncReplicaProxies } from '../lib/remote-proxy'
 import { type WorkspaceStatus, applyStatusChange } from '../lib/workspace-status'
 import {
   listReapableWorkspaces,
@@ -64,9 +64,15 @@ export async function runEnvProjection(thresholdSec: number): Promise<void> {
 
     // Forward proxy lifecycle: a reachable, running remote workspace gets a
     // localhost proxy so cp's fetch sites can reach it through the tunnel;
-    // anything else (stopped/starting/offline) has none.
+    // anything else (stopped/starting/offline) has none. An auto-scaling
+    // workspace reports a ready-replica set → one proxy per ready ordinal; a
+    // static one reports none → the single ordinal-less proxy, unchanged.
     if (!o.env_offline && status === 'running') {
-      await ensureRemoteProxy(o.workspace_id, o.environment_id)
+      if (o.ready_replica_ids && o.ready_replica_ids.length > 0) {
+        await syncReplicaProxies(o.workspace_id, o.environment_id, o.ready_replica_ids)
+      } else {
+        await ensureRemoteProxy(o.workspace_id, o.environment_id)
+      }
     } else {
       dropRemoteProxy(o.workspace_id)
     }

--- a/env-runner-k8s/src/tunnel-dataplane.ts
+++ b/env-runner-k8s/src/tunnel-dataplane.ts
@@ -4,8 +4,10 @@ import { type Mux, listenAndTunnel, pipeToTcp } from '../../internal/env-tunnel'
 import { handleAfsControl } from './afs-control'
 
 // Runner-side data plane. Two directions over the tunnel mux:
-//   - forward (cp→workspace): cp opens `fwd:<wsId>:<port>`; we dial the pod's
-//     cluster-DNS in the customer cluster and pipe.
+//   - forward (cp→workspace): cp opens `fwd:<wsId>:<port>` for a single-Service
+//     (static) workspace, or `fwd:<wsId>:<ordinal>:<port>` for one replica of an
+//     auto-scaling workspace; we dial the pod's cluster-DNS in the customer
+//     cluster and pipe.
 //   - reverse (sidecar→cp): we run local TCP listeners (fronted by a k8s Service
 //     in the customer cluster, see F3 manifest); a sidecar's CP_URL /
 //     AFS_CONTROLLER points here, and its bytes ride the tunnel back to cp.
@@ -19,13 +21,32 @@ const FORWARD_PORTS = new Set([3001, 9101, 9102])
 const CP_PROXY_PORT = Number(process.env.TUNNEL_CP_PROXY_PORT) || 38000
 const AFS_PROXY_PORT = Number(process.env.TUNNEL_AFS_PROXY_PORT) || 39100
 
-/** Resolve a forward stream's target pod address, or null if invalid/disallowed. */
+/**
+ * Resolve a forward stream's target pod address, or null if invalid/disallowed.
+ *
+ * Two meta forms:
+ *   - `fwd:<ws>:<port>` — static workspace, its single Service:
+ *     `<prefix>-<ws>.<ns>.svc.cluster.local`.
+ *   - `fwd:<ws>:<ordinal>:<port>` — one replica of an auto-scaling workspace, via
+ *     its headless Service: `<prefix>-<ws>-<ordinal>.<prefix>-<ws>-hl.<ns>...`.
+ *     Byte-identical to internal/k8s-provider's builtinReplicaAddress, so a
+ *     remote-routed replica resolves to the same pod DNS a built-in one would.
+ *
+ * The workspace id can't contain a colon, so the optional middle group
+ * unambiguously distinguishes the two forms.
+ */
 function resolveForwardTarget(meta: string): { host: string; port: number } | null {
-  const m = /^fwd:([^:]+):(\d+)$/.exec(meta)
+  const m = /^fwd:([^:]+):(?:(\d+):)?(\d+)$/.exec(meta)
   if (!m) return null
-  const port = Number(m[2])
+  const [, ws, ordinal] = m
+  const port = Number(m[3])
   if (!FORWARD_PORTS.has(port)) return null
-  return { host: `${NAME_PREFIX}-${m[1]}.${NAMESPACE}.svc.cluster.local`, port }
+  const base = `${NAME_PREFIX}-${ws}`
+  const host =
+    ordinal === undefined
+      ? `${base}.${NAMESPACE}.svc.cluster.local`
+      : `${base}-${ordinal}.${base}-hl.${NAMESPACE}.svc.cluster.local`
+  return { host, port }
 }
 
 /** Handle a forward stream cp opened: validate, dial the pod, pipe. */


### PR DESCRIPTION
Stage s3 of the auto-scaling workspaces series (→ `feat/auto-scaling-workspaces`, not main). Makes the **remote (BYOI)** data plane replica-aware; builtin was already per-ordinal (s3 = c3 seam).

## Problem
A remote workspace is reached via a localhost forward proxy over the tunnel, meta `fwd:<ws>:<port>`, resolved on the runner to the workspace's single Service. An auto-scaling workspace's replicas sit behind a **headless** Service (no ClusterIP) — the old meta can't address an individual pod, so a remote auto-scaling turn had nowhere valid to land.

## Change
- **Runner** (`env-runner-k8s/tunnel-dataplane`): `resolveForwardTarget` also accepts `fwd:<ws>:<ordinal>:<port>` → per-ordinal headless DNS `<prefix>-<ws>-<ordinal>.<prefix>-<ws>-hl.<ns>.svc.cluster.local`, byte-identical to k8s-provider's `builtinReplicaAddress`. Old 3-part meta → single Service (unchanged).
- **cp `remote-proxy`**: a remote workspace keeps a **set** of proxies keyed by ordinal (+ an ordinal-less one for static). `getRemoteProxyPort(ws, replicaId?)`; a session-bound turn reaches its own replica, a miss **fails fast** (no cross-replica mis-route). `syncReplicaProxies` reconciles the per-ordinal set to the ready set; `ensureRemoteProxy` keeps the static path.
- **cp `workspace-address`**: threads `replicaId` into the proxy lookup.
- **cp `env-projection`**: a running remote ws reporting a ready-replica set → one proxy per ready ordinal; a static one → its single proxy. `listRemoteWorkspaceObservations` now returns `endpoint->readyReplicaIds`.

## Dormant / safe
Static workspaces never report `readyReplicaIds` → 3-part meta, single proxy, and cluster-DNS paths are all byte-unchanged. Only a remote auto-scaling workspace exercises the per-ordinal path.

## Tests
`workspace-address.test.ts` updated: replica-bound remote session routes to its replica's proxy, `replicaId` forwarded to the lookup. cp unit suite: 266 passing. tsc/knip/biome clean (cp + env-runner-k8s). Runner `resolveForwardTarget` kept private (env-runner-k8s has no test runner); its DNS contract is anchored byte-for-byte by the cp-side address test.