### PR TITLE
fix(web): dialog content overflows when a share title is long

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -38,6 +38,9 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-6 duration-200",
+        // minmax(0,1fr): long nowrap content (e.g. truncated CJK titles) otherwise inflates the
+        // implicit auto column's min-content and overflows the dialog
+        "grid-cols-[minmax(0,1fr)]",
         "rounded-xl border border-foreground/[0.08] bg-card text-card-foreground",
         "shadow-2xl shadow-foreground/[0.08] ring-1 ring-inset ring-foreground/[0.03]",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",


### PR DESCRIPTION
## Problem

In the share-session dialog, a long share title (CJK, single line) pushes the create button and share rows past the dialog's right edge. The title never truncates despite `truncate` + `min-w-0`.

## Root cause

`DialogContent` is `display: grid` with no explicit column definition. The implicit auto column's minimum track size is the content's min-content, and a `white-space: nowrap` title inside a nested flex row inflates that min-content beyond `max-w-*`. The track blows out, every child lays out wider than the dialog, and the flex-level `min-w-0`/`truncate` guards never get a chance to apply.

Reproduced in a minimal Chromium harness: dialog 448px wide, share row 450px (overflow). With the fix the row lays out at 398px and the title ellipsizes.

## Fix

Pin the column with `grid-cols-[minmax(0,1fr)]` on `DialogContent`, so grid children are constrained to the container width. Global fix — any dialog with long nowrap content was susceptible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AsCxSabmQYADfqEh4gNN9