### PR TITLE
fix(web): unreadable warning callouts in light theme

### DIFF
--- a/web/src/components/dialogs/SkillFormFields.tsx
+++ b/web/src/components/dialogs/SkillFormFields.tsx
@@ -751,7 +751,7 @@ function CandidatePicker({
   const { t } = useTranslation()
   if (candidates.length === 0) {
     return (
-      <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+      <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
         {t('components.library.skills.scan.empty')}
       </div>
     )

--- a/web/src/components/dialogs/SkillShareDialog.tsx
+++ b/web/src/components/dialogs/SkillShareDialog.tsx
@@ -223,7 +223,7 @@ export function SkillShareDialog({ skill, open, onOpenChange }: SkillShareDialog
           )}
 
           {blockedByOthers && dependents && (
-            <div className="rounded-md border border-warning/40 bg-warning/10 p-2 text-tiny text-warning-foreground">
+            <div className="rounded-md border border-warning/40 bg-warning/10 p-2 text-tiny text-warning">
               {t('components.skillShare.narrowWarning', {
                 count: dependents.other_workspace_count,
               })}


### PR DESCRIPTION
## Problem

The skill share dialog's "cannot narrow visibility" warning (and the skill scan empty-state notice) use `text-warning-foreground` on a `bg-warning/10` tinted background. `--warning-foreground` is white in both themes — it's the pairing for **solid** warning backgrounds (e.g. badges). On the 10% tint it renders white-on-light-amber in light theme and is unreadable.

## Fix

Switch both callouts to `text-warning`, which is what every other `bg-warning/10` callout in the codebase already uses (CreateTokenDialog, SecretReveal, ApplicationDialog, etc.). These were the only two occurrences of the wrong token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K762iUYkEGXuhbwjFGKYf1