### PR TITLE
c10: workspace-scoped routing + reload fan-out (auto-scaling)

### DIFF
--- a/control-plane/src/lib/workspace-address.test.ts
+++ b/control-plane/src/lib/workspace-address.test.ts
@@ -5,12 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // resolveAgentAddress must stay identity-equal to getWorkspaceAddress for
 // every route context while workspaces are single-replica.
 
-const { getRemoteProxyPortMock } = vi.hoisted(() => ({
+const { getRemoteProxyPortMock, anyReadyReplicaMock, readyReplicaIdsMock } = vi.hoisted(() => ({
   getRemoteProxyPortMock: vi.fn<(workspaceId: string, replicaId?: number) => number | undefined>(),
+  anyReadyReplicaMock: vi.fn<(workspaceId: string) => number | undefined>(),
+  readyReplicaIdsMock: vi.fn<(workspaceId: string) => readonly number[]>(),
 }))
 
 vi.mock('./remote-proxy', () => ({
   getRemoteProxyPort: getRemoteProxyPortMock,
+}))
+
+vi.mock('../services/replica-router', () => ({
+  anyReadyReplica: anyReadyReplicaMock,
+  readyReplicaIds: readyReplicaIdsMock,
 }))
 
 import {
@@ -22,6 +29,8 @@ import {
 
 beforeEach(() => {
   getRemoteProxyPortMock.mockReturnValue(undefined)
+  anyReadyReplicaMock.mockReturnValue(undefined) // static: no ready replicas
+  readyReplicaIdsMock.mockReturnValue([])
 })
 
 afterEach(() => {
@@ -43,6 +52,14 @@ describe('getWorkspaceAddress', () => {
   it('resolves remote workspaces to their localhost forward proxy', () => {
     getRemoteProxyPortMock.mockReturnValue(41234)
     expect(getWorkspaceAddress('ws1')).toBe('http://127.0.0.1:41234')
+  })
+
+  it('resolves a built-in auto-scaling workspace (no replica) to any ready replica', () => {
+    // no ClusterIP Service exists → the bare name would not resolve; pick a ready one
+    anyReadyReplicaMock.mockReturnValue(1)
+    expect(getWorkspaceAddress('ws1')).toBe(
+      'http://tos-ws1-1.tos-ws1-hl.default.svc.cluster.local:3001',
+    )
   })
 })
 
@@ -110,5 +127,32 @@ describe('notifyAgentReload', () => {
 
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
     expect(await notifyAgentReload('ws1', ['config'])).toBe(false)
+  })
+
+  it('fans out to every ready replica of an auto-scaling workspace', async () => {
+    readyReplicaIdsMock.mockReturnValue([0, 1, 2])
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await notifyAgentReload('ws1', ['config'])).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const urls = fetchMock.mock.calls.map((c) => c[0])
+    expect(urls).toEqual([
+      'http://tos-ws1-0.tos-ws1-hl.default.svc.cluster.local:3001/reload-config',
+      'http://tos-ws1-1.tos-ws1-hl.default.svc.cluster.local:3001/reload-config',
+      'http://tos-ws1-2.tos-ws1-hl.default.svc.cluster.local:3001/reload-config',
+    ])
+  })
+
+  it('reports false when any replica in the fan-out fails (caller retries)', async () => {
+    readyReplicaIdsMock.mockReturnValue([0, 1])
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+      .mockResolvedValueOnce(new Response('err', { status: 500 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await notifyAgentReload('ws1', ['config'])).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/control-plane/src/lib/workspace-address.ts
+++ b/control-plane/src/lib/workspace-address.ts
@@ -1,4 +1,5 @@
 import { builtinReplicaAddress, defaultCfg } from '../../../internal/k8s-provider'
+import { anyReadyReplica, readyReplicaIds } from '../services/replica-router'
 import { getRemoteProxyPort } from './remote-proxy'
 
 /**
@@ -21,11 +22,19 @@ import { getRemoteProxyPort } from './remote-proxy'
  * through so a session-bound turn reaches its own replica; if that replica's
  * proxy isn't up yet (observe lag), the lookup misses and we fall through, which
  * fails fast rather than mis-routing the turn to another replica.
+ *
+ * With no `replicaId`, a workspace-scoped call (health, reload, usage, export):
+ * a static workspace resolves to its single Service (unchanged); a built-in
+ * auto-scaling one has NO ClusterIP Service — only per-ordinal headless DNS — so
+ * it resolves to any one ready replica (all share the volume). Falls back to the
+ * bare name only when no replica is ready (scaled to zero / not yet observed),
+ * where nothing is reachable anyway.
  */
 export function getWorkspaceAddress(workspaceId: string, replicaId?: number): string {
   const remotePort = getRemoteProxyPort(workspaceId, replicaId)
   if (remotePort !== undefined) return `http://127.0.0.1:${remotePort}`
-  return builtinReplicaAddress(defaultCfg, workspaceId, replicaId)
+  const id = replicaId ?? anyReadyReplica(workspaceId)
+  return builtinReplicaAddress(defaultCfg, workspaceId, id)
 }
 
 /**
@@ -74,16 +83,19 @@ const RELOAD_TIMEOUT_MS = 60_000
 /**
  * POST JSON to a running agent's endpoint with a timeout. Returns the Response,
  * or null if the agent is unreachable / timed out (caller decides what that
- * means). Shared by the reload and usage-pull paths.
+ * means). Shared by the reload and usage-pull paths. `replicaId` targets one
+ * replica of an auto-scaling workspace; omit it for a workspace-scoped call
+ * (any ready replica — usage reads the shared transcripts, so any answers).
  */
 export async function postToAgent(
   workspaceId: string,
   path: string,
   body: unknown,
   timeoutMs: number,
+  replicaId?: number,
 ): Promise<Response | null> {
   try {
-    return await fetch(`${getWorkspaceAddress(workspaceId)}${path}`, {
+    return await fetch(`${getWorkspaceAddress(workspaceId, replicaId)}${path}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -94,11 +106,30 @@ export async function postToAgent(
   }
 }
 
-/** Notify a running agent to reload specific scopes. Returns true if agent acknowledged. */
+/**
+ * Notify a running agent to reload specific scopes. Returns true if the agent
+ * acknowledged.
+ *
+ * A reload mutates the agent's IN-MEMORY config/skills/credentials cache, which
+ * — unlike the shared workspace volume — is per-process. So an auto-scaling
+ * workspace must reload EVERY ready replica, or the ones missed keep serving
+ * stale config. We fan out and require all to ack; a partial failure returns
+ * false so the caller (e.g. the skill-reload queue) retries. A static workspace
+ * has no ready set → the single default-address call, unchanged.
+ */
 export async function notifyAgentReload(
   workspaceId: string,
   scope: ReloadScope[],
 ): Promise<boolean> {
-  const resp = await postToAgent(workspaceId, '/reload-config', { scope }, RELOAD_TIMEOUT_MS)
-  return resp?.ok ?? false
+  const replicas = readyReplicaIds(workspaceId)
+  if (replicas.length === 0) {
+    const resp = await postToAgent(workspaceId, '/reload-config', { scope }, RELOAD_TIMEOUT_MS)
+    return resp?.ok ?? false
+  }
+  const results = await Promise.all(
+    replicas.map((id) =>
+      postToAgent(workspaceId, '/reload-config', { scope }, RELOAD_TIMEOUT_MS, id),
+    ),
+  )
+  return results.every((r) => r?.ok ?? false)
 }

--- a/control-plane/src/services/replica-router.ts
+++ b/control-plane/src/services/replica-router.ts
@@ -168,10 +168,28 @@ export function setDraining(workspaceId: string, ids: number[]): void {
 /**
  * The ready replica ids of a workspace, sorted ascending (empty for a static or
  * scaled-to-zero workspace). The autoscaler reads this to compute which ordinals
- * a scale-down would remove.
+ * a scale-down would remove; the address seam fans a reload out across it.
  */
 export function readyReplicaIds(workspaceId: string): readonly number[] {
   return readyReplicas.get(workspaceId) ?? []
+}
+
+/**
+ * Any one ready replica of a workspace to serve a workspace-scoped (no session
+ * affinity) call — health, config/skills reload, usage pull, file export. All
+ * replicas share the workspace volume, so any answers; a non-draining one is
+ * preferred so the pick doesn't land on a replica about to be removed. undefined
+ * for a static or scaled-to-zero workspace (the caller then uses the default
+ * address). This is what lets a built-in auto-scaling workspace — which has no
+ * ClusterIP Service, only per-ordinal headless DNS — be reached without a
+ * replica binding.
+ */
+export function anyReadyReplica(workspaceId: string): number | undefined {
+  const ready = readyReplicas.get(workspaceId)
+  if (!ready || ready.length === 0) return undefined
+  const draining = drainingReplicas.get(workspaceId)
+  if (!draining) return ready[0]
+  return ready.find((id) => !draining.has(id)) ?? ready[0]
 }
 
 /**


### PR DESCRIPTION
Stage c10 (was gap **B1**) of the auto-scaling series (→ `feat/auto-scaling-workspaces`). Fixes the workspace-scoped addressing hole that blocks a **built-in** auto-scaling workspace from being reachable at all for non-session calls.

## Problem
A built-in auto-scaling workspace has **no ClusterIP Service** — only per-ordinal headless DNS. Two consequences:
1. `getWorkspaceAddress(ws)` with no `replicaId` (health, config/skills/credentials reload, usage pull, file export, autostart `/health`) resolved to the bare `<prefix>-<ws>` name → doesn't resolve → every workspace-scoped call fails.
2. A reload hit **one** address; each replica is a separate process with its own in-memory config/skills/credentials cache, so the others stayed stale.

## Change
- **`replica-router`**: `anyReadyReplica(ws)` — a non-draining ready ordinal for a workspace-scoped call (shared volume → any answers).
- **`workspace-address`**: `getWorkspaceAddress(ws)` (no replicaId) resolves a built-in auto-scaling ws to any ready replica's per-ordinal DNS; remote already covered by `getRemoteProxyPort`'s any-replica fallback. `postToAgent` takes an optional `replicaId`.
- **`notifyAgentReload`**: **fans out to every ready replica**, all must ack; a partial failure returns false so the caller (skill-reload queue) retries.

usage pull needs no fan-out (shared transcripts → any replica returns all); autostart `/health` now lands on a ready replica once the address resolves.

## Dormant / safe
Static workspace → no ready set → `anyReadyReplica` undefined (bare DNS, unchanged) and `readyReplicaIds` empty (single reload call, unchanged). Byte-identical.

## Tests
`workspace-address.test.ts`: no-replica built-in auto-scaling resolves to a ready replica; reload fans out to all ready replicas; partial fan-out failure → false; static paths unchanged. cp unit suite: 269 passing. tsc/knip/biome clean.