### PR TITLE
fix(web): layout switching broken over plain HTTP + dangling layout selection

### DIFF
--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -1166,7 +1166,7 @@ export function extractSkeletonFromProfile(
 
 /**
  * Materialize a skeleton into the profile `slots` shape, minting instance ids
- * via the injected factory (server uses generateId, client uses crypto UUID).
+ * via the injected factory (server mints deterministic ids, client random ones).
  * Each slot's first instance becomes active. Returns the `{ layout_id, slots }`
  * patch to merge into a workspace_profile payload.
  */

--- a/web/src/components/shell/LayoutSwitcher.tsx
+++ b/web/src/components/shell/LayoutSwitcher.tsx
@@ -19,6 +19,7 @@ import {
 import type { ApiWorkspaceLayout } from '@/lib/api/types'
 import { isCommitEnter } from '@/lib/keyboard'
 import { cn } from '@/lib/utils'
+import { useWorkspaceProfileStore } from '@/stores/workspace-profile-store'
 import { Check, LayoutPanelLeft, Pencil, Plus, RotateCcw, Save, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -120,7 +121,11 @@ export function LayoutSwitcher({
         <SaveLayoutDialog workspaceId={workspaceId} open={saveOpen} onOpenChange={setSaveOpen} />
       )}
       <EditLayoutDialog layout={editing} onClose={() => setEditing(null)} />
-      <DeleteLayoutDialog layout={deleting} onClose={() => setDeleting(null)} />
+      <DeleteLayoutDialog
+        layout={deleting}
+        profileId={profileId}
+        onClose={() => setDeleting(null)}
+      />
     </>
   )
 }
@@ -519,9 +524,12 @@ function EditLayoutDialog({
 
 function DeleteLayoutDialog({
   layout,
+  profileId,
   onClose,
 }: {
   layout: ApiWorkspaceLayout | null
+  /** Profile whose selection should be cleared if it points at the deleted layout. */
+  profileId: string | undefined
   onClose: () => void
 }) {
   const { t } = useTranslation()
@@ -530,6 +538,14 @@ function DeleteLayoutDialog({
   async function confirm() {
     if (!layout) return
     await del.mutateAsync(layout.id)
+    // Deleting the currently-selected layout would leave the profile's
+    // selection dangling — drop it so the built-in default becomes active.
+    if (profileId) {
+      const store = useWorkspaceProfileStore.getState()
+      if (store.byWorkspace[profileId]?.selected_layout_id === layout.id) {
+        store.patch(profileId, { selected_layout_id: null })
+      }
+    }
     onClose()
   }
 

--- a/web/src/hooks/useLayoutState.ts
+++ b/web/src/hooks/useLayoutState.ts
@@ -3,8 +3,6 @@ import { useRequiredSlotContext } from '@/contexts/SlotContext'
 import { api } from '@/lib/api/client'
 import type { ApiWorkspaceLayout } from '@/lib/api/types'
 import { useWorkspaceProfile, useWorkspaceProfileStore } from '@/stores/workspace-profile-store'
-import { useQueryClient } from '@tanstack/react-query'
-import { useCallback, useMemo } from 'react'
 import {
   type LayoutSkeleton,
   POPOUT_SLOT_ID,
@@ -12,6 +10,8 @@ import {
   normalizeLayoutSkeleton,
   skeletonToProfilePatch,
 } from '@neutree-ai/types'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo } from 'react'
 import { useWorkspaceLayouts, workspaceLayoutsQueryKey } from './useWorkspaceLayouts'
 
 type LayoutKind = 'builtin' | 'template' | 'custom'
@@ -37,8 +37,11 @@ function builtinSkeletonFor(id: LayoutId): LayoutSkeleton {
   return s
 }
 
+// Not crypto.randomUUID(): that API only exists in secure contexts, and
+// self-hosted deployments are commonly reached over plain HTTP — it being
+// undefined there made every layout switch throw before writing the profile.
 const mkInstanceId = (slotId: string, appId: string, i: number) =>
-  `${slotId}:${appId}:${i}:${crypto.randomUUID().slice(0, 8)}`
+  `${slotId}:${appId}:${i}:${Math.random().toString(36).slice(2, 10)}`
 
 interface LayoutState {
   /** Current live arrangement as a normalized skeleton. */
@@ -73,7 +76,7 @@ interface LayoutState {
 export function useLayoutState(workspaceId: string): LayoutState {
   const ctx = useRequiredSlotContext()
   const profile = useWorkspaceProfile(workspaceId)
-  const { layouts } = useWorkspaceLayouts()
+  const { layouts, isLoading: layoutsLoading } = useWorkspaceLayouts()
   const qc = useQueryClient()
 
   const layoutId = (
@@ -90,9 +93,16 @@ export function useLayoutState(workspaceId: string): LayoutState {
     return normalizeLayoutSkeleton({ layout_id: layoutId, slots })
   }, [ctx.slots, ctx.getState, layoutId])
 
-  const selectedId =
+  const storedSelectedId =
     typeof profile.selected_layout_id === 'string' ? profile.selected_layout_id : null
-  const selectedLayout = selectedId ? (layouts.find((l) => l.id === selectedId) ?? null) : null
+  const selectedLayout = storedSelectedId
+    ? (layouts.find((l) => l.id === storedSelectedId) ?? null)
+    : null
+  // A stored selection pointing at a layout that no longer exists (deleted
+  // while selected, removed template copy) collapses to the built-in default
+  // once the list has loaded — otherwise the switcher highlights no row at
+  // all and Reset re-stamps a reference that can never resolve.
+  const selectedId = selectedLayout || layoutsLoading ? storedSelectedId : null
   const selected = selectedLayout
     ? normalizeLayoutSkeleton(selectedLayout.skeleton)
     : builtinSkeletonFor(layoutId)


### PR DESCRIPTION
## Symptoms

Reported from a self-hosted deployment reached over plain HTTP: in the layout switcher popover, no frame (1/2/3-col) shows as active, and clicking any frame (or Reset) does nothing.

## Root causes

1. **`crypto.randomUUID()` in `mkInstanceId`** (`useLayoutState.ts`) — this API only exists in secure contexts. Over plain HTTP it is `undefined`, so every `stamp()` (frame switch / apply saved layout / reset) threw a `TypeError` synchronously, before the profile patch was written. Replaced with a `Math.random()`-based id, same scheme `SlotContext.newInstanceId` already uses.

2. **Dangling `selected_layout_id`** — a profile selection can point at a layout that no longer exists (layout deleted while selected; template copy removed). Since frame highlighting keys off `selectedId === null`, a dangling selection left *no* row highlighted anywhere, and Reset re-stamped an unresolvable reference. Now:
   - `useLayoutState` collapses a dangling selection to the built-in default once the layouts list has loaded;
   - deleting the currently-selected layout clears the profile's `selected_layout_id`.

## Validation

- `npx tsc --noEmit` in `web/` passes; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq5YTG6CswWndDPPKxR57Z