### PR TITLE
fix(workspaces): don't seed user default prompt into template-created workspaces

### DIFF
--- a/control-plane/src/routes/workspaces/write.ts
+++ b/control-plane/src/routes/workspaces/write.ts
@@ -111,7 +111,12 @@ write.openapi(createRouteDef, async (c) => {
     }
 
     const ownerId = isSystem ? 'system' : currentUser.sub
-    const workspace = await createWorkspace(ownerId, body.name, agentType, isSystem)
+    // Template-created workspaces take their prompt from the template —
+    // seeding the user's default prompt would shadow it (workspace-level
+    // values win in config resolution).
+    const workspace = await createWorkspace(ownerId, body.name, agentType, isSystem, {
+      seedDefaultPrompt: !body.template_id,
+    })
 
     if (body.template_id && templateLatestVersion !== undefined) {
       await updateWorkspaceConfig(workspace.id, {

--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -6,7 +6,9 @@ export async function createWorkspace(
   name: string,
   agentType = 'claude-code',
   isSystem = false,
+  opts: { seedDefaultPrompt?: boolean } = {},
 ): Promise<Workspace> {
+  const { seedDefaultPrompt = true } = opts
   const client = await pool.connect()
   try {
     await client.query('BEGIN')
@@ -16,13 +18,19 @@ export async function createWorkspace(
       [id, userId, name, isSystem],
     )
 
-    // Resolve default system prompt from user's default prompt (if set)
-    const { rows: dpRows } = await client.query(
-      `SELECT p.id, p.content FROM users u
-       LEFT JOIN prompts p ON u.default_prompt_id = p.id
-       WHERE u.id = $1`,
-      [userId],
-    )
+    // Resolve default system prompt from user's default prompt (if set).
+    // Skipped for template-created workspaces: config resolution prefers
+    // workspace-level values, so a seeded default would shadow the
+    // template's prompt (or fill in one the template deliberately left
+    // empty).
+    const { rows: dpRows } = seedDefaultPrompt
+      ? await client.query(
+          `SELECT p.id, p.content FROM users u
+           LEFT JOIN prompts p ON u.default_prompt_id = p.id
+           WHERE u.id = $1`,
+          [userId],
+        )
+      : { rows: [] }
     const defaultPrompt = dpRows[0]?.id ? dpRows[0] : null
     const promptId = defaultPrompt ? defaultPrompt.id : null
 

--- a/web/src/components/library/PromptsSection.tsx
+++ b/web/src/components/library/PromptsSection.tsx
@@ -39,10 +39,10 @@ import {
   Globe,
   Lock,
   Pencil,
+  Pin,
   Plus,
   RotateCcw,
   Share2,
-  Star,
   Trash2,
   Users,
 } from 'lucide-react'
@@ -310,7 +310,9 @@ export function PromptsSection({ instanceId }: { instanceId: string }) {
                   onSelect={() => handleSelect(p.id)}
                   leading={
                     user?.default_prompt_id === p.id ? (
-                      <Star className="h-3 w-3 fill-warning text-warning" />
+                      // Pin (not Star) marks the default prompt — the star is
+                      // reserved platform-wide for favorites (e.g. sessions).
+                      <Pin className="h-3 w-3 fill-primary/25 text-primary" />
                     ) : (
                       <VisIcon className="h-3 w-3 text-muted-foreground/60" />
                     )
@@ -479,19 +481,19 @@ export function PromptsSection({ instanceId }: { instanceId: string }) {
                   size="icon"
                   className={`h-7 w-7 hover:text-foreground ${
                     user?.default_prompt_id === selectedPrompt.id
-                      ? 'text-warning'
+                      ? 'text-primary'
                       : 'text-muted-foreground'
                   }`}
                   onClick={() => handleToggleDefault(selectedPrompt.id)}
                   title={
                     user?.default_prompt_id === selectedPrompt.id
-                      ? t('components.library.prompts.toasts.defaultCleared')
-                      : t('components.library.prompts.toasts.defaultSet')
+                      ? t('components.library.prompts.actions.clearDefault')
+                      : t('components.library.prompts.actions.setDefault')
                   }
                 >
-                  <Star
+                  <Pin
                     className={`h-3.5 w-3.5 ${
-                      user?.default_prompt_id === selectedPrompt.id ? 'fill-current' : ''
+                      user?.default_prompt_id === selectedPrompt.id ? 'fill-primary/25' : ''
                     }`}
                   />
                 </Button>

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -761,7 +761,9 @@
           "delete": "Delete",
           "fork": "Fork",
           "createNew": "Create new prompt",
-          "rollbackTo": "Rollback to v{{version}}"
+          "rollbackTo": "Rollback to v{{version}}",
+          "setDefault": "Set as default prompt for new workspaces",
+          "clearDefault": "Clear default"
         },
         "empty": {
           "noPrompts": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -791,7 +791,9 @@
           "delete": "删除",
           "fork": "Fork",
           "createNew": "创建新 Prompt",
-          "rollbackTo": "回滚到 v{{version}}"
+          "rollbackTo": "回滚到 v{{version}}",
+          "setDefault": "设为新工作空间的默认 Prompt",
+          "clearDefault": "取消默认"
         },
         "empty": {
           "noPrompts": {


### PR DESCRIPTION
## Summary

Reported by a user: their template's prompt is empty, yet every workspace created from it came with a prompt filled in.

Root cause: `createWorkspace` always seeds the new workspace's config with the user's default prompt (`users.default_prompt_id`), and config resolution prefers workspace-level values over template values — so the seeded default **shadowed the template's prompt** (and filled in one on templates that deliberately left it empty).

- `createWorkspace` gains `opts.seedDefaultPrompt` (default `true`); the create route passes `false` when `template_id` is set, so template-created workspaces take their prompt purely from the template
- Blank-mode creation keeps the existing default-prompt behavior

### UI: default marker Star → Pin

The same user's follow-up: they had set the default prompt *by accident*, because the prompt library's default toggle is a star — and a star means "favorite" elsewhere (sessions). The default marker/toggle now uses a **Pin** with primary tint; the star stays reserved for favorites. Toggle tooltips get proper action labels (`setDefault`/`clearDefault` in both locales) instead of reusing toast strings.

## Test plan
- [x] `tsc --noEmit` clean in control-plane and web; biome clean; cp service tests 153/153
- [x] Verified against prod data that the reported workspace's prompt matches the user's default prompt row (root-cause confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gue9EQS8orvFjdQHdrKdM