### PR TITLE
feat(skills): export a skill to local agents via npx skills

### DIFF
--- a/control-plane/migrations/126_skill_export_tokens.sql
+++ b/control-plane/migrations/126_skill_export_tokens.sql
@@ -1,0 +1,47 @@
+-- Skill exports: capability URLs that expose a single skill to local agents
+-- through the Agent Skills `.well-known` discovery protocol.
+--
+-- Scope is deliberately per-skill (not per-user): a leaked token exposes
+-- exactly one skill, and the grant is legible in the UI as "this skill is
+-- exported" rather than "this person's library is shared".
+--
+-- Mirrors export_tokens: opaque 128-bit token as the PK, scope looked up
+-- from the row (never embedded in the token), NULL expires_at = permanent,
+-- revocation is a hard DELETE.
+CREATE TABLE public.skill_export_tokens (
+    token text NOT NULL,
+    skill_id uuid NOT NULL,
+    -- The name the skill is published under, and the directory name the
+    -- client creates on disk. Derived from the skill name when that yields a
+    -- protocol-valid slug, supplied by the user otherwise (e.g. CJK names).
+    -- Frozen at mint time: deriving it per request would silently retarget an
+    -- existing install if the skill were later renamed.
+    slug text NOT NULL,
+    -- Who minted it. Kept for listing/audit; the grant itself rides on
+    -- skill_id, so this does not widen or narrow what the token can reach.
+    user_id text NOT NULL,
+    label text DEFAULT ''::text NOT NULL,
+    -- NULL = permanent. Default TTL is applied by the service, not here.
+    expires_at timestamp with time zone,
+    last_used_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE ONLY public.skill_export_tokens
+    ADD CONSTRAINT skill_export_tokens_pkey PRIMARY KEY (token);
+
+ALTER TABLE ONLY public.skill_export_tokens
+    ADD CONSTRAINT skill_export_tokens_skill_id_fkey FOREIGN KEY (skill_id)
+    REFERENCES public.skills(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.skill_export_tokens
+    ADD CONSTRAINT skill_export_tokens_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- List every export for a skill (management UI).
+CREATE INDEX skill_export_tokens_skill_id_idx ON public.skill_export_tokens USING btree (skill_id);
+
+-- Expiry sweep. Unlike export_tokens (which has no sweep and grows
+-- unbounded), these are long-lived and user-managed, so dead rows would
+-- otherwise linger for months.
+CREATE INDEX skill_export_tokens_expires_at_idx ON public.skill_export_tokens USING btree (expires_at);

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -49,6 +49,7 @@ import { publicExportsApp } from './routes/public-exports'
 import saasProxyRoutes from './routes/saas-proxy'
 import serviceTokenRoutes from './routes/service-tokens'
 import sharesRoutes from './routes/shares'
+import { skillRegistryApp, wellKnownRootApp } from './routes/skill-registry'
 import skillsRoutes from './routes/skills'
 import systemWorkspacesRoutes from './routes/system-workspaces'
 import tagsRoutes from './routes/tags'
@@ -160,6 +161,8 @@ app.use('/*', async (c, next) => {
     path === '/api/auth/wecom/callback' ||
     path.startsWith('/api/shares/public/') ||
     path.startsWith('/s/') ||
+    path.startsWith('/sk/') ||
+    path.startsWith('/.well-known/agent-skills') ||
     path.startsWith('/api/docs') ||
     path.startsWith('/_cp/') ||
     path.startsWith('/_cg/') ||
@@ -345,6 +348,10 @@ app.route('/api/asr', asrRoutes)
 app.route('/api/memory-stores', memoryStoresRoutes)
 app.route('/api/workspaces', workspaceMemoryAttachmentRoutes)
 app.route('/api/skills', skillsRoutes)
+// Public skill registry (`.well-known` discovery for `npx skills add`).
+// No auth — the share token in the path is the capability.
+app.route('/sk', skillRegistryApp)
+app.route('/.well-known/agent-skills', wellKnownRootApp)
 app.route('/api/plugins', pluginsRoutes)
 app.route('/api/mcp-catalog', mcpCatalogRoutes)
 app.route('/api/system-workspaces', systemWorkspacesRoutes)

--- a/control-plane/src/lib/skill-slug.test.ts
+++ b/control-plane/src/lib/skill-slug.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Slug rules for the Agent Skills discovery protocol.
+ *
+ * The `npx skills` client validates every index entry and *silently drops*
+ * the ones that fail — a malformed name produces an empty skill list, not an
+ * error. These tests pin the exact rules so a regression surfaces here rather
+ * than as "the install did nothing".
+ *
+ * The module under test lives in `internal/types` because web derives the
+ * same slug client-side (to pre-fill the export dialog) and the two must not
+ * drift. The test lives here because cp is the only consumer with a runner,
+ * and cp is where the rules are actually enforced.
+ */
+import { describe, expect, it } from 'vitest'
+import { deriveSkillSlug, isValidSkillSlug } from '../../../internal/types/skill-slug'
+
+describe('isValidSkillSlug', () => {
+  it.each(['code-review', 'a', '123', 'a-b-c', 'x'.repeat(64)])('accepts %j', (slug) => {
+    expect(isValidSkillSlug(slug)).toBe(true)
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['-lead', 'leading hyphen'],
+    ['trail-', 'trailing hyphen'],
+    ['a--b', 'consecutive hyphens'],
+    ['Caps', 'uppercase'],
+    ['under_score', 'underscore'],
+    ['with space', 'space'],
+    ['术语', 'non-latin'],
+    ['x'.repeat(65), 'over 64 chars'],
+  ])('rejects %j (%s)', (slug) => {
+    expect(isValidSkillSlug(slug)).toBe(false)
+  })
+})
+
+describe('deriveSkillSlug', () => {
+  it('passes through an already-valid name', () => {
+    expect(deriveSkillSlug('code-review')).toBe('code-review')
+  })
+
+  it('lowercases and replaces spaces', () => {
+    expect(deriveSkillSlug('Code Review')).toBe('code-review')
+  })
+
+  it('collapses runs of separators into a single hyphen', () => {
+    // Consecutive hyphens are rejected by the client, so `a  b` must not
+    // become `a--b`.
+    expect(deriveSkillSlug('PR   Review__Helper')).toBe('pr-review-helper')
+  })
+
+  it('strips leading and trailing separators', () => {
+    expect(deriveSkillSlug('  _release notes_  ')).toBe('release-notes')
+  })
+
+  it('truncates to 64 chars without leaving a trailing hyphen', () => {
+    // 'abc ' → 'abc-' (4 chars), so the 64-char cut lands exactly on a
+    // separator — the case where truncation itself creates a trailing hyphen.
+    const slug = deriveSkillSlug('abc '.repeat(20))
+    expect(slug).toBe(`${'abc-'.repeat(15)}abc`)
+    expect(slug?.length).toBe(63)
+  })
+
+  it.each([
+    ['术语检查', 'all CJK'],
+    ['!!!', 'punctuation only'],
+    ['---', 'hyphens only'],
+    ['🎉', 'emoji only'],
+    ['   ', 'whitespace only'],
+  ])('returns null for %j (%s) so the caller can ask for one', (name) => {
+    expect(deriveSkillSlug(name)).toBeNull()
+  })
+
+  it('keeps whatever latin survives a mixed name', () => {
+    expect(deriveSkillSlug('术语 check 检查')).toBe('check')
+  })
+
+  it('only ever returns slugs the client accepts', () => {
+    const names = [
+      'code-review',
+      'Code Review',
+      'PR   Review__Helper',
+      '  _release notes_  ',
+      'abc '.repeat(20),
+      'Skill (v2) — final',
+      'emoji 🎉 skill',
+      '123',
+      '术语 check 检查',
+    ]
+    for (const name of names) {
+      const slug = deriveSkillSlug(name)
+      expect(slug, `expected a slug for ${name}`).not.toBeNull()
+      expect(isValidSkillSlug(slug as string), `bad slug ${slug} from ${name}`).toBe(true)
+    }
+  })
+})

--- a/control-plane/src/routes/skill-registry.test.ts
+++ b/control-plane/src/routes/skill-registry.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Public skill registry routing.
+ *
+ * The client walks a fixed path shape and treats any non-200 as "no skills
+ * here", so a route that fails to match is indistinguishable from an empty
+ * registry. These tests pin the URLs the client actually requests.
+ *
+ * Slug rules themselves live in `internal/types/skill-slug.test.ts` — the slug here is
+ * whatever was frozen onto the export row at mint time.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getActiveSkillExportToken = vi.hoisted(() => vi.fn())
+const skillsContentFetch = vi.hoisted(() => vi.fn())
+
+vi.mock('../services/db/skill-export-tokens', () => ({
+  getActiveSkillExportToken,
+  touchSkillExportToken: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../services/skills-content', () => ({
+  skillsContentFetch,
+  skillsContentUrl: (id: string, sub: string) => `http://scs/skills/${id}${sub}`,
+}))
+
+const { skillRegistryApp } = await import('./skill-registry')
+
+const SKILL_ID = '3f2a1b9c-4d5e-6f70-8192-a3b4c5d6e7f8'
+
+const EXPORT_RECORD = {
+  token: 'skexp_testtoken',
+  skill_id: SKILL_ID,
+  user_id: 'u1',
+  slug: 'code-review',
+  label: '',
+  expires_at: null,
+  last_used_at: null,
+  created_at: new Date('2026-07-20T00:00:00Z'),
+  skill_name: 'Code Review',
+  skill_description: 'Review code for bugs',
+  content_hash: 'a'.repeat(64),
+}
+
+const INDEX_PATH = 'http://host/skexp_testtoken/.well-known/agent-skills/index.json'
+
+describe('skill registry routes', () => {
+  beforeEach(() => {
+    getActiveSkillExportToken.mockReset()
+    skillsContentFetch.mockReset()
+  })
+
+  it('serves a v0.2.0 index at the path the client probes', async () => {
+    getActiveSkillExportToken.mockResolvedValue(EXPORT_RECORD)
+    const res = await skillRegistryApp.request(INDEX_PATH)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.$schema).toBe('https://schemas.agentskills.io/discovery/0.2.0/schema.json')
+    expect(body.skills).toEqual([
+      {
+        name: 'code-review',
+        type: 'archive',
+        description: 'Review code for bugs',
+        url: 'code-review.tar.gz',
+        digest: `sha256:${'a'.repeat(64)}`,
+      },
+    ])
+  })
+
+  it('publishes the frozen slug, not one re-derived from the current name', async () => {
+    // The skill was renamed after the export was minted. The install on
+    // someone's disk is keyed to the old slug, so that is what we keep serving.
+    getActiveSkillExportToken.mockResolvedValue({ ...EXPORT_RECORD, skill_name: 'Renamed Thing' })
+    const res = await skillRegistryApp.request(INDEX_PATH)
+    const body = await res.json()
+    expect(body.skills[0].name).toBe('code-review')
+    expect(body.skills[0].url).toBe('code-review.tar.gz')
+  })
+
+  it('resolves the relative archive url the index advertises', async () => {
+    getActiveSkillExportToken.mockResolvedValue(EXPORT_RECORD)
+    // The client resolves `code-review.tar.gz` against the index URL.
+    const archiveUrl = new URL('code-review.tar.gz', INDEX_PATH).toString()
+    skillsContentFetch.mockResolvedValue({
+      ok: true,
+      response: new Response('tarball', { status: 200, headers: { ETag: '"abc"' } }),
+    })
+    const res = await skillRegistryApp.request(archiveUrl)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/gzip')
+    expect(res.headers.get('ETag')).toBe('"abc"')
+  })
+
+  it('forwards If-None-Match and passes a 304 straight through', async () => {
+    getActiveSkillExportToken.mockResolvedValue(EXPORT_RECORD)
+    skillsContentFetch.mockResolvedValue({
+      ok: true,
+      response: new Response(null, { status: 304, headers: { ETag: '"abc"' } }),
+    })
+    const res = await skillRegistryApp.request(
+      'http://host/skexp_testtoken/.well-known/agent-skills/code-review.tar.gz',
+      { headers: { 'If-None-Match': '"abc"' } },
+    )
+    expect(res.status).toBe(304)
+    expect(skillsContentFetch.mock.calls[0][2]).toEqual({ 'If-None-Match': '"abc"' })
+  })
+
+  it('404s an unknown or expired token', async () => {
+    getActiveSkillExportToken.mockResolvedValue(null)
+    const res = await skillRegistryApp.request(INDEX_PATH)
+    expect(res.status).toBe(404)
+  })
+
+  it('404s an exported skill that has no published version', async () => {
+    getActiveSkillExportToken.mockResolvedValue({ ...EXPORT_RECORD, content_hash: null })
+    const res = await skillRegistryApp.request(INDEX_PATH)
+    expect(res.status).toBe(404)
+  })
+
+  it('substitutes a non-empty description when the skill has none', async () => {
+    // An empty description makes the client drop the entry.
+    getActiveSkillExportToken.mockResolvedValue({ ...EXPORT_RECORD, skill_description: '   ' })
+    const res = await skillRegistryApp.request(INDEX_PATH)
+    const body = await res.json()
+    expect(body.skills[0].description).toBe('code-review')
+  })
+
+  it('clamps an over-long description to the client limit', async () => {
+    getActiveSkillExportToken.mockResolvedValue({
+      ...EXPORT_RECORD,
+      skill_description: 'x'.repeat(2000),
+    })
+    const res = await skillRegistryApp.request(INDEX_PATH)
+    const body = await res.json()
+    expect(body.skills[0].description.length).toBeLessThanOrEqual(1024)
+  })
+
+  it('answers the bare export URL with the install command', async () => {
+    getActiveSkillExportToken.mockResolvedValue(EXPORT_RECORD)
+    const res = await skillRegistryApp.request('http://host/skexp_testtoken')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('npx skills add http://host/skexp_testtoken')
+  })
+})

--- a/control-plane/src/routes/skill-registry.ts
+++ b/control-plane/src/routes/skill-registry.ts
@@ -1,0 +1,180 @@
+/**
+ * Public skill registry — serves one exported skill over the Agent Skills
+ * `.well-known` discovery protocol so local agents can install it with the
+ * stock client:
+ *
+ *     npx skills add https://<host>/sk/<token>
+ *
+ * The client probes `<base>/.well-known/agent-skills/index.json`, validates
+ * each entry, fetches the archive, and verifies its sha256 against the
+ * declared digest. Spec: https://github.com/cloudflare/agent-skills-discovery-rfc
+ *
+ * Mounted at `/sk` and bypasses auth: the token is the only authenticator
+ * (128-bit random, TTL-bounded, revocable), exactly like export_tokens. It
+ * grants exactly one skill, so a leaked URL has a one-skill blast radius.
+ *
+ * Unlike file exports this rides the main app origin rather than a separate
+ * `files.*` host. That split exists so inline HTML can't reach app cookies;
+ * here every response is JSON or gzip served with `nosniff` and an attachment
+ * disposition, so nothing is ever rendered as a document.
+ */
+import { Hono } from 'hono'
+import {
+  type SkillExportTokenTarget,
+  getActiveSkillExportToken,
+  touchSkillExportToken,
+} from '../services/db/skill-export-tokens'
+import { skillsContentFetch, skillsContentUrl } from '../services/skills-content'
+
+export const skillRegistryApp = new Hono()
+
+/** Discovery path the client probes, relative to the export's base URL. */
+const WELL_KNOWN = '.well-known/agent-skills'
+
+/**
+ * `description` must be non-empty and ≤1024 chars or the client drops the
+ * entry. `skills.description` defaults to '' and plenty of rows keep it.
+ */
+function registryDescription(record: SkillExportTokenTarget): string {
+  const raw = record.skill_description.trim()
+  if (!raw) return record.slug
+  return raw.length > 1024 ? `${raw.slice(0, 1021)}...` : raw
+}
+
+function logServe(c: any, token: string, record: SkillExportTokenTarget, what: string) {
+  // Log a token prefix only. export_tokens logs the full value, which turns a
+  // log leak into a credential leak; not repeating that here.
+  console.log(
+    `[skill-registry] serve ${what} token=${token.slice(0, 12)}… skill=${record.skill_id} ` +
+      `ip=${c.req.header('x-forwarded-for') || 'unknown'} ua=${c.req.header('user-agent') || '-'}`,
+  )
+}
+
+/** Resolve a token, or a Response to short-circuit on. */
+async function resolveExport(c: any, token: string): Promise<SkillExportTokenTarget | Response> {
+  const record = await getActiveSkillExportToken(token)
+  if (!record) return c.text('Not found or expired', 404)
+  if (!record.content_hash) {
+    // Skill exists but was never published — there is no package to serve.
+    return c.text('Skill has no published version', 404)
+  }
+  return record
+}
+
+/**
+ * Discovery index. One entry, because an export grants one skill.
+ *
+ * `digest` is the skill's active-version content_hash — a generated column
+ * over the stored tarball — so it needs no separate computation and is exactly
+ * what the client hashes on arrival. Because we read the *active* version, a
+ * republish changes both the index digest and the served bytes together.
+ */
+skillRegistryApp.get(`/:token/${WELL_KNOWN}/index.json`, async (c) => {
+  const token = c.req.param('token')
+  const record = await resolveExport(c, token)
+  if (record instanceof Response) return record
+
+  logServe(c, token, record, 'index')
+  void touchSkillExportToken(token)
+
+  return c.json(
+    {
+      $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+      skills: [
+        {
+          // Stored at mint time, so renaming the skill can't retarget an
+          // install that is already on someone's disk.
+          name: record.slug,
+          type: 'archive',
+          description: registryDescription(record),
+          // Relative to the index URL, per RFC 3986 resolution.
+          url: `${record.slug}.tar.gz`,
+          digest: `sha256:${record.content_hash}`,
+        },
+      ],
+    },
+    200,
+    {
+      'Cache-Control': 'private, no-store',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Robots-Tag': 'noindex',
+    },
+  )
+})
+
+/**
+ * Archive fetch. The `.tar.gz` basename is cosmetic — the token already
+ * identifies the skill — so any name resolves, mirroring how export tokens
+ * treat their URL tail.
+ *
+ * Proxied straight from skills-content-service; cp never materializes the
+ * tarball. ETag is passed through so a client that keeps it gets a cheap 304
+ * (scs answers from content_hash without reading the bytea).
+ */
+skillRegistryApp.get(`/:token/${WELL_KNOWN}/:filename{.+\\.tar\\.gz}`, async (c) => {
+  const token = c.req.param('token')
+  const record = await resolveExport(c, token)
+  if (record instanceof Response) return record
+
+  const inm = c.req.header('If-None-Match')
+  const result = await skillsContentFetch(
+    skillsContentUrl(record.skill_id, '/package'),
+    c.req.raw.signal,
+    inm ? { 'If-None-Match': inm } : undefined,
+  )
+  if (!result.ok) return c.text('Skill content unavailable', 502)
+
+  const { response } = result
+  if (response.status === 404) return c.text('Not found', 404)
+
+  logServe(c, token, record, 'package')
+  void touchSkillExportToken(token)
+
+  const headers = new Headers({
+    'Cache-Control': 'private, no-store',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Robots-Tag': 'noindex',
+  })
+  const etag = response.headers.get('ETag')
+  if (etag) headers.set('ETag', etag)
+
+  if (response.status === 304) return new Response(null, { status: 304, headers })
+  if (!response.ok) return c.text('Skill content unavailable', 502)
+
+  headers.set('Content-Type', 'application/gzip')
+  headers.set('Content-Disposition', `attachment; filename="${record.slug}.tar.gz"`)
+  const cl = response.headers.get('Content-Length')
+  if (cl) headers.set('Content-Length', cl)
+  return new Response(response.body, { status: 200, headers })
+})
+
+/**
+ * Bare export URL. Not part of the protocol — a human who opens the link in a
+ * browser lands here, so answer with the command they actually need.
+ */
+skillRegistryApp.get('/:token', async (c) => {
+  const token = c.req.param('token')
+  const record = await resolveExport(c, token)
+  if (record instanceof Response) return record
+  const base = new URL(c.req.url)
+  base.search = ''
+  return c.text(
+    `${record.skill_name}\n\nInstall with:\n  npx skills add ${base.toString()}\n`,
+    200,
+    { 'Cache-Control': 'private, no-store', 'X-Robots-Tag': 'noindex' },
+  )
+})
+
+skillRegistryApp.all('*', (c) => c.text('Not found', 404))
+
+/**
+ * Host-root discovery probe. The client checks `<host>/.well-known/...` as
+ * well as the base URL it was given, and this app publishes nothing there —
+ * every export is scoped to a token path.
+ *
+ * Answered explicitly because the alternative is worse: the path would fall
+ * through to the SPA and return `200 text/html`, which a client looking for
+ * JSON reports as a parse failure rather than "nothing here".
+ */
+export const wellKnownRootApp = new Hono()
+wellKnownRootApp.all('*', (c) => c.json({ error: 'No skills published at this host' }, 404))

--- a/control-plane/src/routes/skills.ts
+++ b/control-plane/src/routes/skills.ts
@@ -17,6 +17,8 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import {
   type ApiSkill,
+  type ApiSkillExport,
+  ApiSkillExportSchema,
   ApiSkillGrantSchema,
   ApiSkillSchema,
   type ApiSkillSource,
@@ -26,6 +28,7 @@ import {
   SkillActiveVersionBodySchema,
   SkillCreateNativeBodySchema,
   SkillDependentsSchema,
+  SkillExportCreateBodySchema,
   SkillFromGitErrorSchema,
   SkillGrantsBodySchema,
   SkillImportFromGitBodySchema,
@@ -41,6 +44,7 @@ import {
 } from '../../../internal/types/api'
 import type { AppEnv } from '../lib/types'
 import { getUserCredentialValue } from '../services/db/credentials'
+import type { SkillExportToken } from '../services/db/skill-export-tokens'
 import type { SkillMeta, SkillSource, SkillVersion } from '../services/db/types'
 import type { SkillWithAccess } from '../services/skill-repository'
 import { skillsService } from '../services/skills-composition'
@@ -1562,6 +1566,130 @@ skills.openapi(setGrantsRoute, async (c) => {
   const { grants } = c.req.valid('json')
   const rows = await skillsService.setGrants(user.sub, id, grants)
   return c.json(rows, 200)
+})
+
+// ── shares (public registry for local agents) ─────────────────────────────
+//
+// Owner-only. A share is a capability URL: holding it is sufficient to
+// download the skill, so these handlers return the full token — the listing
+// endpoint is a credential-listing endpoint by design, same as the export
+// token list.
+
+function exportToApi(s: SkillExportToken): ApiSkillExport {
+  const base = (process.env.WEB_PUBLIC_URL || '').replace(/\/$/, '')
+  return {
+    token: s.token,
+    url: `${base}/sk/${s.token}`,
+    slug: s.slug,
+    label: s.label,
+    expires_at: s.expires_at ? new Date(s.expires_at).toISOString() : null,
+    last_used_at: s.last_used_at ? new Date(s.last_used_at).toISOString() : null,
+    created_at: new Date(s.created_at).toISOString(),
+  }
+}
+
+const listExportsRoute = createRoute({
+  method: 'get',
+  path: '/{id}/exports',
+  tags: ['skills'],
+  summary: 'List active public shares for a skill (owner only)',
+  security: [{ bearerAuth: [] }],
+  request: { params: IdParam },
+  responses: {
+    200: {
+      description: 'Share list',
+      content: { 'application/json': { schema: z.array(ApiSkillExportSchema) } },
+    },
+    404: {
+      description: 'Skill not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+skills.openapi(listExportsRoute, async (c) => {
+  const user = c.get('user')
+  const { id } = c.req.valid('param')
+  const rows = await skillsService.listExports(user.sub, id)
+  return c.json(rows.map(exportToApi), 200)
+})
+
+const createExportRoute = createRoute({
+  method: 'post',
+  path: '/{id}/exports',
+  tags: ['skills'],
+  summary: 'Mint a public share URL for a skill (owner only)',
+  description:
+    'Returns a capability URL installable with `npx skills add <url>`. Defaults to a ' +
+    '90-day lifetime; pass `ttl_days: null` for a permanent share. Shares cannot be ' +
+    'extended — mint a replacement and revoke the old one. `slug` is derived from the ' +
+    'skill name; when the name yields nothing usable (e.g. all-CJK) the call returns ' +
+    '400 and `slug` must be supplied.',
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: IdParam,
+    body: { content: { 'application/json': { schema: SkillExportCreateBodySchema } } },
+  },
+  responses: {
+    200: {
+      description: 'Share created',
+      content: { 'application/json': { schema: ApiSkillExportSchema } },
+    },
+    400: {
+      description: 'Skill has no published version',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+    404: {
+      description: 'Skill not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+skills.openapi(createExportRoute, async (c) => {
+  const user = c.get('user')
+  const { id } = c.req.valid('param')
+  const body = c.req.valid('json')
+  try {
+    const share = await skillsService.createExport(user.sub, id, {
+      slug: body.slug,
+      ttlDays: body.ttl_days,
+      label: body.label,
+    })
+    return c.json(exportToApi(share), 200)
+  } catch (e) {
+    if (e instanceof InvalidInputError) return c.json({ error: e.message }, 400)
+    throw e
+  }
+})
+
+const TokenParam = z.object({
+  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+  token: z.string().openapi({ param: { name: 'token', in: 'path' } }),
+})
+
+const revokeExportRoute = createRoute({
+  method: 'delete',
+  path: '/{id}/exports/{token}',
+  tags: ['skills'],
+  summary: 'Revoke a public share (owner only)',
+  security: [{ bearerAuth: [] }],
+  request: { params: TokenParam },
+  responses: {
+    204: { description: 'Revoked' },
+    404: {
+      description: 'Skill or share not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+skills.openapi(revokeExportRoute, async (c) => {
+  const user = c.get('user')
+  const { id, token } = c.req.valid('param')
+  const removed = await skillsService.revokeExport(user.sub, id, token)
+  if (!removed) return c.json({ error: 'Share not found' }, 404)
+  return c.body(null, 204)
 })
 
 export default skills

--- a/control-plane/src/services/db/skill-export-tokens.ts
+++ b/control-plane/src/services/db/skill-export-tokens.ts
@@ -1,0 +1,146 @@
+import { randomBytes } from 'node:crypto'
+import { pool } from './pool'
+
+export interface SkillExportToken {
+  token: string
+  skill_id: string
+  user_id: string
+  /** Protocol name + on-disk directory name. Frozen at mint time. */
+  slug: string
+  label: string
+  expires_at: Date | null
+  last_used_at: Date | null
+  created_at: Date
+}
+
+/** An export joined with the fields the public registry needs to answer with. */
+export interface SkillExportTokenTarget extends SkillExportToken {
+  skill_name: string
+  skill_description: string
+  /** NULL when the skill has never been published — the registry 404s on it. */
+  content_hash: string | null
+}
+
+/** Default lifetime when the caller doesn't pick one. */
+export const DEFAULT_EXPORT_TTL_DAYS = 90
+
+/** 128-bit URL-safe token, `skexp_` prefix for at-a-glance recognition in logs. */
+function generateToken(): string {
+  return `skexp_${randomBytes(16).toString('base64url')}`
+}
+
+/**
+ * Mint an export for one skill. Pass `ttlDays = null` for a permanent export;
+ * it stays valid until explicitly revoked. There is deliberately no renew —
+ * extending a live credential in place makes revocation ambiguous, so the
+ * only way to move an expiry is to mint a replacement and delete the old one.
+ */
+export async function createSkillExportToken(
+  skillId: string,
+  userId: string,
+  slug: string,
+  ttlDays: number | null,
+  label = '',
+): Promise<SkillExportToken> {
+  const token = generateToken()
+  if (ttlDays == null) {
+    const { rows } = await pool.query(
+      `INSERT INTO skill_export_tokens (token, skill_id, user_id, slug, label, expires_at)
+       VALUES ($1, $2, $3, $4, $5, NULL)
+       RETURNING *`,
+      [token, skillId, userId, slug, label],
+    )
+    return rows[0] as SkillExportToken
+  }
+  const { rows } = await pool.query(
+    `INSERT INTO skill_export_tokens (token, skill_id, user_id, slug, label, expires_at)
+     VALUES ($1, $2, $3, $4, $5, now() + ($6 || ' days')::interval)
+     RETURNING *`,
+    [token, skillId, userId, slug, label, String(ttlDays)],
+  )
+  return rows[0] as SkillExportToken
+}
+
+/**
+ * Resolve a token to its skill for the public registry path. Expiry is
+ * checked in SQL so an expired export is indistinguishable from a bogus token.
+ *
+ * Reads the skill's *current* active version — exports follow republishes
+ * rather than pinning a snapshot, matching how workspace mounts behave.
+ */
+export async function getActiveSkillExportToken(
+  token: string,
+): Promise<SkillExportTokenTarget | null> {
+  const { rows } = await pool.query(
+    `SELECT ss.*, s.name AS skill_name, s.description AS skill_description,
+            sv.content_hash
+       FROM skill_export_tokens ss
+       JOIN skills s ON s.id = ss.skill_id
+       LEFT JOIN skill_versions sv ON sv.id = s.active_version_id
+      WHERE ss.token = $1
+        AND (ss.expires_at IS NULL OR ss.expires_at > now())`,
+    [token],
+  )
+  return (rows[0] as SkillExportTokenTarget) ?? null
+}
+
+/**
+ * Stamp last-use. Fire-and-forget from the serving path: a failed stamp must
+ * not fail the download, and the value is only ever read by humans deciding
+ * which stale export to revoke.
+ */
+export async function touchSkillExportToken(token: string): Promise<void> {
+  try {
+    await pool.query('UPDATE skill_export_tokens SET last_used_at = now() WHERE token = $1', [
+      token,
+    ])
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    console.error(`[skill-exports] last_used_at stamp failed for ${token.slice(0, 12)}…:`, msg)
+  }
+}
+
+/** List active (non-expired) exports for a skill, newest first. */
+export async function listSkillExportTokens(skillId: string): Promise<SkillExportToken[]> {
+  const { rows } = await pool.query(
+    `SELECT * FROM skill_export_tokens
+      WHERE skill_id = $1
+        AND (expires_at IS NULL OR expires_at > now())
+      ORDER BY created_at DESC`,
+    [skillId],
+  )
+  return rows as SkillExportToken[]
+}
+
+/** Hard-delete an export. Returns true if a row was removed. */
+export async function deleteSkillExportToken(skillId: string, token: string): Promise<boolean> {
+  const { rowCount } = await pool.query(
+    'DELETE FROM skill_export_tokens WHERE skill_id = $1 AND token = $2',
+    [skillId, token],
+  )
+  return (rowCount ?? 0) > 0
+}
+
+/** Drop expired rows. Called on the hourly maintenance tick below. */
+async function cleanupExpiredSkillExportTokens(): Promise<number> {
+  const { rowCount } = await pool.query(
+    'DELETE FROM skill_export_tokens WHERE expires_at IS NOT NULL AND expires_at <= now()',
+  )
+  return rowCount ?? 0
+}
+
+// Expired exports are already invisible to every read path, so this is purely
+// to stop the table growing without bound — export_tokens has no sweep and
+// accumulates dead rows for the life of the workspace.
+//
+// unref'd so it never keeps the process (or a test run) alive.
+setInterval(
+  () => {
+    cleanupExpiredSkillExportTokens()
+      .then((n) => {
+        if (n > 0) console.log(`[skill-exports] swept ${n} expired export(s)`)
+      })
+      .catch((err) => console.error('[skill-exports] cleanup error:', err))
+  },
+  60 * 60 * 1000,
+).unref()

--- a/control-plane/src/services/skills-service.test.ts
+++ b/control-plane/src/services/skills-service.test.ts
@@ -26,6 +26,19 @@ import {
 } from './skills-errors'
 import { SkillsService, type SkillsServiceDeps } from './skills-service'
 
+// ── share persistence mock ──────────────────────────────────────────────────
+//
+// Share writes are a thin insert against the pool; what's worth testing here
+// is the slug decision in front of them, so we capture the call args instead
+// of reaching for a database.
+const createSkillExportTokenMock = vi.hoisted(() => vi.fn())
+vi.mock('./db/skill-export-tokens', () => ({
+  DEFAULT_EXPORT_TTL_DAYS: 90,
+  createSkillExportToken: createSkillExportTokenMock,
+  listSkillExportTokens: vi.fn().mockResolvedValue([]),
+  deleteSkillExportToken: vi.fn().mockResolvedValue(true),
+}))
+
 // ── scs mock ────────────────────────────────────────────────────────────────
 //
 // All scs helpers are vi.fn()s by default. Tests override `mockResolvedValue`
@@ -1116,6 +1129,106 @@ describe('SkillsService.listVersions', () => {
       visibility: 'private',
     })
     await expect(h.service.listVersions('alice', skill.id)).rejects.toBeInstanceOf(
+      SkillNotFoundError,
+    )
+  })
+})
+
+// ── shares ─────────────────────────────────────────────────────────────────
+
+describe('createExport', () => {
+  beforeEach(() => {
+    createSkillExportTokenMock.mockReset()
+    createSkillExportTokenMock.mockImplementation(
+      async (skillId: string, userId: string, slug: string) => ({
+        token: 'skexp_x',
+        skill_id: skillId,
+        user_id: userId,
+        slug,
+        label: '',
+        expires_at: null,
+        last_used_at: null,
+        created_at: new Date(0),
+      }),
+    )
+  })
+
+  /** The slug the service decided on, as passed to the insert. */
+  function mintedSlug(): string {
+    return createSkillExportTokenMock.mock.calls[0][2]
+  }
+
+  it('derives the slug from the skill name', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'Code Review' })
+    await h.service.createExport('alice', skill.id)
+    expect(mintedSlug()).toBe('code-review')
+  })
+
+  it('applies the default TTL when none is given', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'Code Review' })
+    await h.service.createExport('alice', skill.id)
+    expect(createSkillExportTokenMock.mock.calls[0][3]).toBe(90)
+  })
+
+  it('mints a permanent share on explicit null', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'Code Review' })
+    await h.service.createExport('alice', skill.id, { ttlDays: null })
+    expect(createSkillExportTokenMock.mock.calls[0][3]).toBeNull()
+  })
+
+  it('demands a slug when the name yields nothing usable', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: '术语检查' })
+    await expect(h.service.createExport('alice', skill.id)).rejects.toBeInstanceOf(
+      InvalidInputError,
+    )
+    expect(createSkillExportTokenMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a caller-supplied slug for a name that cannot be derived', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: '术语检查' })
+    await h.service.createExport('alice', skill.id, { slug: 'glossary-check' })
+    expect(mintedSlug()).toBe('glossary-check')
+  })
+
+  it('prefers an explicit slug over the derivable one', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'Code Review' })
+    await h.service.createExport('alice', skill.id, { slug: 'cr' })
+    expect(mintedSlug()).toBe('cr')
+  })
+
+  it('rejects an invalid explicit slug instead of repairing it', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'Code Review' })
+    // Silently normalizing would hand back a name the user did not choose.
+    await expect(
+      h.service.createExport('alice', skill.id, { slug: 'Code Review' }),
+    ).rejects.toBeInstanceOf(InvalidInputError)
+    expect(createSkillExportTokenMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to share a skill with no published version', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'Code Review' })
+    // Unpublished state: the row exists but points at no version.
+    const row = h.repo._peek(skill.id)
+    if (!row) throw new Error('seeded skill missing')
+    row.active_version_id = null
+    await expect(h.service.createExport('alice', skill.id)).rejects.toBeInstanceOf(
+      InvalidInputError,
+    )
+  })
+
+  it('throws SkillNotFoundError for a non-owner', async () => {
+    const h = setup()
+    h.repo.seedUser({ id: 'bob', display_name: 'Bob' })
+    const { skill } = seedSkill(h.repo, { userId: 'bob', name: 'Code Review' })
+    await expect(h.service.createExport('alice', skill.id)).rejects.toBeInstanceOf(
       SkillNotFoundError,
     )
   })

