### PR TITLE
fix(scs): stream package downloads instead of buffering whole tarballs

### DIFF
--- a/control-plane/migrations/127_skill_package_storage_external.sql
+++ b/control-plane/migrations/127_skill_package_storage_external.sql
@@ -1,0 +1,12 @@
+-- skills-content-service streams package downloads as substring() slices
+-- (see scs src/package-stream.ts). A sliced TOAST fetch is O(slice) only
+-- when the stored value is uncompressed; otherwise every slice decompresses
+-- the whole datum. Tarballs are gzip data that pglz can't shrink, so in
+-- practice they're stored uncompressed already — EXTERNAL makes that a
+-- guarantee instead of a heuristic, and skips the futile compression
+-- attempt on publish.
+--
+-- Applies to newly written rows; existing rows keep their storage until
+-- rewritten, which is fine — they're gzip and thus uncompressed anyway.
+ALTER TABLE public.skill_versions ALTER COLUMN package SET STORAGE EXTERNAL;
+ALTER TABLE public.skill_sources ALTER COLUMN draft_package SET STORAGE EXTERNAL;

--- a/self-host/manifests/skills-content-service.yaml
+++ b/self-host/manifests/skills-content-service.yaml
@@ -43,10 +43,16 @@ spec:
               mountPath: /var/cache/skills-content
           resources:
             requests:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "50m"
+            # Steady state is ~130Mi, but /package reads each skill tarball
+            # fully into memory, so a burst of concurrent downloads (many
+            # workspaces reloading at once, plus npx-skills export fetches)
+            # stacks tarballs and OOM-killed the pod at 512Mi. Raised for
+            # headroom; the real fix is streaming /package from pg rather
+            # than buffering (tracked separately).
             limits:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
           livenessProbe:
             httpGet:

--- a/skills-content-service/src/db.ts
+++ b/skills-content-service/src/db.ts
@@ -153,6 +153,65 @@ export async function getActiveVersionHash(
   return rows[0] ?? null
 }
 
+/**
+ * Package metadata for the streaming download path: everything the response
+ * headers need plus the immutable version id the chunk reads will address.
+ * `octet_length` is computed server-side — no package bytes cross the wire.
+ */
+interface PackageHead {
+  version_id: string
+  skill_id: string
+  content_hash: string
+  name: string
+  byte_length: number
+}
+
+const PACKAGE_HEAD_COLS = `
+  v.id AS version_id, v.skill_id, v.content_hash, s.name,
+  octet_length(v.package) AS byte_length
+`
+
+export async function getActiveVersionPackageHead(skillId: string): Promise<PackageHead | null> {
+  const { rows } = await pool.query<PackageHead>(
+    `SELECT ${PACKAGE_HEAD_COLS}
+       FROM skills s
+       JOIN skill_versions v ON v.id = s.active_version_id
+      WHERE s.id = $1`,
+    [skillId],
+  )
+  return rows[0] ?? null
+}
+
+export async function getVersionPackageHead(versionId: string): Promise<PackageHead | null> {
+  const { rows } = await pool.query<PackageHead>(
+    `SELECT ${PACKAGE_HEAD_COLS}
+       FROM skill_versions v
+       JOIN skills s ON s.id = v.skill_id
+      WHERE v.id = $1`,
+    [versionId],
+  )
+  return rows[0] ?? null
+}
+
+/**
+ * One slice of a version's package, `offset` 0-based. Sliced TOAST fetch —
+ * O(length), not O(package) — because the column stores uncompressed
+ * (gzip data defeats pglz; migration 127 pins STORAGE EXTERNAL). Returns
+ * null when the version row is gone (deleted mid-stream).
+ */
+export async function readPackageChunk(
+  versionId: string,
+  offset: number,
+  length: number,
+): Promise<Buffer | null> {
+  const { rows } = await pool.query<{ chunk: Buffer }>(
+    // substring() is 1-based.
+    'SELECT substring(package FROM $2 FOR $3) AS chunk FROM skill_versions WHERE id = $1',
+    [versionId, offset + 1, length],
+  )
+  return rows[0]?.chunk ?? null
+}
+
 export async function getVersionPackage(
   versionId: string,
 ): Promise<{ content_hash: string; package: Buffer; skill_id: string; name: string } | null> {
@@ -524,9 +583,7 @@ export async function deleteSkill(skillId: string): Promise<boolean> {
     const del = await client.query('DELETE FROM skills WHERE id = $1', [skillId])
     const deleted = (del.rowCount ?? 0) > 0
     if (deleted && source_kind === 'native') {
-      await client.query("DELETE FROM skill_sources WHERE id = $1 AND kind = 'native'", [
-        source_id,
-      ])
+      await client.query("DELETE FROM skill_sources WHERE id = $1 AND kind = 'native'", [source_id])
     }
     return deleted
   })

