### PR TITLE
B4: surface auto-scaling replica counts on status API

### DIFF
--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -7,6 +7,7 @@ import {
   ApiWorkspaceSchema,
 } from '../../../../internal/types/api'
 import type { AppEnv } from '../../lib/types'
+import { getWorkspaceReplicaStatus } from '../../services/db/env-placements'
 import { listAttachmentsForWorkspace } from '../../services/db/memory'
 import { getMessagesWithBlocks } from '../../services/db/messages'
 import { listSessions } from '../../services/db/sessions'
@@ -267,7 +268,12 @@ read.openapi(getStatusRoute, async (c) => {
     return c.json({ error: 'Workspace not found' }, 404)
   }
   try {
-    const status = await k8s.getInstanceStatus(workspace.id)
+    const [status, replicas] = await Promise.all([
+      k8s.getInstanceStatus(workspace.id),
+      // Auto-scaling replica counts come from the placement row, not the live-k8s
+      // read above (a StatefulSet workspace has no Deployment); null for static.
+      getWorkspaceReplicaStatus(workspace.id),
+    ])
     return c.json(
       {
         deployment: status.deployment.exists
@@ -281,6 +287,7 @@ read.openapi(getStatusRoute, async (c) => {
         pods: { total: status.pods.total, ready: status.pods.ready },
         warnings: status.warnings,
         conditions: status.conditions,
+        replicas,
       },
       200,
     )

--- a/control-plane/src/services/db/env-placements.ts
+++ b/control-plane/src/services/db/env-placements.ts
@@ -112,6 +112,31 @@ export async function listWorkspaceReplicaSets(): Promise<
   return rows
 }
 
+/**
+ * Ready/desired replica counts for an auto-scaling workspace, for the status
+ * API (e.g. rendering "running (2/3)"). `desired` is the autoscaler-owned
+ * `spec.replicas`; `ready` is how many the runner reports Ready
+ * (`endpoint.readyReplicaIds`). Returns null for a static workspace — its spec
+ * has no `runtimeMode: 'auto-scaling'` — so callers show replica counts only
+ * where they mean something. Uniform across built-in and remote (both write the
+ * same columns), so no live-k8s read is needed.
+ */
+export async function getWorkspaceReplicaStatus(
+  workspaceId: string,
+): Promise<{ ready: number; desired: number } | null> {
+  const { rows } = await pool.query(
+    `SELECT spec->>'runtimeMode' AS mode,
+            COALESCE((spec->>'replicas')::int, 0) AS desired,
+            COALESCE(jsonb_array_length(endpoint->'readyReplicaIds'), 0) AS ready
+       FROM workspace_placements
+      WHERE workspace_id = $1`,
+    [workspaceId],
+  )
+  const row = rows[0]
+  if (!row || row.mode !== 'auto-scaling') return null
+  return { ready: row.ready, desired: row.desired }
+}
+
 /** Remove a placement after destroy, scoped to the environment. */
 export async function deletePlacementForEnvironment(
   environmentId: string,

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -296,6 +296,11 @@ export const ApiK8sStatusSchema = z.object({
   conditions: z.array(
     z.object({ type: z.string(), status: z.boolean(), message: z.string().optional() }),
   ),
+  // Auto-scaling workspaces only: how many replicas are Ready vs desired, for a
+  // "running (ready/desired)" display. Sourced from the placement row (uniform
+  // for built-in and remote), not from the live-k8s Deployment read above, which
+  // an auto-scaling (StatefulSet) workspace has none of. Omitted for static.
+  replicas: z.object({ ready: z.number().int(), desired: z.number().int() }).nullable().optional(),
 })
 
 export type ApiK8sStatus = z.infer<typeof ApiK8sStatusSchema>


### PR DESCRIPTION
Stage **B4** of the auto-scaling series. Stacked on **c10** (#178) — review after it. → base retargets to `feat/auto-scaling-workspaces` once c10 merges.

## What
The workspace status endpoint (`GET /workspaces/{id}/status`) reported deployment/pod counts from a live-k8s read. An auto-scaling workspace has **no Deployment** (it's a StatefulSet), so there was no way to see replica health. Adds a `replicas: {ready, desired}` field:
- `desired` = autoscaler-owned `spec.replicas`
- `ready` = `endpoint.readyReplicaIds` length (what the runner reports Ready)
- sourced from the **placement row** (uniform built-in + remote), not live k8s
- **null / omitted for a static workspace** → existing responses byte-unchanged

This is the API side of "running (2/3)". No UI this round (deliberately API-only for internal testing), so it lands as a status-API field for manual inspection / scripts.

## Files
- `db/env-placements.ts`: `getWorkspaceReplicaStatus(ws)` — returns `{ready, desired}` only when `spec.runtimeMode = 'auto-scaling'`, else null.
- `routes/workspaces/read.ts`: status route includes `replicas` (fetched in parallel with the k8s read).
- `internal/types/api.ts`: `ApiK8sStatusSchema.replicas` optional nullable.

## Tests
Query-only addition (DB queries aren't unit-tested in this package's unit mode). tsc / knip / biome clean; full cp unit suite 269 passing.