### PR TITLE
fix(k8s): disable service-link env injection on workspace pods

### DIFF
--- a/control-plane/src/services/__snapshots__/k8s-deployment-spec.test.ts.snap
+++ b/control-plane/src/services/__snapshots__/k8s-deployment-spec.test.ts.snap
@@ -6,7 +6,7 @@ exports[`buildDeploymentSpec golden master > afs enabled 1`] = `
   "kind": "Deployment",
   "metadata": {
     "annotations": {
-      "agent-platform/workspace-version": "6",
+      "agent-platform/workspace-version": "7",
     },
     "labels": {
       "app": "nap",
@@ -159,6 +159,7 @@ exports[`buildDeploymentSpec golden master > afs enabled 1`] = `
             ],
           },
         ],
+        "enableServiceLinks": false,
         "nodeSelector": undefined,
         "securityContext": {
           "fsGroup": 1000,
@@ -206,7 +207,7 @@ exports[`buildDeploymentSpec golden master > full: afs + memory + resources + no
   "kind": "Deployment",
   "metadata": {
     "annotations": {
-      "agent-platform/workspace-version": "6",
+      "agent-platform/workspace-version": "7",
     },
     "labels": {
       "app": "nap",
@@ -406,6 +407,7 @@ exports[`buildDeploymentSpec golden master > full: afs + memory + resources + no
             ],
           },
         ],
+        "enableServiceLinks": false,
         "imagePullSecrets": [
           {
             "name": "regcred",
@@ -468,7 +470,7 @@ exports[`buildDeploymentSpec golden master > memory-fuse enabled 1`] = `
   "kind": "Deployment",
   "metadata": {
     "annotations": {
-      "agent-platform/workspace-version": "6",
+      "agent-platform/workspace-version": "7",
     },
     "labels": {
       "app": "nap",
@@ -617,6 +619,7 @@ exports[`buildDeploymentSpec golden master > memory-fuse enabled 1`] = `
             ],
           },
         ],
+        "enableServiceLinks": false,
         "nodeSelector": undefined,
         "securityContext": {
           "fsGroup": 1000,
@@ -656,7 +659,7 @@ exports[`buildDeploymentSpec golden master > minimal: afs off, memory off, no no
   "kind": "Deployment",
   "metadata": {
     "annotations": {
-      "agent-platform/workspace-version": "6",
+      "agent-platform/workspace-version": "7",
     },
     "labels": {
       "app": "nap",
@@ -758,6 +761,7 @@ exports[`buildDeploymentSpec golden master > minimal: afs off, memory off, no no
             ],
           },
         ],
+        "enableServiceLinks": false,
         "nodeSelector": undefined,
         "securityContext": {
           "fsGroup": 1000,

--- a/control-plane/src/services/k8s-deployment-spec.test.ts
+++ b/control-plane/src/services/k8s-deployment-spec.test.ts
@@ -112,6 +112,23 @@ describe('buildWorkspacePodTemplate', () => {
     )
     expect(dep.spec?.template).toEqual(template)
   })
+
+  // Service-link env injection scales with the namespace's Service count, and
+  // every workspace adds one. Left on, bash's quadratic export-environment
+  // rebuild adds seconds to every external command the agent runs. Assert it
+  // explicitly rather than leaning on the golden master, which is easy to
+  // re-record away.
+  it('disables service-link env injection', () => {
+    const template = buildWorkspacePodTemplate(
+      labels,
+      'ws1',
+      'claude-code',
+      'nap-ws1-workspace',
+      undefined,
+      baseCfg,
+    )
+    expect(template.spec?.enableServiceLinks).toBe(false)
+  })
 })
 
 // Minimal Deployment shapes for the status/annotation readers. Cast through

--- a/internal/k8s-provider/workspace-spec.ts
+++ b/internal/k8s-provider/workspace-spec.ts
@@ -32,7 +32,16 @@ import { type K8sConfig, agentImageFor, defaultCfg } from './config'
 //     changed in buildDeploymentSpec without a version bump, so existing
 //     v5 Deployments kept the old 1s-timeout / no-startupProbe config and
 //     CrashLoopBackOff'd; bumping forces reconcile to rebuild them.
