### PR TITLE
fix(web): stop DocumentedDialog overflowing on long unbreakable content

### DIFF
--- a/web/src/components/dialogs/CreateEnvironmentDialog.tsx
+++ b/web/src/components/dialogs/CreateEnvironmentDialog.tsx
@@ -123,7 +123,7 @@ export default function CreateEnvironmentDialog({ open, onOpenChange }: DialogPr
           <SecretReveal value={created.token} />
           <div className="space-y-1.5">
             <div className="text-xs font-medium">{t('components.createEnvironment.helmTitle')}</div>
-            <pre className="overflow-x-auto rounded-md border border-foreground/[0.08] bg-foreground/[0.04] p-3 font-mono text-tiny leading-relaxed text-muted-foreground">
+            <pre className="whitespace-pre-wrap break-all rounded-md border border-foreground/[0.08] bg-foreground/[0.04] p-3 font-mono text-tiny leading-relaxed text-muted-foreground">
               {`helm install my-env ./charts/env-runner-k8s \\
   --namespace agent-runner --create-namespace \\
   --set controlPlane.url=${controlPlaneUrl} \\

--- a/web/src/components/dialogs/SecretReveal.tsx
+++ b/web/src/components/dialogs/SecretReveal.tsx
@@ -31,7 +31,7 @@ export function SecretReveal({ value, warning }: SecretRevealProps) {
         <span>{warning ?? t('components.secretReveal.saveNow')}</span>
       </div>
       <div className="relative">
-        <pre className="overflow-x-auto rounded-md border border-foreground/[0.08] bg-foreground/[0.04] p-3 pr-12 font-mono text-xs">
+        <pre className="whitespace-pre-wrap break-all rounded-md border border-foreground/[0.08] bg-foreground/[0.04] p-3 pr-12 font-mono text-xs">
           {value}
         </pre>
         <button

--- a/web/src/components/ui/documented-dialog.tsx
+++ b/web/src/components/ui/documented-dialog.tsx
@@ -52,7 +52,10 @@ export function DocumentedDialog({
             than `w-3/5` / `w-2/5`: under content pressure Safari treats
             fractional widths as suggestions and can collapse the docs
             panel to ~0 when the form column has long content. */}
-        <div className={cn("flex min-h-0", hasDocs && s.height)}>
+        {/* `min-w-0` because this is a grid item of DialogContent: without it
+            the automatic minimum size lets long unbreakable content (secrets,
+            install commands) push the whole dialog past its `max-w-*`. */}
+        <div className={cn("flex min-h-0 min-w-0", hasDocs && s.height)}>
           {/* Left: form */}
           <div
             className={cn(
@@ -63,7 +66,7 @@ export function DocumentedDialog({
             <DialogHeader className="shrink-0 px-6 pt-5 pb-3">
               <DialogTitle className="text-base font-semibold">{title}</DialogTitle>
             </DialogHeader>
-            <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">{children}</div>
+            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto px-6 pb-4">{children}</div>
             {footer && <DialogFooter className="shrink-0 px-6 pb-5 pt-0">{footer}</DialogFooter>}
           </div>
 


### PR DESCRIPTION
## Problem

The "environment registered" dialog overflows horizontally: the runner token and the `helm install` command spill past the dialog's right edge.

## Root cause

`DocumentedDialog`'s inner flex container is a grid item of `DialogContent` (`grid w-full max-w-lg`). Without `min-w-0`, its automatic minimum size lets long unbreakable content (tokens, install commands) push the whole dialog past its configured `max-w-*`. This affects any dialog using `DocumentedDialog`, not just this one.

## Fix

- `documented-dialog.tsx` — add `min-w-0` to the flex container and content column.
- `SecretReveal.tsx` / `CreateEnvironmentDialog.tsx` — wrap the token and helm-command blocks (`whitespace-pre-wrap break-all`) instead of scrolling them horizontally, which is friendlier for content with no copy button.

## Test

`npx tsc --noEmit` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)