--- a/control-plane/src/services/skills-service.ts
+++ b/control-plane/src/services/skills-service.ts
@@ -10,7 +10,19 @@
  * Streamed write paths (upload, save-draft) pass the raw request body
  * straight to scs without materializing in cp memory.
  */
+import {
+  MAX_SKILL_SLUG_LENGTH,
+  deriveSkillSlug,
+  isValidSkillSlug,
+} from '../../../internal/types/skill-slug'
 import type { AgentNotifier, ReloadEnqueuer } from './agent-notifier'
+import {
+  DEFAULT_EXPORT_TTL_DAYS,
+  type SkillExportToken,
+  createSkillExportToken,
+  deleteSkillExportToken,
+  listSkillExportTokens,
+} from './db/skill-export-tokens'
 import type { SkillMeta, SkillSource, SkillVersion, SkillVisibility } from './db/types'
 import type {
   ListSkillsFilters,
@@ -555,6 +567,72 @@ export class SkillsService {
     await this.assertOwnTeams(userId, grants)
     await this.repo.setSkillGrants(skillId, grants, userId)
     return this.repo.listSkillGrants(skillId)
+  }
+
+  // ─── public shares (local-agent registry) ────────────────────────────────
+  //
+  // Owner-only, like grants: a share hands the skill to anyone holding the
+  // URL, so it is a wider act than the `editor` permission is meant to cover.
+  // Non-owners get 404 rather than 403 so the surface doesn't confirm that a
+  // skill they can read is shareable by someone else.
+
+  async listExports(userId: string, skillId: string): Promise<SkillExportToken[]> {
+    const existing = await this.repo.getSkillForUser(skillId, userId)
+    if (!existing || !existing.is_owner) throw new SkillNotFoundError()
+    return listSkillExportTokens(skillId)
+  }
+
+  /**
+   * Mint a share. `ttlDays === null` means permanent; omitting it applies the
+   * default window. There is no renew — see createSkillExportToken.
+   *
+   * The slug is derived from the skill name when that produces something the
+   * discovery protocol accepts. When it doesn't — a CJK or emoji name leaves
+   * nothing behind — the caller must supply one. We deliberately don't invent
+   * an id-derived fallback: the slug becomes a directory name on the
+   * installer's machine, and `skill-3f2a1b9c` is a poor thing to hand someone.
+   */
+  async createExport(
+    userId: string,
+    skillId: string,
+    opts: { slug?: string; ttlDays?: number | null; label?: string } = {},
+  ): Promise<SkillExportToken> {
+    const existing = await this.repo.getSkillForUser(skillId, userId)
+    if (!existing || !existing.is_owner) throw new SkillNotFoundError()
+    if (!existing.active_version_id) {
+      throw new InvalidInputError('Publish the skill before sharing it')
+    }
+
+    // Stated in full on both failure paths — the UI surfaces these verbatim
+    // when prompting for a slug.
+    const rules = `${MAX_SKILL_SLUG_LENGTH} lowercase letters, digits, and single hyphens (not leading or trailing)`
+
+    let slug: string
+    if (opts.slug !== undefined) {
+      // Explicit input is validated, never silently repaired — a user who
+      // typed a name should get it or be told why not.
+      if (!isValidSkillSlug(opts.slug)) {
+        throw new InvalidInputError(`Invalid slug "${opts.slug}": use 1-${rules}`)
+      }
+      slug = opts.slug
+    } else {
+      const derived = deriveSkillSlug(existing.name)
+      if (!derived) {
+        throw new InvalidInputError(
+          `Cannot derive a share name from "${existing.name}" — provide a slug: 1-${rules}`,
+        )
+      }
+      slug = derived
+    }
+
+    const ttlDays = opts.ttlDays === undefined ? DEFAULT_EXPORT_TTL_DAYS : opts.ttlDays
+    return createSkillExportToken(skillId, userId, slug, ttlDays, opts.label ?? '')
+  }
+
+  async revokeExport(userId: string, skillId: string, token: string): Promise<boolean> {
+    const existing = await this.repo.getSkillForUser(skillId, userId)
+    if (!existing || !existing.is_owner) throw new SkillNotFoundError()
+    return deleteSkillExportToken(skillId, token)
   }
 
   // ─── workspace ↔ skill ───────────────────────────────────────────────────

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -427,7 +427,7 @@ export type SkillPermission = z.infer<typeof SkillPermissionSchema>
 
 const SkillMyPermissionSchema = z.enum(['owner', 'editor', 'viewer', 'public'])
 
-const SkillSharedTeamSchema = z.object({
+const SkillExportTokendTeamSchema = z.object({
   id: z.string(),
   name: z.string(),
   permission: SkillPermissionSchema,
@@ -494,7 +494,7 @@ export const ApiSkillSchema = z.object({
   is_public: z.boolean(),
   visibility: SkillVisibilitySchema,
   my_permission: SkillMyPermissionSchema,
-  shared_via_teams: z.array(SkillSharedTeamSchema),
+  shared_via_teams: z.array(SkillExportTokendTeamSchema),
   owner_name: z.string(),
   is_own: z.boolean(),
   category: z.string().nullable(),
@@ -531,6 +531,38 @@ export const SkillDependentsSchema = z.object({
   template_version_count: z.number(),
 })
 export type SkillDependents = z.infer<typeof SkillDependentsSchema>
+
+// Public share of a single skill, consumed by local agents via
+// `npx skills add <url>`. The URL *is* the credential — anyone holding it can
+// download the skill — so `url` is only ever returned to the owner.
+export const ApiSkillExportSchema = z.object({
+  token: z.string(),
+  url: z.string(),
+  /** Name the skill installs under, and its directory name on disk. */
+  slug: z.string(),
+  label: z.string(),
+  /** null = permanent; stays valid until revoked. */
+  expires_at: z.string().nullable(),
+  /** null until someone actually installs from it. */
+  last_used_at: z.string().nullable(),
+  created_at: z.string(),
+})
+export type ApiSkillExport = z.infer<typeof ApiSkillExportSchema>
+
+// Expiry is expressed in days (not seconds like export_tokens): these are
+// long-lived credentials that live on a developer machine, so the useful
+// range is weeks-to-months rather than minutes.
+export const SkillExportCreateBodySchema = z.object({
+  /** Omit for the 90-day default; explicit null mints a permanent share. */
+  ttl_days: z.number().int().min(1).max(3650).nullable().optional(),
+  label: z.string().max(200).optional(),
+  /**
+   * Omit to derive it from the skill name. Required when the name yields
+   * nothing usable (CJK, emoji, punctuation-only) — the API answers 400 with
+   * the rules when that happens, so the UI can prompt for one.
+   */
+  slug: z.string().max(64).optional(),
+})
 
 // ── request schemas ───────────────────────────────────────────────────────
 

--- a/internal/types/index.ts
+++ b/internal/types/index.ts
@@ -1,4 +1,5 @@
 export * from './events.js'
 export * from './api.js'
+export * from './skill-slug.js'
 export * from './builder.js'
 export * from './environments.js'

--- a/internal/types/skill-slug.ts
+++ b/internal/types/skill-slug.ts
@@ -1,0 +1,45 @@
+/**
+ * Slug rules for the Agent Skills discovery protocol.
+ *
+ * A published skill is addressed by a `name` that the `npx skills` client
+ * validates as `^[a-z0-9-]+$`, 1–64 chars, with no leading, trailing, or
+ * consecutive hyphens. Entries failing any of those are *silently skipped* —
+ * a bad slug produces an empty skill list, not an error — so validation has
+ * to happen on our side, at mint time, where we can still tell the user.
+ *
+ * The slug also names the directory the client creates on disk, which is why
+ * it is stored on the export rather than derived per request: renaming the
+ * skill afterwards would otherwise silently retarget the install.
+ */
+
+export const MAX_SKILL_SLUG_LENGTH = 64
+
+/** The client's own validation, mirrored exactly. */
+export function isValidSkillSlug(slug: string): boolean {
+  return (
+    slug.length >= 1 &&
+    slug.length <= MAX_SKILL_SLUG_LENGTH &&
+    /^[a-z0-9-]+$/.test(slug) &&
+    !slug.startsWith('-') &&
+    !slug.endsWith('-') &&
+    !slug.includes('--')
+  )
+}
+
+/**
+ * Best-effort projection of a free-form skill name into a valid slug.
+ *
+ * Returns null when nothing usable survives — an all-CJK name ("术语检查"),
+ * pure punctuation, emoji. Callers must then ask the user for one instead of
+ * inventing an opaque id-derived name they'd have to live with on disk.
+ */
+export function deriveSkillSlug(name: string): string | null {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SKILL_SLUG_LENGTH)
+    // Truncation can land on a separator, which would be a trailing hyphen.
+    .replace(/-+$/g, '')
+  return isValidSkillSlug(slug) ? slug : null
+}

--- a/web/src/components/dialogs/SkillExportDialog.tsx
+++ b/web/src/components/dialogs/SkillExportDialog.tsx
@@ -1,0 +1,280 @@
+/**
+ * Export a skill to local agents.
+ *
+ * Mints capability URLs that `npx skills add <url>` installs from, via the
+ * Agent Skills `.well-known` discovery protocol. Distinct from
+ * `SkillShareDialog`, which governs who inside the platform can see the
+ * skill — this one hands it to anything holding the URL, with no login.
+ *
+ * The two are deliberately separate surfaces rather than tabs of one dialog:
+ * SkillShareDialog defers everything to a Save button, while minting and
+ * revoking here take effect immediately. Mixing the two save models would
+ * make "Cancel" a lie about credentials that already exist.
+ */
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { ConfirmButton } from '@/components/ui/confirm-button'
+import { CopyButton } from '@/components/ui/copy-button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  useCreateSkillExport,
+  useRevokeSkillExport,
+  useSkillExports,
+} from '@/hooks/useSkillExports'
+import type { ApiSkill, ApiSkillExport } from '@/lib/api/types'
+import { MAX_SKILL_SLUG_LENGTH, deriveSkillSlug, isValidSkillSlug } from '@neutree-ai/types'
+import { AlertTriangle, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+/** Sentinel for the TTL select — never sent as a value. Mirrors PublicLinkDialog. */
+const PERMANENT = 'permanent'
+
+/**
+ * Longer than the file-export ladder (minutes/hours) because these live on a
+ * developer's machine and get re-fetched over weeks, not during one session.
+ */
+const TTL_OPTIONS = [
+  { value: '7', labelKey: '7days' },
+  { value: '30', labelKey: '30days' },
+  { value: '90', labelKey: '90days' },
+  { value: PERMANENT, labelKey: 'permanent' },
+] as const
+
+const DEFAULT_TTL = '90'
+
+interface SkillExportDialogProps {
+  skill: ApiSkill | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/** The command a user actually pastes — copying the bare URL helps less. */
+function installCommand(url: string): string {
+  return `npx skills add ${url}`
+}
+
+export function SkillExportDialog({ skill, open, onOpenChange }: SkillExportDialogProps) {
+  const { t, i18n } = useTranslation()
+  const k = 'components.library.skills.exportDialog'
+
+  const { data: exports, isLoading } = useSkillExports(skill?.id ?? null, open)
+  const createExport = useCreateSkillExport(skill?.id ?? '')
+  const revokeExport = useRevokeSkillExport(skill?.id ?? '')
+
+  const [slug, setSlug] = useState('')
+  const [ttl, setTtl] = useState(DEFAULT_TTL)
+  const [error, setError] = useState<string | null>(null)
+  const [fresh, setFresh] = useState<ApiSkillExport | null>(null)
+
+  // Derived locally so a name we can't slugify surfaces as an empty, focused
+  // field instead of a 400 after the user commits.
+  const derivedSlug = useMemo(() => (skill ? deriveSkillSlug(skill.name) : null), [skill])
+
+  useEffect(() => {
+    if (open) {
+      setSlug(derivedSlug ?? '')
+      setTtl(DEFAULT_TTL)
+      setError(null)
+      setFresh(null)
+    }
+  }, [open, derivedSlug])
+
+  const isPermanent = ttl === PERMANENT
+  const slugValid = isValidSkillSlug(slug)
+  const canSubmit = slugValid && !createExport.isPending
+
+  const handleCreate = async () => {
+    setError(null)
+    try {
+      const created = await createExport.mutateAsync({
+        slug,
+        ttl_days: isPermanent ? null : Number(ttl),
+      })
+      setFresh(created)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  const handleRevoke = (token: string) => {
+    revokeExport.mutate(token, {
+      onSuccess: () => {
+        if (fresh?.token === token) setFresh(null)
+        toast.success(t(`${k}.toasts.revoked`))
+      },
+      onError: (e) => toast.error(e instanceof Error ? e.message : t(`${k}.errors.revokeFailed`)),
+    })
+  }
+
+  const formatExpiry = (value: string | null) =>
+    value === null
+      ? t(`${k}.expiresNever`)
+      : t(`${k}.expiresAt`, { value: new Date(value).toLocaleString(i18n.language) })
+
+  if (!skill) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t(`${k}.title`)}</DialogTitle>
+          <DialogDescription>{t(`${k}.description`, { name: skill.name })}</DialogDescription>
+        </DialogHeader>
+
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            {isPermanent ? t(`${k}.warningPermanent`) : t(`${k}.warning`)}
+          </AlertDescription>
+        </Alert>
+
+        {/* Freshly minted link. Shown as the full command because that is what
+            gets pasted into a terminal; the list below only offers copy. */}
+        {fresh && (
+          <div className="space-y-1.5 rounded-md border border-border/60 bg-muted/30 p-3">
+            <Label className="text-xs text-muted-foreground">{t(`${k}.newLinkLabel`)}</Label>
+            <div className="flex items-center gap-1">
+              <Input
+                readOnly
+                value={installCommand(fresh.url)}
+                className="flex-1 font-mono text-xs"
+              />
+              <CopyButton value={installCommand(fresh.url)} />
+            </div>
+            <p className="text-xs text-muted-foreground">{formatExpiry(fresh.expires_at)}</p>
+          </div>
+        )}
+
+        {/* Existing links. No URL text by design — the row offers copy and
+            revoke; showing live credentials in a list invites shoulder-surfing
+            and screenshots. */}
+        <div className="space-y-1.5">
+          <Label className="text-xs text-muted-foreground">{t(`${k}.existingLabel`)}</Label>
+          {isLoading ? (
+            <div className="flex items-center gap-2 px-1 py-2 text-xs text-muted-foreground">
+              <Spinner size="sm" />
+              {t(`${k}.loading`)}
+            </div>
+          ) : !exports || exports.length === 0 ? (
+            <p className="px-1 py-2 text-xs text-muted-foreground">{t(`${k}.empty`)}</p>
+          ) : (
+            <ScrollArea className="max-h-44">
+              <div className="space-y-1 pr-2">
+                {exports.map((e) => (
+                  <div
+                    key={e.token}
+                    className="flex items-center gap-2 rounded-md border border-border/60 px-2 py-1.5"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-mono text-xs">{e.slug}</div>
+                      <div className="truncate text-[11px] text-muted-foreground">
+                        {formatExpiry(e.expires_at)}
+                        {' · '}
+                        {e.last_used_at
+                          ? t(`${k}.lastUsed`, {
+                              value: new Date(e.last_used_at).toLocaleString(i18n.language),
+                            })
+                          : t(`${k}.neverUsed`)}
+                      </div>
+                    </div>
+                    <CopyButton value={installCommand(e.url)} />
+                    <ConfirmButton
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-destructive hover:text-destructive"
+                      onConfirm={() => handleRevoke(e.token)}
+                      icon={<Trash2 className="h-3.5 w-3.5" />}
+                      tooltip={t(`${k}.revoke`)}
+                      confirmLabel={t(`${k}.revokeConfirm`)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+
+        {/* Mint a new one. */}
+        <div className="space-y-3 border-t border-border/60 pt-3">
+          <div className="space-y-1">
+            <Label htmlFor="export-slug" className="text-xs text-muted-foreground">
+              {t(`${k}.slugLabel`)}
+            </Label>
+            <Input
+              id="export-slug"
+              value={slug}
+              onChange={(ev) => setSlug(ev.target.value)}
+              // A name with nothing latin in it leaves this empty, so send the
+              // user straight to the field they have to fill in.
+              autoFocus={!derivedSlug}
+              className="font-mono text-xs"
+              placeholder={t(`${k}.slugPlaceholder`)}
+            />
+            <p className="text-xs text-muted-foreground">
+              {slug && !slugValid ? (
+                <span className="text-destructive">
+                  {t(`${k}.slugInvalid`, { max: MAX_SKILL_SLUG_LENGTH })}
+                </span>
+              ) : (
+                t(`${k}.slugHint`)
+              )}
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="export-ttl" className="text-xs text-muted-foreground">
+              {t(`${k}.ttlLabel`)}
+            </Label>
+            <Select value={ttl} onValueChange={setTtl} disabled={createExport.isPending}>
+              <SelectTrigger id="export-ttl">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TTL_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {t(`${k}.ttlOptions.${opt.labelKey}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription className="break-all">{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t('common.close')}
+          </Button>
+          <Button onClick={handleCreate} disabled={!canSubmit}>
+            {createExport.isPending ? t(`${k}.creating`) : t(`${k}.create`)}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/library/SkillsSection.tsx
+++ b/web/src/components/library/SkillsSection.tsx
@@ -1,3 +1,4 @@
+import { SkillExportDialog } from '@/components/dialogs/SkillExportDialog'
 import {
   INITIAL_SKILL_FORM,
   SkillFormFields,
@@ -53,6 +54,7 @@ import { useQuery } from '@tanstack/react-query'
 import {
   AlertTriangle,
   GitBranch,
+  Link2,
   MoreVertical,
   Pencil,
   Plus,
@@ -134,6 +136,7 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [shareSkill, setShareSkill] = useState<ApiSkill | null>(null)
+  const [exportSkill, setExportSkill] = useState<ApiSkill | null>(null)
   const [deletingSkill, setDeletingSkill] = useState<ApiSkill | null>(null)
 
   const importFromGit = useImportSkillFromGit()
@@ -709,6 +712,21 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
                         <Share2 className="h-3 w-3" />
                       </Button>
                     )}
+                    {/* Distinct from Share2 above: that governs who inside the
+                        platform can see the skill, this hands it to a local
+                        agent over a public URL. Different verbs on purpose. */}
+                    {s.is_own && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                        onClick={() => setExportSkill(s)}
+                        title={t('components.library.skills.actions.export')}
+                      >
+                        <Link2 className="h-3 w-3" />
+                      </Button>
+                    )}
                     <Button
                       type="button"
                       variant="ghost"
@@ -964,6 +982,12 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
         skill={shareSkill}
         open={!!shareSkill}
         onOpenChange={(o) => !o && setShareSkill(null)}
+      />
+
+      <SkillExportDialog
+        skill={exportSkill}
+        open={!!exportSkill}
+        onOpenChange={(o) => !o && setExportSkill(null)}
       />
 
       <SkillDeleteDialog

--- a/web/src/hooks/useSkillExports.ts
+++ b/web/src/hooks/useSkillExports.ts
@@ -1,0 +1,44 @@
+import { api } from '@/lib/api/client'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+/**
+ * Skill exports — capability URLs for installing a skill into a local agent.
+ *
+ * Owner-only, and keyed per skill. Unlike the skills list these are never
+ * prefetched: the query is enabled only while the export dialog is open, so
+ * we don't scatter live credentials through the cache for every skill the
+ * user merely looked at.
+ */
+const skillExportsQueryKey = (skillId: string) => ['skill-exports', skillId] as const
+
+export function useSkillExports(skillId: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: skillExportsQueryKey(skillId ?? ''),
+    queryFn: () => api.listSkillExports(skillId as string),
+    enabled: enabled && !!skillId,
+    // Expiry is server-evaluated, so a stale list can show a link that has
+    // since lapsed. Short window keeps the management view honest.
+    staleTime: 10_000,
+  })
+}
+
+export function useCreateSkillExport(skillId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: { slug?: string; ttl_days?: number | null; label?: string }) =>
+      api.createSkillExport(skillId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: skillExportsQueryKey(skillId) })
+    },
+  })
+}
+
+export function useRevokeSkillExport(skillId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (token: string) => api.revokeSkillExport(skillId, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: skillExportsQueryKey(skillId) })
+    },
+  })
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -40,6 +40,7 @@ import type {
   ApiShare,
   ApiShareData,
   ApiSkill,
+  ApiSkillExport,
   ApiSkillGrant,
   ApiSkillSource,
   ApiSkillVersion,
@@ -757,6 +758,37 @@ class ApiClient {
 
   async deleteSkill(id: string): Promise<void> {
     await this.request<void>(`/skills/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  }
+
+  /**
+   * Skill exports — capability URLs a local agent installs from with
+   * `npx skills add <url>`. Owner-only. The URL is the credential, so the
+   * list endpoint returns full tokens by design.
+   */
+  async listSkillExports(id: string): Promise<ApiSkillExport[]> {
+    return this.request<ApiSkillExport[]>(`/skills/${encodeURIComponent(id)}/exports`)
+  }
+
+  /**
+   * `slug` may be omitted when the skill name yields a valid one; the server
+   * answers 400 with the rules when it can't derive one (CJK names, emoji),
+   * and the caller should then prompt for it.
+   */
+  async createSkillExport(
+    id: string,
+    body: { slug?: string; ttl_days?: number | null; label?: string },
+  ): Promise<ApiSkillExport> {
+    return this.request<ApiSkillExport>(`/skills/${encodeURIComponent(id)}/exports`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  }
+
+  async revokeSkillExport(id: string, token: string): Promise<void> {
+    await this.request<void>(
+      `/skills/${encodeURIComponent(id)}/exports/${encodeURIComponent(token)}`,
+      { method: 'DELETE' },
+    )
   }
 
   /**

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -82,6 +82,7 @@ export type {
 
 export type {
   ApiSkill,
+  ApiSkillExport,
   ApiSkillGrant,
   ApiSkillSource,
   ApiSkillVersion,

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -868,7 +868,8 @@
           "syncFromGit": "Sync from Git",
           "previewSkills": "Preview",
           "chooseFile": "Choose file",
-          "back": "Back"
+          "back": "Back",
+          "export": "Export"
         },
         "detail": {
           "unpackingHint": "Skill is large — unpacking on the server, please wait…",
@@ -992,6 +993,42 @@
           "blockedOwn": "Detach this skill from your workspaces below before deleting it.",
           "blockedExternal": "This skill is still used by other users' workspaces or templates; it can't be deleted until they're all detached.",
           "clear": "This can't be undone."
+        },
+        "exportDialog": {
+          "title": "Export to local agent",
+          "description": "Create an install link so a local agent can add \"{{name}}\" with npx skills add.",
+          "warning": "Anyone with this link can download the skill until it expires — no login required. Make sure the contents are safe to share.",
+          "warningPermanent": "This link never expires. Anyone who ever sees the URL can keep downloading the latest published version of this skill. Revoke it once you're done.",
+          "newLinkLabel": "Install command",
+          "existingLabel": "Existing links",
+          "loading": "Loading…",
+          "empty": "No export links yet.",
+          "expiresNever": "Never expires",
+          "expiresAt": "Expires {{value}}",
+          "lastUsed": "Last used {{value}}",
+          "neverUsed": "Never used",
+          "copyCommand": "Copy install command",
+          "revoke": "Revoke",
+          "revokeConfirm": "Confirm revoke",
+          "slugLabel": "Install name",
+          "slugPlaceholder": "e.g. code-review",
+          "slugHint": "The directory name on the installer's machine. Fixed once the link is created.",
+          "slugInvalid": "Use lowercase letters, digits, and single hyphens (not leading or trailing), up to {{max}} characters.",
+          "ttlLabel": "Expires after",
+          "ttlOptions": {
+            "7days": "7 days",
+            "30days": "30 days",
+            "90days": "90 days",
+            "permanent": "Never (permanent)"
+          },
+          "create": "Create link",
+          "creating": "Creating…",
+          "toasts": {
+            "revoked": "Link revoked"
+          },
+          "errors": {
+            "revokeFailed": "Failed to revoke"
+          }
         }
       },
       "sources": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -898,7 +898,8 @@
           "syncFromGit": "从 Git 同步",
           "chooseFile": "选择文件",
           "back": "返回",
-          "previewSkills": "预览"
+          "previewSkills": "预览",
+          "export": "导出"
         },
         "detail": {
           "unpackingHint": "Skill 较大,服务端正在解压,稍候…",
@@ -1017,6 +1018,42 @@
           "blockedOwn": "请先把此 Skill 从下列你的 workspace 中移除，再执行删除。",
           "blockedExternal": "此 Skill 仍被其他用户的 workspace 或模板引用，需全部解除挂载后才能删除。",
           "clear": "此操作不可撤销。"
+        },
+        "exportDialog": {
+          "title": "导出到本地 agent",
+          "description": "生成安装链接，让本地 agent 通过 npx skills add 安装「{{name}}」。",
+          "warning": "拿到链接的任何人都可在有效期内下载这个 skill，无需登录。请确认内容可以公开。",
+          "warningPermanent": "永久链接没有有效期。只要任何人拿到 URL，就能一直下载这个 skill 的最新已发布版本。用完请及时撤销。",
+          "newLinkLabel": "安装命令",
+          "existingLabel": "已有链接",
+          "loading": "加载中…",
+          "empty": "还没有导出链接。",
+          "expiresNever": "永久有效",
+          "expiresAt": "过期时间 {{value}}",
+          "lastUsed": "最近使用 {{value}}",
+          "neverUsed": "从未使用",
+          "copyCommand": "复制安装命令",
+          "revoke": "撤销",
+          "revokeConfirm": "确认撤销",
+          "slugLabel": "安装名称",
+          "slugPlaceholder": "例如 code-review",
+          "slugHint": "对方机器上的目录名。链接生成后不可修改。",
+          "slugInvalid": "只能用小写字母、数字和单个连字符（不能在首尾），最长 {{max}} 个字符。",
+          "ttlLabel": "有效期",
+          "ttlOptions": {
+            "7days": "7 天",
+            "30days": "30 天",
+            "90days": "90 天",
+            "permanent": "永不过期"
+          },
+          "create": "生成链接",
+          "creating": "生成中…",
+          "toasts": {
+            "revoked": "链接已撤销"
+          },
+          "errors": {
+            "revokeFailed": "撤销失败"
+          }
         }
       },
       "sources": {


### PR DESCRIPTION
## What

A per-skill **export** capability. An owner mints a public capability URL, and a local agent installs the skill with:

```
npx skills add https://<host>/sk/<token>
```

Served over the Agent Skills [`.well-known` discovery protocol](https://github.com/cloudflare/agent-skills-discovery-rfc) (v0.2.0), which the stock `npx skills` client speaks with zero configuration — the URL is self-describing.

This is distinct from the existing **Share** dialog (platform visibility: private / team / public). Share governs who *inside* the platform can see a skill; Export hands it to anything holding the URL, no login.

## Backend (control-plane)

- **`skill_export_tokens`** table + service (migration `126`). Mirrors `export_tokens`: opaque 128-bit `skexp_` token, scope looked up from the row (never embedded in the token), `NULL expires_at` = permanent, revoke = hard `DELETE`. Adds two things the file-export tokens lack: `last_used_at` (so a user can tell which link is stale before revoking) and an hourly sweep (file-export rows accumulate forever).
- **Public `/sk/<token>` registry** — v0.2.0 index + tarball, proxied from skills-content-service with ETag/304 passthrough (cp never materializes the tarball). `digest` is the active version's generated `content_hash`, so the index and the served bytes move together on republish. Auth-bypassed by design: the token is the only authenticator and grants exactly **one** skill, so a leaked URL has a one-skill blast radius. Token is logged by prefix only (`export_tokens` logs the full value — not repeating that).
- **`GET` / `POST /api/skills/{id}/exports`** + **`DELETE .../{token}`**, owner-only. Non-owners get 404, not 403.

## Slug handling (`internal/types/skill-slug.ts`, shared by cp + web)

The protocol requires `^[a-z0-9-]+$` names, 1–64 chars, no leading/trailing/consecutive hyphens — and **silently drops** entries that fail (a bad name → empty skill list, no error). So:

- Names are projected best-effort into a valid slug and **frozen onto the export row at mint time** — renaming the skill afterwards can't retarget an install already on someone's disk.
- When a name yields nothing usable (all-CJK, emoji, punctuation) the API returns **400** and the caller must supply a slug. No opaque `skill-<id>` fallback — the slug becomes a directory name on the installer's machine.
- The module lives in `internal/types` because web derives the same slug client-side (to pre-fill the dialog) and the two must not drift; the test lives in `control-plane/src/lib` because cp is the only workspace with a test runner.
- Host-root `.well-known` probe is answered with a clean 404 rather than falling through to the SPA and returning HTML a JSON client would fail to parse.

## Frontend (web)

- **`SkillExportDialog`**, opened from a `Link2` action on the skill row (beside the existing `Share2`). Kept a **separate dialog**, not a tab of the Share dialog: Share defers to a Save button, while mint/revoke here are **immediate** — mixing the two save models would make "Cancel" a lie about credentials that already exist.
- TTL ladder **7 / 30 / 90 days + permanent**, default 90 (these live on a dev machine for weeks, unlike the minutes/hours file-export ladder). Permanent shows a destructive warning, following `PublicLinkDialog`.
- Existing links show slug + expiry + last-used with copy/revoke, **no URL text** (a list of live credentials invites shoulder-surfing). The freshly minted one is shown as the full `npx skills add …` command — what actually gets pasted.
- Slug is derived client-side to pre-fill the field, or left empty and focused when the name can't be slugified.

## Tests

- `control-plane` — 251 pass. New: slug rules (derive + validate, incl. CJK/emoji → null), registry routing (index shape, frozen-slug-on-rename, ETag/304, unpublished/expired 404s), and the `createExport` slug-decision branch (derive / explicit / invalid-rejected / unpublished-rejected / non-owner).
- `tsc --noEmit` clean in both cp and web; biome clean.

## Not covered here — needs a real deployment to verify

The `npx skills` client's **probe order**: if it hits the host root first, gets our 404, and gives up without trying the `/sk/<token>` path prefix, the URL shape would need to change. Couldn't confirm this locally — first thing to check after rollout.

`WEB_PUBLIC_URL` (used to build the returned `url`) is set on both prod and self-host (self-host requires an HTTPS ingress to use this feature anyway; the HTTP/NodePort default isn't a target case, since the discovery protocol requires HTTPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)