-export const CURRENT_TEMPLATE_VERSION = 6
+// v7: enableServiceLinks: false. kubelet was injecting the legacy Docker-link
+//     env vars for every Service in the namespace (~15 vars each). Since every
+//     workspace owns a Service, the env grew with the workspace count — at ~950
+//     Services that is ~15k vars / ~600KB, and bash rebuilds its export
+//     environment quadratically before every external command, so each shell
+//     tool call in every workspace paid a fixed ~3s (measured: `bash -c
+//     /bin/true` 2.9s vs 0.008s with a clean env; builtins and non-bash shells
+//     were unaffected, which is why it read as "workspace IO is slow"). Nothing
+//     consumes these vars — service discovery goes through DNS.
+export const CURRENT_TEMPLATE_VERSION = 7
 export const TEMPLATE_VERSION_ANNOTATION = 'agent-platform/workspace-version'
 export const MEMORY_FUSE_CONTAINER_NAME = 'memory-fuse'
 
@@ -217,6 +226,14 @@ export function buildWorkspacePodTemplate(
         fsGroup: 1000,
         fsGroupChangePolicy: 'OnRootMismatch',
       },
+      // Each workspace owns a Service, so the default service-link injection
+      // makes every workspace's environment grow with the total workspace
+      // count — and bash rebuilds its export environment quadratically before
+      // each external command, which turns into seconds of latency per agent
+      // shell call once the cluster has a few hundred workspaces. Nothing in
+      // the pod reads these vars; the agent resolves the control plane and the
+      // fuse sidecars by DNS / explicit env.
+      enableServiceLinks: false,
       nodeSelector: cfg.nodeSelector,
       ...(cfg.imagePullSecret ? { imagePullSecrets: [{ name: cfg.imagePullSecret }] } : {}),
       containers: [agentContainer, afsSidecar, memoryFuseSidecar].filter(


### PR DESCRIPTION
## Problem

A user reported "workspace IO is slow". It is not IO — it is process spawn, and it affects every workspace on the cluster.

kubelet injects the legacy Docker-link env vars for every Service in the namespace (~15 vars each). Every workspace owns a Service, so each workspace's environment grows with the **total** workspace count. At ~950 Services that is ~15k vars / ~600KB of environment.

bash rebuilds its export environment before every external command, and that rebuild is quadratic in the variable count — so the entire 600KB is re-processed on each spawn. Measured inside a workspace container (healthy pod, no CPU throttling):

| command | time |
| --- | --- |
| `/bin/true` (direct exec) | 0.008s |
| `bash -c ":"` (builtin, no external command) | 0.029s |
| `bash -c "/bin/true"` | **2.911s** |
| `dash -c "/bin/true"` | 0.070s |
| `env -i bash -c "/bin/true"` | 0.010s |

Scaling, same container, synthetic environments:

```
     1000 vars   bash 0.031s   dash 0.006s
     2000 vars   bash 0.108s   dash 0.010s
     4000 vars   bash 0.432s   dash 0.021s
     8000 vars   bash 1.701s   dash 0.046s
    15243 vars   bash 6.397s   dash 0.094s     <- current cluster
```

Agents run their shell tool through bash, so **every** tool call paid a fixed ~3s floor unrelated to the command. In the reported session a 5KB file read took 47s and a full turn took 8.6 minutes; concurrent tool calls serialized into clean multiples of the floor (2 calls → 8s, 3 → 12s, 4 → 17s). The one fast call in the whole transcript was `pwd` — a bash builtin, no spawn.

This also explains why it is consistently misdiagnosed as a filesystem problem: file reads are what an agent retries when it stalls, and builtins stay fast, so every experiment points away from the real cause.

It is quadratic, so it gets worse on its own: ~950 workspaces → ~3s, ~1300 workspaces → ~6s.

## Fix

`enableServiceLinks: false` on the workspace pod spec. Nothing in the pod consumes those vars — the agent reaches the control plane and the fuse sidecars via DNS and explicit env.

`CURRENT_TEMPLATE_VERSION` bumps to 7 so reconcile rebuilds existing pods (they keep the old env until replaced).

## Test

- New explicit assertion that the pod template disables service links — the golden master alone is too easy to re-record away.
- Golden-master snapshots re-recorded; the only diffs are `enableServiceLinks: false` and the version annotation `6` → `7`.
- `control-plane`: 256 tests pass, `tsc --noEmit` clean.

## Note

Other pods in the same namespace (control plane, web, business services) inherit the same injection and pay a smaller version of this cost. Those come from deployment manifests rather than this code path, so they are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkJxN12ghQuEWcHWwQMHsg
