### PR TITLE
fix(jobs): stop selecting expire_in, removed in pg-boss v12

### DIFF
--- a/control-plane/e2e/jobs.test.ts
+++ b/control-plane/e2e/jobs.test.ts
@@ -6,7 +6,8 @@ async function waitForJobDone(wsId: string, jobId: string, maxWaitMs = 120_000) 
   const start = Date.now()
   while (Date.now() - start < maxWaitMs) {
     const job = await client.jobs.get(wsId, jobId)
-    if (job.status === 'completed' || job.status === 'failed') return job
+    // pg-boss calls it `state`, and reports cancelled jobs as terminal too.
+    if (job.state === 'completed' || job.state === 'failed' || job.state === 'cancelled') return job
     await new Promise((r) => setTimeout(r, 3000))
   }
   throw new Error(`Job ${jobId} did not complete within ${maxWaitMs}ms`)
@@ -49,16 +50,16 @@ describeEachCore('jobs', (agentType) => {
     expect(typeof job.id).toBe('string')
   })
 
-  // Blocked on neutree-ai/agent-platform#152 — GET /workspaces/:id/jobs answers
-  // 500 because listJobs selects `expire_in`, a column pg-boss v12 removed.
-  // Both tests below read that endpoint. Re-enable with the fix.
-  test.skip('list jobs contains created job', async () => {
+  test('list jobs contains created job', async () => {
     const job = await client.jobs.create(wsId, {
       prompt: 'Reply with: JOB_LIST_TEST',
       trigger: { type: 'manual' },
     })
     const jobs = await client.jobs.list(wsId)
-    expect(jobs.some((j) => j.id === job.id)).toBe(true)
+    const listed = jobs.find((j) => j.id === job.id)
+    expect(listed).toBeDefined()
+    // The queue payload carries the caller's platform token; it must not surface.
+    expect((listed?.data as { service_token?: string }).service_token).toBeUndefined()
   })
 
   test('get job matches', async () => {
@@ -70,13 +71,13 @@ describeEachCore('jobs', (agentType) => {
     expect(job.id).toBe(created.id)
   })
 
-  test.skip('wait for job completion', async () => {
+  test('wait for job completion', async () => {
     const created = await client.jobs.create(wsId, {
       prompt: 'Reply with: JOB_COMPLETE',
       trigger: { type: 'manual' },
     })
     const job = await waitForJobDone(wsId, created.id, 120_000)
-    expect(['completed', 'failed']).toContain(job.status as string)
+    expect(['completed', 'failed']).toContain(job.state as string)
   }, 300_000)
 
   test('create schedule', async () => {

--- a/control-plane/src/lib/jobs.ts
+++ b/control-plane/src/lib/jobs.ts
@@ -113,9 +113,18 @@ export async function cancelScheduleTimer(schedule: {
   }
 }
 
+/** Job payloads carry the requesting user's platform token so the worker can
+ *  act as them — strip it before anything leaves through the API. */
+function redactJobData<T>(data: T): T {
+  if (!data || typeof data !== 'object') return data
+  const { service_token: _token, ...rest } = data as unknown as JobData
+  return rest as T
+}
+
 /** Get a job by ID */
 export async function getJob(id: string) {
-  return boss.getJobById(QUEUE_NAME, id)
+  const job = await boss.getJobById<JobData>(QUEUE_NAME, id)
+  return job && { ...job, data: redactJobData(job.data) }
 }
 
 /** Find the job that produced a given session (if any) */
@@ -135,14 +144,17 @@ export async function listJobs(
   workspaceId: string,
   { limit = 50, offset = 0 }: { limit?: number; offset?: number } = {},
 ) {
+  // No expiry column here on purpose: pg-boss v12 renamed `expire_in` to
+  // `expire_seconds`, and it is a creation-time input knob (`expire_in_seconds`)
+  // rather than job state worth echoing back.
   const { rows } = await pool.query(
     `SELECT id, name, data, state, output, retry_count,
-            created_on, started_on, completed_on, expire_in
+            created_on, started_on, completed_on
      FROM pgboss.job
      WHERE name = $1 AND data->>'workspace_id' = $2
      ORDER BY created_on DESC
      LIMIT $3 OFFSET $4`,
     [QUEUE_NAME, workspaceId, limit, offset],
   )
-  return rows
+  return rows.map((row) => ({ ...row, data: redactJobData(row.data) }))
 }


### PR DESCRIPTION
Fixes #152.

## What was broken

`GET /api/workspaces/:id/jobs` answered 500 with `column "expire_in" does not exist` on every deployment — `listJobs` selected a column pg-boss dropped in v12 (it is `expire_seconds` now).

## Changes

- **Drop the expiry column from the SELECT** rather than renaming it. Expiry is a creation-time input knob (`expire_in_seconds` on job create), not job state worth echoing back.
- **Redact `service_token` from job payloads.** Job data carries the requesting user's platform token so the worker can act as them, and both read paths returned `data` verbatim — masked by the 500 on list, live on the detail endpoint. Verified against a deployed `pgboss.job` that stored payloads really do contain it.
- **Un-skip the two blocked e2e cases.** `waitForJobDone` polled `job.status`, which pg-boss never returns — the field is `state`, and `cancelled` is terminal too; that test would have hung for its full timeout even after the list fix.

## Scope check

Reviewed the other raw queries against `pgboss.job` for pre-v12 assumptions: `getJobBySessionId` (control-plane), `cleanupOrphanedWsSlots` (scheduler), and the `event_log` join (channel-gateway) all select columns that still exist in v12.

## Verification

`tsc --noEmit` and biome clean; the new SELECT runs against a live `pgboss.job`. The e2e suite needs a deployment, so it was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us9d3M3a3svyCEbT37CFoo