### PR TITLE
fix(self-host): render offline/registry.yaml so single-node installs get it

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -123,7 +123,7 @@ export AGENT_NODE_SELECTOR="${AGENT_NODE_SELECTOR:-}"
 
 export DEPLOY_PROFILE="${DEPLOY_PROFILE:-multi-node}"
 # In-cluster registry config, consumed only by the single-node offline path
-# (single_node_load_registry + manifests/registry.yaml). Safe to render in any
+# (single_node_load_registry + offline/registry.yaml). Safe to render in any
 # profile.
 export REGISTRY_NODE_PORT="${REGISTRY_NODE_PORT:-30500}"
 export REGISTRY_STORAGE_SIZE="${REGISTRY_STORAGE_SIZE:-20Gi}"
@@ -300,6 +300,13 @@ render_manifests() {
     envsubst "$VARS" < "$tmpl" > "$RENDERED_DIR/$name"
     log "  rendered $name"
   done
+
+  # registry.yaml is single-node-only offline infra and lives under offline/,
+  # not manifests/, so downstream consumers that treat manifests/ as the
+  # platform-service set don't render it as a service. Render it into the same
+  # output dir so single_node_load_registry can apply it.
+  envsubst "$VARS" < "$SCRIPT_DIR/offline/registry.yaml" > "$RENDERED_DIR/registry.yaml"
+  log "  rendered registry.yaml (offline)"
 
   # External ingress mode: strip `nodePort:` lines from Service specs.
   # k8s rejects nodePort on ClusterIP, but we keep the value in values.env


### PR DESCRIPTION
Follow-up to 515a436, which moved `registry.yaml` out of `manifests/` into
`offline/`.

`render_manifests` globs `manifests/`, so after the move nothing rendered the
file at all — it silently vanished from the rendered output and
`single_node_load_registry` had nothing to apply. An offline single-node install
then comes up without an in-cluster registry, which is the one component it
cannot pull images without.

Render it explicitly into the same output directory. It deliberately stays out
of `manifests/`: consumers that treat that directory as the set of platform
services shouldn't see it as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5KnA2eheU6drWhdeL5s5K