### PR TITLE
feat(self-host): decouple first-party image prefix from the object-name prefix

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -77,6 +77,13 @@ export IMAGE_TAG="${IMAGE_TAG:-latest}"
 export APP_PREFIX="${APP_PREFIX:-nap}"
 export DB_NAME="${DB_NAME:-nap}"
 
+# First-party image prefix, decoupled from the k8s object prefix. Defaults to
+# ${REGISTRY}/${APP_PREFIX} (image names match object names). Override when an
+# existing install keeps its historical APP_PREFIX for object names but pulls
+# the public nap-* images, e.g.:
+#   PLATFORM_IMAGE_PREFIX=ghcr.io/neutree-ai/agent-platform/nap
+export PLATFORM_IMAGE_PREFIX="${PLATFORM_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}}"
+
 # --- Third-party images -----------------------------------------------------
 # Non-first-party images (language runtimes, pause, gotenberg, coturn, nfs).
 # Default to their public upstreams; an offline/mirrored install overrides each
@@ -96,7 +103,7 @@ export PAUSE_IMAGE="${PAUSE_IMAGE:-registry.k8s.io/pause:3.9}"
 export AFS_IMAGE="${AFS_IMAGE:-ghcr.io/neutree-ai/afs:latest}"
 
 # Resolve AGENT_IMAGE_PREFIX if it references REGISTRY
-AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${REGISTRY}/${APP_PREFIX}-agent}"
+AGENT_IMAGE_PREFIX="${AGENT_IMAGE_PREFIX:-${PLATFORM_IMAGE_PREFIX}-agent}"
 export AGENT_IMAGE_PREFIX
 
 # Registry authentication. Blank for a public / anonymous registry. When both