--- a/skills-content-service/src/index.ts
+++ b/skills-content-service/src/index.ts
@@ -21,16 +21,19 @@ import {
   findSkillByOwnerName,
   getActiveVersionHash,
   getActiveVersionPackage,
+  getActiveVersionPackageHead,
   getDraftPackage,
   getSkillById,
   getSourceById,
   getVersionPackage,
+  getVersionPackageHead,
   insertSkill,
   insertSkillSource,
   insertVersion,
   patchSkill,
   patchSource,
   pool,
+  readPackageChunk,
   saveDraftPackage,
   setActiveVersion,
   withTx,
@@ -46,6 +49,7 @@ import {
 import { DUFS_ORIGIN, startDufs } from './dufs'
 import { importFromGit, scanGit, scanTarballBytes, switchSourceToGit, syncSource } from './from-git'
 import { startLruSweep } from './lru'
+import { packageStream } from './package-stream'
 
 const MAX_SKILL_PACKAGE_BYTES = Number(process.env.MAX_SKILL_PACKAGE_BYTES || 50 * 1024 * 1024)
 
@@ -1325,27 +1329,29 @@ const skillPackageRoute = createRoute({
 
 app.openapi(skillPackageRoute, async (c) => {
   const { id } = c.req.valid('param')
-  // Conditional download: probe the active version's content hash first (cheap,
-  // no bytea read). The agent-skills client at workspace boot/reload sends the
-  // ETag it last extracted; when it still matches we 304 and skip streaming the
-  // package entirely. Fanout reloads (one skill edit reloads every workspace
-  // that has it) make almost every package request a no-change probe.
-  const hashRow = await getActiveVersionHash(id)
-  if (!hashRow) return c.json({ error: 'Skill or active version not found' }, 404)
-  const etag = `"${hashRow.content_hash}"`
+  // Conditional download: the head probe carries the content hash (plus the
+  // byte length and version id the 200 path needs) without reading a single
+  // package byte. The agent-skills client at workspace boot/reload sends the
+  // ETag it last extracted; when it still matches we 304 and skip the body
+  // entirely. Fanout reloads (one skill edit reloads every workspace that
+  // has it) make almost every package request a no-change probe.
+  const head = await getActiveVersionPackageHead(id)
+  if (!head) return c.json({ error: 'Skill or active version not found' }, 404)
+  const etag = `"${head.content_hash}"`
   if (c.req.header('If-None-Match') === etag) {
     return new Response(null, { status: 304, headers: { ETag: etag } })
   }
-  const row = await getActiveVersionPackage(id)
-  if (!row) return c.json({ error: 'Skill or active version not found' }, 404)
-  const view = new Uint8Array(row.package.byteLength)
-  view.set(row.package)
-  return new Response(view, {
+  // Chunks address the immutable version row resolved above, not the active
+  // pointer — a concurrent set-active can't tear the stream.
+  const body = packageStream(head.byte_length, (offset, length) =>
+    readPackageChunk(head.version_id, offset, length),
+  )
+  return new Response(body, {
     status: 200,
     headers: {
       'Content-Type': 'application/gzip',
-      'Content-Length': String(row.package.byteLength),
-      'Content-Disposition': packageDisposition(row.name),
+      'Content-Length': String(head.byte_length),
+      'Content-Disposition': packageDisposition(head.name),
       ETag: etag,
     },
   })
@@ -1367,18 +1373,19 @@ const versionPackageRoute = createRoute({
 
 app.openapi(versionPackageRoute, async (c) => {
   const { id, vid } = c.req.valid('param')
-  const row = await getVersionPackage(vid)
-  if (!row || row.skill_id !== id) return c.json({ error: 'Version not found' }, 404)
-  const view = new Uint8Array(row.package.byteLength)
-  view.set(row.package)
-  return new Response(view, {
+  const head = await getVersionPackageHead(vid)
+  if (!head || head.skill_id !== id) return c.json({ error: 'Version not found' }, 404)
+  const body = packageStream(head.byte_length, (offset, length) =>
+    readPackageChunk(vid, offset, length),
+  )
+  return new Response(body, {
     status: 200,
     headers: {
       'Content-Type': 'application/gzip',
-      'Content-Length': String(row.package.byteLength),
+      'Content-Length': String(head.byte_length),
       // Tag historical downloads with a short content hash so multiple
       // versions of the same skill don't collide in the downloads folder.
-      'Content-Disposition': packageDisposition(row.name, `-${row.content_hash.slice(0, 8)}`),
+      'Content-Disposition': packageDisposition(head.name, `-${head.content_hash.slice(0, 8)}`),
     },
   })
 })

--- a/skills-content-service/src/package-stream.test.ts
+++ b/skills-content-service/src/package-stream.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { packageStream } from './package-stream'
+
+/** Drain a stream, collecting chunks; rejects if the stream errors. */
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const parts: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) break
+    parts.push(value)
+  }
+  return Buffer.concat(parts)
+}
+
+/** ChunkReader over an in-memory buffer. */
+function readerFor(data: Buffer) {
+  return vi.fn(async (offset: number, length: number) => data.subarray(offset, offset + length))
+}
+
+describe('packageStream', () => {
+  it('streams the exact bytes across multiple chunks', async () => {
+    // 10 bytes in chunks of 4 → 4+4+2.
+    const data = Buffer.from('0123456789')
+    const read = readerFor(data)
+    const out = await drain(packageStream(data.byteLength, read, 4))
+    expect(out.equals(data)).toBe(true)
+    expect(read.mock.calls).toEqual([
+      [0, 4],
+      [4, 4],
+      [8, 2],
+    ])
+  })
+
+  it('serves a package smaller than one chunk with a single read', async () => {
+    const data = Buffer.from('tiny')
+    const read = readerFor(data)
+    const out = await drain(packageStream(data.byteLength, read, 4 * 1024))
+    expect(out.equals(data)).toBe(true)
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes immediately for a zero-length package', async () => {
+    const read = vi.fn()
+    const out = await drain(packageStream(0, read))
+    expect(out.byteLength).toBe(0)
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('errors when the row disappears mid-stream', async () => {
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce(Buffer.alloc(4))
+      // Version deleted between chunks.
+      .mockResolvedValueOnce(null)
+    await expect(drain(packageStream(8, read, 4))).rejects.toThrow(/row disappeared/)
+  })
+
+  it('errors on a short read instead of emitting a truncated tarball', async () => {
+    const read = vi.fn().mockResolvedValue(Buffer.alloc(2))
+    await expect(drain(packageStream(8, read, 4))).rejects.toThrow(/got 2, want 4/)
+  })
+
+  it('does not read ahead of consumption (pull-based backpressure)', async () => {
+    const data = Buffer.alloc(12)
+    const read = readerFor(data)
+    const reader = packageStream(data.byteLength, read, 4).getReader()
+    await reader.read()
+    // One chunk consumed — at most one readahead pull may be in flight, so the
+    // reader must not have raced through all three chunks.
+    expect(read.mock.calls.length).toBeLessThanOrEqual(2)
+    await reader.cancel()
+  })
+})

--- a/skills-content-service/src/package-stream.ts
+++ b/skills-content-service/src/package-stream.ts
@@ -1,0 +1,64 @@
+/**
+ * Chunked streaming of a package bytea to an HTTP response.
+ *
+ * The naive read (`SELECT package ...`) materializes the whole tarball in
+ * this process — and the route then copied it once more — so peak memory
+ * scaled as (concurrent downloads × 2 × package size). A burst of a dozen
+ * agent boots pulling distinct skills stacked enough tarballs to blow the
+ * pod's memory limit (OOM kills observed in production; see issue #159).
+ *
+ * Instead we probe the byte length server-side (`octet_length`, no bytes
+ * transferred) and then read `substring(package FROM off FOR len)` slices,
+ * fed through a pull-based ReadableStream so backpressure from a slow
+ * client suspends the reads. Peak memory per request is one chunk.
+ *
+ * Two properties the SQL relies on:
+ *  - Chunks address an immutable `skill_versions` row by id (the caller
+ *    resolves the active pointer once, up front), so a concurrent
+ *    set-active can't tear the bytes mid-stream.
+ *  - Tarballs are gzip data, which pglz can't compress, so TOAST stores
+ *    them uncompressed and `substring` uses a sliced fetch — O(chunk), not
+ *    O(package). Migration 127 sets the column STORAGE EXTERNAL to make
+ *    that guarantee explicit rather than heuristic.
+ */
+
+/** Reads [offset, offset+length) of the package, 0-based. Null = row gone. */
+type ChunkReader = (offset: number, length: number) => Promise<Buffer | null>
+
+/**
+ * 4 MiB: almost every skill fits in one chunk (they're KBs to a few MBs),
+ * so the common case stays a single read like before — just bounded.
+ */
+const PACKAGE_CHUNK_BYTES = 4 * 1024 * 1024
+
+/**
+ * Stream exactly `byteLength` bytes via `readChunk`.
+ *
+ * The version row is immutable, so a short or missing read mid-stream means
+ * it was deleted under us — the stream errors rather than emitting a
+ * silently truncated tarball that the client would hash-reject anyway.
+ */
+export function packageStream(
+  byteLength: number,
+  readChunk: ChunkReader,
+  chunkBytes = PACKAGE_CHUNK_BYTES,
+): ReadableStream<Uint8Array> {
+  let offset = 0
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (offset >= byteLength) {
+        controller.close()
+        return
+      }
+      const want = Math.min(chunkBytes, byteLength - offset)
+      const chunk = await readChunk(offset, want)
+      if (!chunk || chunk.byteLength !== want) {
+        const detail = chunk ? `got ${chunk.byteLength}, want ${want}` : 'row disappeared'
+        controller.error(new Error(`package read failed at ${offset}/${byteLength}: ${detail}`))
+        return
+      }
+      offset += want
+      controller.enqueue(chunk)
+    },
+  })
+}


### PR DESCRIPTION
Fixes #159

## Problem

`GET /skills/:id/package` (and the per-version variant) read the entire package bytea into memory — and the route then copied it once more into a fresh `Uint8Array` — so peak memory scaled as **(concurrent downloads × 2 × package size)**. A burst of agent boots pulling a dozen distinct skills stacked enough tarballs to blow the 512Mi pod limit: 32 OOM kills over 40 days in a production deployment, surfacing downstream as cp 502s and a misleading `No skills found` from the `npx skills` client (discovery succeeded; only the archive fetch failed).

## Fix

Chunked streaming, bounded at one chunk (4 MiB) per in-flight request:

- **Head probe** — one query returns `octet_length(package)`, `content_hash`, the version id, and the skill name. It serves both the ETag/304 path (unchanged cost: the fanout-reload hot path stays a no-byte probe) and the 200 response headers.
- **Body** — a pull-based `ReadableStream` over `substring(package FROM off FOR len)` slices. Pull-based means a slow client suspends the reads (backpressure) instead of the server buffering ahead.
- **Torn-stream safety** — chunks address the immutable `skill_versions` row by id, resolved once up front, so a concurrent set-active can't switch bytes mid-stream. A short/missing chunk (version deleted mid-stream) errors the response instead of emitting a truncated tarball.

**Migration 127** pins `STORAGE EXTERNAL` on `skill_versions.package` and `skill_sources.draft_package`. Sliced TOAST fetches are O(slice) only for uncompressed storage; tarballs are gzip data that pglz can't shrink, so they're stored uncompressed in practice already — the migration turns that heuristic into a guarantee and skips the futile compression attempt on publish.

**Kept buffered on purpose**: the cache-materialization loaders (`ensureUnpacked`) and draft flows — tar extraction needs the whole payload, and those run sequentially rather than in request-driven bursts.

Also includes the **self-host memory bump** for scs (limit 512Mi → 1Gi, request 128Mi → 256Mi) as deploy-time headroom. With streaming the old limit would suffice; a higher ceiling costs nothing (the request is what reserves scheduler capacity).

## Validation

- Unit tests for the stream (chunk boundaries, short final chunk, zero-length, mid-stream row deletion, short-read rejection, pull-based no-readahead).
- Against a production-scale dataset: chunked reassembly of the **largest stored package (46 MB → 12 chunks) sha256-matches its `content_hash`**, and server-side slice cost is **flat ~60–75 ms at offsets 0 / 20 MiB / 40 MiB** — confirming sliced TOAST fetch stays O(chunk) regardless of position.
- `tsc --noEmit` clean; scs suite 69/69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)