### PR TITLE
feat(goose): enable summon builtin for subagent delegation

### DIFF
--- a/agents/goose/src/index.ts
+++ b/agents/goose/src/index.ts
@@ -83,10 +83,13 @@ if (rc) {
 
 // ── ACP bridge factory (1 bridge : 1 session : 1 data dir) ──
 
-// --with-builtin developer: when session/new carries mcpServers (always, for
-// tos-platform), goose REPLACES the config-file extension set with that list —
-// only CLI-pinned builtins survive (initial_session_extensions in goose's ACP
-// server). Without this flag the agent has no shell/edit tools.
+// --with-builtin developer,summon: when session/new carries mcpServers
+// (always, for tos-platform), goose REPLACES the config-file extension set
+// with that list — only CLI-pinned builtins survive
+// (initial_session_extensions in goose's ACP server). Without developer the
+// agent has no shell/edit tools; summon adds the delegate/load subagent tools
+// (in-process platform extension — subagents run as child sessions inside the
+// same goose process, inheriting the parent's extensions and provider).
 //
 // GOOSE_PATH_ROOT: every session runs against its own private goose store —
 // the platform session id (acp-server's draft UUID for new sessions) names
@@ -106,7 +109,7 @@ setBridgeFactory(async (sessionId: string) => {
   const dataDir = prepareSessionDir(sessionId)
   const b = new AcpBridge({
     program: 'goose',
-    args: ['acp', '--with-builtin', 'developer'],
+    args: ['acp', '--with-builtin', 'developer,summon'],
     cwd: WORKSPACE_DIR,
     env: { GOOSE_PATH_ROOT: dataDir },
     sessionIdCodec: sessionDirCodec(sessionId),


### PR DESCRIPTION
## What

Pin the `summon` platform extension alongside `developer` when spawning `goose acp`, exposing goose's built-in subagent tools (`delegate` / `load`) in platform sessions.

## Why

Goose's ACP server (`initial_session_extensions`) discards the config-file extension set whenever `session/new` carries `mcpServers` — which we always send for the platform MCP. Only CLI-pinned builtins survive, and we only pinned `developer`, so the Summon extension (upstream `default_enabled: true`) never loaded and goose sessions had no subagent capability.

## Notes

- Summon runs in-process: subagents are child sessions inside the same goose process, inheriting the parent's extensions (incl. platform MCP) and provider config. No new pods/containers.
- Subagent turn cap stays at goose's default (25, `GOOSE_SUBAGENT_MAX_TURNS`).
- Follow-up to verify at runtime: whether subagent token usage rolls up into the parent session's accumulated usage counters (our billing source) or needs separate tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YhCVuYty3YMRNEPsL1H3p