### PR TITLE
fix(self-host): attach the registry pull secret to the env-runner ServiceAccount

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -730,6 +730,10 @@ apply_manifests() {
   create_regcred "${NAMESPACE}"
   attach_pull_secret_to_sa "${NAMESPACE}" default
   attach_pull_secret_to_sa "${NAMESPACE}" "${APP_PREFIX}-cp"
+  # env-runner-k8s runs under its own SA (it needs RBAC), so it does not
+  # inherit the default SA's pull secret — without this, its image pull is
+  # anonymous and an authenticated registry rejects it (ImagePullBackOff).
+  attach_pull_secret_to_sa "${NAMESPACE}" "${APP_PREFIX}-env-runner-k8s"
   kapply -f "$RENDERED_DIR/secrets.yaml"
 
   log "Creating PostgreSQL cluster ..."


### PR DESCRIPTION
env-runner-k8s runs under its own ServiceAccount (it needs RBAC), so it does not inherit the default SA's `imagePullSecrets`. On an authenticated registry its image pull goes out anonymous and is rejected, leaving the deployment in ImagePullBackOff — and since workspace lifecycle reconciliation lives in env-runner, workspaces never start.

Found while release-verifying an install against a private registry: every other platform pod pulled fine (default / control-plane SAs carry the secret), env-runner alone failed. Verified live: patching the secret onto the SA brings the deployment up immediately.

One-line fix: attach the pull secret to the env-runner SA alongside `default` and the control-plane SA. No-op on public/anonymous registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLytAVduhh42CCy5vcCP7h