### PR TITLE
chore(goose): bump pinned goose CLI to v1.43.0

### DIFF
--- a/agents/goose/Dockerfile
+++ b/agents/goose/Dockerfile
@@ -94,7 +94,7 @@ RUN case "$TARGETARCH" in amd64) AB_ARCH=x64 ;; arm64) AB_ARCH=arm64 ;; \
 # the AAIF org after the Linux Foundation donation).
 RUN case "$TARGETARCH" in amd64) GOOSE_ARCH=x86_64 ;; arm64) GOOSE_ARCH=aarch64 ;; \
         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; esac \
-    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/block/goose/releases/download/v1.41.0/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.bz2 \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/block/goose/releases/download/v1.43.0/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.bz2 \
     | tar xj -C /usr/local/bin ./goose \
     && chmod +x /usr/local/bin/goose \
     && /usr/local/bin/goose --version


### PR DESCRIPTION
Bumps the goose CLI pinned in `agents/goose/Dockerfile` from v1.41.0 to v1.43.0 (latest release, 2026-07-14).

## Why

Picks up [block/goose#10366](https://github.com/block/goose/pull/10366) — DeepSeek/Kimi thinking-mode turns lost their reasoning blocks across multi-turn tool calls, so providers rejected the follow-up request with `reasoning_content in thinking mode must be passed back` 400s. The fix accumulates all prior thinking, keeps `RedactedThinking`, extracts reasoning from mixed thinking+text messages, and dedupes signed blocks. It landed in v1.43.0 and nothing earlier (`git tag --contains 1e03bbb56` → `v1.43.0` only).

## Contract check

Everything the ACP bridge in `agents/goose/src` depends on was diffed across `v1.41.0..v1.43.0` and is unchanged:

- `goose acp --with-builtin developer` flag
- `GOOSE_PATH_ROOT` per-session store
- session id format `YYYYMMDD_<n>` (the `sessionDirCodec` assumption)
- `_goose/unstable/session/update` → `usage_update` with `accumulatedInputTokens` / `accumulatedOutputTokens`
- `_meta.goose.toolCall.toolName`
- every `GOOSE_*` / `OPENAI_*` env var `applyProviderEnv` sets

## Behaviour changes to know about

- **Usage totals** (block/goose#10172): now derived as `max(sessions.accumulated_*, SUM(usage_ledger))` and rolled up recursively from subagent sessions into the parent. Monotonic — existing sessions don't reset — but delegated work that previously went unbilled now shows up in the counters. The new `message_usage` notification is ignored by the bridge, which only reads `usage_update`.
- **Shell timeout** (block/goose#10348): a `shell` call that omits `timeout_secs` now falls back to `DEFAULT_EXTENSION_TIMEOUT` (300s) instead of running unbounded. Left at the upstream default; override with `GOOSE_DEFAULT_EXTENSION_TIMEOUT` if it turns out to bite.
- **Session store migration v15 → v16**: adds the `usage_ledger` table and `sessions.parent_session_id`. Both steps are additive and a rollback to v1.41.0 still reads the schema (queries name columns explicitly).

`crates/goose-server` (the goosed REST path) was removed upstream — we talk ACP, so no impact.

## Verification

In a `linux/amd64` container built from the new pin:

- release asset downloads, `goose --version` → `1.43.0`
- `goose acp --help` still offers `--with-builtin`
- a real JSON-RPC `initialize` (with `_meta.goose.customNotifications`) + `session/new` handshake returns `agentInfo.version: 1.43.0`, session id `20260721_1`, loads the `developer` builtin, creates `data/sessions/sessions.db` under `GOOSE_PATH_ROOT`, and emits `_goose/unstable/session/update` carrying `accumulatedInputTokens` / `accumulatedOutputTokens`

Not verified locally: an actual thinking-model turn exercising the #10366 fix — that needs a DeepSeek/Kimi endpoint and will be checked on a canary workspace after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNkGCVRVYMSziXZFbCTG68