### PR TITLE
feat(skills): allow owners to rename skills from the edit dialog

### DIFF
--- a/control-plane/src/services/skills-service.test.ts
+++ b/control-plane/src/services/skills-service.test.ts
@@ -417,6 +417,58 @@ describe('SkillsService.patchMeta', () => {
     })
     expect(h.repo._peekGrants().filter((g) => g.skill_id === skill.id)).toEqual([])
   })
+
+  it('owner rename delegates trimmed name to scs and enqueues dependent reload', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 'old-name' })
+    vi.mocked(scsPatchSkill).mockResolvedValue(ok({ skill: { ...skill, name: 'new-name' } }))
+
+    await h.service.patchMeta({ userId: 'alice', skillId: skill.id, name: '  new-name  ' })
+    expect(vi.mocked(scsPatchSkill)).toHaveBeenCalledWith(skill.id, {
+      name: 'new-name',
+      description: undefined,
+      visibility: undefined,
+      category: undefined,
+    })
+    expect(h.reloadQueue.calls).toEqual([skill.id])
+  })
+
+  it('unchanged name is a no-op: no rename write, no reload', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 's', description: 'old' })
+    vi.mocked(scsPatchSkill).mockResolvedValue(ok({ skill }))
+
+    await h.service.patchMeta({ userId: 'alice', skillId: skill.id, name: 's', description: 'new' })
+    expect(vi.mocked(scsPatchSkill)).toHaveBeenCalledWith(skill.id, {
+      name: undefined,
+      description: 'new',
+      visibility: undefined,
+      category: undefined,
+    })
+    expect(h.reloadQueue.calls).toEqual([])
+  })
+
+  it('rejects empty rename', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 's' })
+    await expect(
+      h.service.patchMeta({ userId: 'alice', skillId: skill.id, name: '   ' }),
+    ).rejects.toBeInstanceOf(InvalidInputError)
+    expect(vi.mocked(scsPatchSkill)).not.toHaveBeenCalled()
+  })
+
+  it('editor cannot rename (owner-only)', async () => {
+    const h = setup()
+    h.repo.seedUser({ id: 'bob', display_name: 'Bob' })
+    seedTeam(h.repo, { id: 't', name: 'T' }, ['alice', 'bob'])
+    const { skill } = seedSkill(h.repo, { userId: 'bob', name: 's', visibility: 'team' })
+    await h.repo.setSkillGrants(skill.id, [{ team_id: 't', permission: 'editor' }], 'bob')
+
+    await expect(
+      h.service.patchMeta({ userId: 'alice', skillId: skill.id, name: 'renamed' }),
+    ).rejects.toBeInstanceOf(NotAllowedError)
+    expect(vi.mocked(scsPatchSkill)).not.toHaveBeenCalled()
+  })
 })
 
 // ── tests: remove ──────────────────────────────────────────────────────────

--- a/control-plane/src/services/skills-service.ts
+++ b/control-plane/src/services/skills-service.ts
@@ -450,6 +450,17 @@ export class SkillsService {
       throw new NotAllowedError('Only the owner can change visibility or grants')
     }
 
+    // Rename is owner-only: the name keys the mounted directory in every
+    // dependent workspace, so an editor rename would ripple far beyond the
+    // content-edit rights they were granted.
+    let nextName: string | undefined
+    if (input.name !== undefined) {
+      if (!isOwner) throw new NotAllowedError('Only the owner can rename a skill')
+      const trimmed = input.name.trim()
+      if (!trimmed) throw new InvalidInputError('Skill name cannot be empty')
+      if (trimmed !== existing.name) nextName = trimmed
+    }
+
     const nextVisibility = input.visibility
     const effectiveVisibility = nextVisibility ?? existing.visibility
     const nextGrants = input.grants
@@ -476,14 +487,23 @@ export class SkillsService {
       await this.assertOwnTeams(input.userId, nextGrants)
     }
 
-    // scs owns the skills row write — delegate.
+    // scs owns the skills row write — delegate. (`nextName` is undefined when
+    // the name is unchanged, keeping the write — and the reload below — a
+    // no-op for pure description/category edits.)
     const result = await scsPatchSkill(input.skillId, {
-      name: input.name,
+      name: nextName,
       description: input.description,
       visibility: nextVisibility,
       category: input.category,
     })
     this.unwrap(result)
+
+    // Dependent workspaces mount the skill under a directory keyed by its
+    // name — fan out a reload so running agents drop the old directory and
+    // fetch the new one.
+    if (nextName !== undefined) {
+      await this.notifyAffectedWorkspaces(input.skillId)
+    }
 
     if (isOwner && nextGrants !== undefined) {
       await this.repo.setSkillGrants(input.skillId, nextGrants, input.userId)

--- a/web/src/components/dialogs/SkillFormFields.tsx
+++ b/web/src/components/dialogs/SkillFormFields.tsx
@@ -120,8 +120,9 @@ interface SkillFormFieldsProps {
   form: SkillFormState
   setForm: (next: (prev: SkillFormState) => SkillFormState) => void
   credentials: ApiCredentialMeta[]
-  /** Set when this is the edit flow — locks the name, makes the file
-   *  optional ("keep current"), and shows the git last-synced banner. */
+  /** Set when this is the edit flow — locks the name for non-owners, makes
+   *  the file optional ("keep current"), and shows the git last-synced
+   *  banner. */
   editingSkill?: ApiSkill | null
   /** Resolved source for `editingSkill`. Required when `editingSkill.source_id`
    *  points at a `kind='git'` row so the git fields can be prefilled and the
@@ -147,6 +148,10 @@ export function SkillFormFields({
 }: SkillFormFieldsProps) {
   const { t } = useTranslation()
   const isEditing = !!editingSkill
+  // Renaming propagates to every workspace that mounts the skill (the name
+  // keys the mounted directory), so the field stays locked for editors —
+  // only the owner can rename. Server enforces the same rule.
+  const nameLocked = isEditing && editingSkill?.my_permission !== 'owner'
   // p3: a skill's "origin kind" lives on its source row, not the skill row.
   // While the source is still loading we conservatively assume native
   // (single-mode UI) — it'll re-render with the toggle once the source lands.
@@ -548,7 +553,7 @@ export function SkillFormFields({
                   value={form.name}
                   onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
                   placeholder={t('components.library.skills.placeholders.autoDetectedName')}
-                  disabled={isEditing}
+                  disabled={nameLocked}
                 />
               </Field>
               <Field
@@ -580,7 +585,7 @@ export function SkillFormFields({
               value={form.name}
               onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
               placeholder={t('components.library.skills.placeholders.name')}
-              disabled={isEditing}
+              disabled={nameLocked}
             />
           </Field>
           <Field

--- a/web/src/components/library/SkillsSection.tsx
+++ b/web/src/components/library/SkillsSection.tsx
@@ -277,10 +277,18 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
         })
         // Category isn't part of the from-git body — server doesn't take it
         // on insert. Fold it into a follow-up PATCH when the user picked one
-        // that differs from what the row already has.
+        // that differs from what the row already has. Same for rename on
+        // re-import: from-git keeps the existing row's name, so a changed
+        // name goes through the meta PATCH (owner-only, server-enforced).
         const catPatch = categoryPatch(imported.category)
-        if (catPatch !== undefined) {
-          await updateMeta.mutateAsync({ id: imported.id, meta: { category: catPatch } })
+        const nextName = form.name.trim()
+        const namePatch =
+          editingSkill && nextName && nextName !== imported.name ? nextName : undefined
+        if (catPatch !== undefined || namePatch !== undefined) {
+          await updateMeta.mutateAsync({
+            id: imported.id,
+            meta: { category: catPatch, name: namePatch },
+          })
         }
         setDialogOpen(false)
         toast.success(
@@ -337,9 +345,14 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
     try {
       if (editingSkill) {
         const catPatch = categoryPatch(editingSkill.category)
+        // Rename rides the same meta PATCH (owner-only, server-enforced).
+        // Patch before any re-upload: upload upserts by (user_id, name), so
+        // it must see the new name or it would fork a second skill.
+        const nextName = form.name.trim()
+        const namePatch = nextName && nextName !== editingSkill.name ? nextName : undefined
         await updateMeta.mutateAsync({
           id: editingSkill.id,
-          meta: { description: form.description, category: catPatch },
+          meta: { name: namePatch, description: form.description, category: catPatch },
         })
         if (form.file) {
           // p3 dropped the per-skill `PUT /skills/:name` re-upload endpoint.
@@ -348,7 +361,7 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
           // which upserts by (user_id, name) and creates a fresh version.
           const buf = await form.file.arrayBuffer()
           await upload.mutateAsync({
-            name: editingSkill.name,
+            name: namePatch ?? editingSkill.name,
             description: form.description,
             buffer: buf,
             visibility: editingSkill.visibility,


### PR DESCRIPTION
## Summary

Users had no way to rename a skill — the workaround was "create new + migrate workspaces + delete old". The `PATCH /skills/:id` API already accepted `name` (with a per-user unique constraint surfacing as 409), but the edit dialog kept the field locked, and nothing propagated a rename to dependent workspaces (agent-side skill directories are keyed by name).

### control-plane
- `patchMeta` validates rename: **owner-only** (editors keep description/category), non-empty after trim, no-op when unchanged
- On an actual name change, enqueues the dependent-workspace reload fanout so running agents sweep the old-name directory and fetch the new one (same mechanism as version switches)

### web
- Edit dialog unlocks the name field for owners (native and git modes; stays locked for editors — server enforces the same rule)
- Native save patches the name via meta PATCH **before** any package re-upload, which upserts by `(user_id, name)` and would otherwise fork a second skill under the old name
- Git re-import keeps the existing row's name server-side, so a changed name is applied via a follow-up meta PATCH (same pattern as category)

### Notes
- The agent-visible skill name still comes from `SKILL.md` frontmatter inside the package; renaming platform-side does not rewrite package contents. Syncing frontmatter for native skills could be a follow-up.

## Test plan
- [x] 4 new unit tests in `skills-service.test.ts` (owner rename + reload enqueue, unchanged-name no-op, empty rename rejected, editor rename rejected) — 79/79 pass
- [x] `tsc --noEmit` clean in control-plane and web; biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gue9EQS8orvFjdQHdrKdM