@@ -268,12 +275,17 @@ check_prereqs() {
 # first-party image was rebuilt or mirrored under that prefix in your own
 # registry. Two guards keep it from being mistaken for a cosmetic setting.
 check_app_prefix() {
-  # A non-default prefix against the default public registry references images
-  # that cannot exist there (it only hosts nap-*). Refuse before applying.
-  if [ "$APP_PREFIX" != "nap" ] && [ "$REGISTRY" = "ghcr.io/neutree-ai/agent-platform" ]; then
-    die "APP_PREFIX=${APP_PREFIX} with the default public REGISTRY, which only hosts nap-* images.
-       A non-default APP_PREFIX is for redistributions that rebuild every first-party image
-       under that prefix in their own registry. Unset APP_PREFIX unless that is you."
+  # A non-default prefix whose image prefix still resolves against the default
+  # public registry references images that cannot exist there (it only hosts
+  # nap-*). Refuse before applying. Setting PLATFORM_IMAGE_PREFIX explicitly
+  # (e.g. to .../nap while keeping historical object names) sidesteps this.
+  if [ "$APP_PREFIX" != "nap" ] \
+    && [ "$PLATFORM_IMAGE_PREFIX" = "ghcr.io/neutree-ai/agent-platform/${APP_PREFIX}" ]; then
+    die "APP_PREFIX=${APP_PREFIX} resolves PLATFORM_IMAGE_PREFIX to the default public REGISTRY,
+       which only hosts nap-* images. Either rebuild every first-party image under that prefix
+       in your own registry (redistributors), or set
+       PLATFORM_IMAGE_PREFIX=ghcr.io/neutree-ai/agent-platform/nap to keep your object names
+       while pulling the public images."
   fi
   # Never change the prefix of an existing install: the render would come up as
   # a second, empty ${APP_PREFIX}-* stack (empty database included) beside the
@@ -297,7 +309,7 @@ render_manifests() {
 
   # Explicit variable list — prevents envsubst from replacing k8s $(VAR)
   # references like $(POSTGRES_PASSWORD)
-  local VARS='${NAMESPACE}${REGISTRY}${IMAGE_TAG}${APP_PREFIX}${DB_NAME}${NAP_HOST}${NAP_NODE_PORT}'
+  local VARS='${NAMESPACE}${REGISTRY}${IMAGE_TAG}${APP_PREFIX}${PLATFORM_IMAGE_PREFIX}${DB_NAME}${NAP_HOST}${NAP_NODE_PORT}'
   VARS+='${IMAGE_PULL_SECRET}'
   VARS+='${POSTGRES_IMAGE}${GOTENBERG_IMAGE}${COTURN_IMAGE}${NFS_SERVER_IMAGE}'
   VARS+='${RUNTIME_NODE_IMAGE}${RUNTIME_PYTHON_IMAGE}${RUNTIME_GOLANG_IMAGE}${PAUSE_IMAGE}'

--- a/self-host/manifests/browser-service.yaml
+++ b/self-host/manifests/browser-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: browser
-          image: ${REGISTRY}/${APP_PREFIX}-browser:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-browser:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3005

--- a/self-host/manifests/channel-gateway.yaml
+++ b/self-host/manifests/channel-gateway.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: channel-gateway
-          image: ${REGISTRY}/${APP_PREFIX}-cg:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-cg:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3002

--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -74,7 +74,7 @@ spec:
       terminationGracePeriodSeconds: 150
       containers:
         - name: control-plane
-          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-cp:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
@@ -134,7 +134,7 @@ spec:
             - name: AFS_CONTROLLER_ADDR
               value: "afs-controller.${NAMESPACE}.svc:9100"
             - name: MEMORY_FUSE_IMAGE
-              value: "${REGISTRY}/${APP_PREFIX}-memory-fuse:${IMAGE_TAG}"
+              value: "${PLATFORM_IMAGE_PREFIX}-memory-fuse:${IMAGE_TAG}"
             - name: OFFICE_CONVERTER_URL
               value: "http://${APP_PREFIX}-office-converter:3007"
             - name: WEB_PUBLIC_URL

--- a/self-host/manifests/env-runner-k8s.yaml
+++ b/self-host/manifests/env-runner-k8s.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: ${APP_PREFIX}-env-runner-k8s
       containers:
         - name: env-runner-k8s
-          image: ${REGISTRY}/${APP_PREFIX}-env-runner-k8s:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-env-runner-k8s:${IMAGE_TAG}
           imagePullPolicy: Always
           # Provider config MUST match control-plane.yaml exactly, so both build
           # byte-identical workspace pods. Keep this block in sync.
@@ -87,7 +87,7 @@ spec:
             - name: AFS_CONTROLLER_ADDR
               value: "afs-controller.${NAMESPACE}.svc:9100"
             - name: MEMORY_FUSE_IMAGE
-              value: "${REGISTRY}/${APP_PREFIX}-memory-fuse:${IMAGE_TAG}"
+              value: "${PLATFORM_IMAGE_PREFIX}-memory-fuse:${IMAGE_TAG}"
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/self-host/manifests/sandbox-service.yaml
+++ b/self-host/manifests/sandbox-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: sandbox
-          image: ${REGISTRY}/${APP_PREFIX}-sandbox:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-sandbox:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3006

--- a/self-host/manifests/scheduler.yaml
+++ b/self-host/manifests/scheduler.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: scheduler
-          image: ${REGISTRY}/${APP_PREFIX}-scheduler:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-scheduler:${IMAGE_TAG}
           imagePullPolicy: Always
           env:
             - name: POSTGRES_PASSWORD

--- a/self-host/manifests/seed-admin-job.yaml
+++ b/self-host/manifests/seed-admin-job.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-admin.js"]
           args:
             - "--username"

--- a/self-host/manifests/seed-mcp-job.yaml
+++ b/self-host/manifests/seed-mcp-job.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-mcp-catalog-core.js"]
           env:
             - name: POSTGRES_PASSWORD

--- a/self-host/manifests/seed-oauth-clients-job.yaml
+++ b/self-host/manifests/seed-oauth-clients-job.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: ${REGISTRY}/${APP_PREFIX}-cp:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-oauth-clients.js"]
           env:
             - name: POSTGRES_PASSWORD

--- a/self-host/manifests/skills-content-service.yaml
+++ b/self-host/manifests/skills-content-service.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: skills-content-service
-          image: ${REGISTRY}/${APP_PREFIX}-skills-content-service:${IMAGE_TAG}
+          image: ${PLATFORM_IMAGE_PREFIX}-skills-content-service:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 3008

--- a/self-host/values.env.example
+++ b/self-host/values.env.example
@@ -21,6 +21,10 @@ REGISTRY=ghcr.io/neutree-ai/agent-platform
 # Tag applied to every first-party image. Default "latest"; pin to a release
 # tag (e.g. v4.2.0) for a reproducible install.
 IMAGE_TAG=latest
+# First-party image prefix, decoupled from the k8s object-name prefix. Defaults
+# to ${REGISTRY}/${APP_PREFIX} — only set this when an existing install keeps
+# its historical APP_PREFIX for object names but pulls the public nap-* images:
+# PLATFORM_IMAGE_PREFIX=ghcr.io/neutree-ai/agent-platform/nap
 
 # Registry authentication. Leave blank for a public / anonymous registry. When
 # your registry requires a login, set all three: the installer creates a


### PR DESCRIPTION
## What

Adds `PLATFORM_IMAGE_PREFIX` — the registry path prefix for first-party images — defaulting to `${REGISTRY}/${APP_PREFIX}`, so rendering is **byte-identical** for every existing install (verified by rendering all manifests old-vs-new with defaults). Manifests reference first-party images through it; `AGENT_IMAGE_PREFIX` defaults to `${PLATFORM_IMAGE_PREFIX}-agent`.

## Why

`APP_PREFIX` currently couples two things: k8s object names and image sub-path names. An existing install cannot rename its objects (the PG cluster's name is part of its identity — renaming means a new empty cluster), which locked any install with a historical prefix out of consuming the public `nap-*` GHCR images. With this change such an install sets:

```
PLATFORM_IMAGE_PREFIX=ghcr.io/neutree-ai/agent-platform/nap
```

and keeps its object names while pulling public images.

## Guard

`check_app_prefix` now dies on the *resolved image prefix* pointing a non-nap prefix at the default public registry, instead of on `REGISTRY` alone, and its message explains the new escape hatch. The existing-install prefix-change guard is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X14c9sp4KoQdqemUKfPt8