### PR TITLE
B3: concurrent-safe shared-home skill install (auto-scaling cold-start)

### DIFF
--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -35,9 +35,14 @@ function createMemFs(): Fs & {
       return Buffer.isBuffer(content) ? content : Buffer.from(content)
     },
     async rm(path) {
+      // Recursive, matching node's rm({ recursive: true, force: true }).
       files.delete(path)
       dirs.delete(path)
       symlinks.delete(path)
+      const prefix = path.endsWith('/') ? path : `${path}/`
+      for (const k of [...files.keys()]) if (k.startsWith(prefix)) files.delete(k)
+      for (const d of [...dirs]) if (d.startsWith(prefix)) dirs.delete(d)
+      for (const s of [...symlinks]) if (s.startsWith(prefix)) symlinks.delete(s)
     },
     async readdir(path) {
       const prefix = path.endsWith('/') ? path : `${path}/`
@@ -177,10 +182,11 @@ describe('SkillManager', () => {
       const tarCall = shell.calls.find((c) => c.cmd === 'tar' && c.args[0] === 'xzf')
       expect(tarCall).toBeTruthy()
       expect(tarCall!.args[1]).toMatch(/\/tmp\/skill-my-skill\.staging-.+\/\.skill\.tar\.gz$/)
-      // Symlink points at the canonical localDir after the staging swap.
+      // Symlink points at the canonical localDir after the staging swap, created
+      // idempotently with `ln -sfn` so concurrent replicas don't race rm/ln.
       expect(shell.calls).toContainEqual({
         cmd: 'ln',
-        args: ['-s', '/tmp/skill-my-skill', '/workspace/.claude/skills/my-skill'],
+        args: ['-sfn', '/tmp/skill-my-skill', '/workspace/.claude/skills/my-skill'],
       })
     })
 
@@ -711,6 +717,90 @@ describe('SkillManager draft persistence (draftBase)', () => {
     const tarCall = shell.calls.find((c) => c.cmd === 'tar' && c.args[0] === 'xzf')
     expect(tarCall!.args[1]).toMatch(/^\/tmp\/skill-done\.staging-/)
     expect(result.loaded).toEqual(['done'])
+  })
+
+  // installPlatformSkill runs on every agent boot. Under auto-scaling, N replicas
+  // boot in parallel and install into the SAME shared skillsDir, so it must be
+  // idempotent and never expose a half-written tree.
+  describe('installPlatformSkill (concurrent-safe)', () => {
+    const DEST = `${SKILLS_DIR}/__platform__`
+    const VER = `${SKILLS_DIR}/.__platform__.version`
+    const mgr = () =>
+      createManager(async () => {
+        throw new Error('installPlatformSkill must not fetch')
+      })
+
+    test('installs the tree, locks it readonly, and records a version', async () => {
+      await mgr().installPlatformSkill({ 'SKILL.md': 'body', 'ref/a.md': 'A' })
+      expect(fs.files.get(`${DEST}/SKILL.md`)).toBe('body')
+      expect(fs.files.get(`${DEST}/ref/a.md`)).toBe('A')
+      expect(fs.files.get(VER)).toBeTruthy()
+      // The staged tree was chmod'd readonly before publishing.
+      expect(shell.calls.some((c) => c.cmd === 'chmod' && c.args.includes('a-w'))).toBe(true)
+      // No staging dir left behind.
+      expect([...fs.dirs].some((d) => d.includes('.__platform__.staging-'))).toBe(false)
+    })
+
+    test('is a no-op when the same version is already installed (idempotent skip)', async () => {
+      await mgr().installPlatformSkill({ 'SKILL.md': 'body' })
+      shell.calls.length = 0
+      const before = new Map(fs.files)
+      // A second replica with identical content agrees on the version and skips.
+      await mgr().installPlatformSkill({ 'SKILL.md': 'body' })
+      expect(shell.calls).toEqual([])
+      expect(fs.files).toEqual(before)
+    })
+
+    test('reinstalls and drops stale files when the content version changes', async () => {
+      await mgr().installPlatformSkill({ 'SKILL.md': 'v1', 'old.md': 'gone' })
+      const v1 = fs.files.get(VER)
+      await mgr().installPlatformSkill({ 'SKILL.md': 'v2' })
+      expect(fs.files.get(`${DEST}/SKILL.md`)).toBe('v2')
+      expect(fs.files.has(`${DEST}/old.md`)).toBe(false)
+      expect(fs.files.get(VER)).not.toBe(v1)
+    })
+
+    test('rejects a path-traversal entry', async () => {
+      await expect(mgr().installPlatformSkill({ '../evil': 'x' })).rejects.toThrow(
+        /Invalid platform skill path/,
+      )
+    })
+
+    test('discards its staging and does not throw when a racer publishes first', async () => {
+      // Model a sibling replica winning the publish: the rename into dest fails.
+      const realRename = fs.rename
+      fs.rename = async (from, to) => {
+        if (to === DEST) throw new Error('EEXIST: published by a racer')
+        return realRename(from, to)
+      }
+      await expect(mgr().installPlatformSkill({ 'SKILL.md': 'body' })).resolves.toBeUndefined()
+      expect([...fs.dirs].some((d) => d.includes('.__platform__.staging-'))).toBe(false)
+      expect([...fs.files.keys()].some((k) => k.includes('.__platform__.staging-'))).toBe(false)
+      fs.rename = realRename
+    })
+  })
+
+  // Pre-sweep must not delete a still-enabled skill's symlink just because THIS
+  // pod hasn't extracted its /tmp copy yet — under auto-scaling that symlink may
+  // belong to a sibling replica that is already serving it.
+  describe('pre-sweep (auto-scaling safe)', () => {
+    test('preserves an enabled skill’s symlink when this pod has no local copy', async () => {
+      // Sibling created skillsDir/foo → /tmp/skill-foo; here /tmp is empty, so it
+      // is dangling on this pod. foo stays enabled and its download fails this
+      // round — the symlink must survive rather than be swept.
+      fs.dirs.add(`${SKILLS_DIR}/foo`)
+      fs.symlinks.add(`${SKILLS_DIR}/foo`)
+      const fetchImpl = async (url: string) => {
+        if (url.includes('/workspaces/ws-1/skills'))
+          return jsonResponse({ skills: [{ name: 'foo', id: 'sk-foo' }] })
+        if (url.includes('/_cp/skills/sk-foo/package')) return errorResponse(500)
+        if (url.includes('/_cp/skills')) return jsonResponse([{ name: 'foo' }])
+        throw new Error(`Unexpected fetch: ${url}`)
+      }
+      const result = await createManager(fetchImpl).load()
+      expect(result.failed).toEqual(['foo'])
+      expect(fs.symlinks.has(`${SKILLS_DIR}/foo`)).toBe(true)
+    })
   })
 })
 

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -360,6 +360,8 @@ export class SkillManager {
     // 2. Ensure skillsDir exists
     await this.fs.mkdir(this.skillsDir)
 
+    const enabledSet = new Set(skills)
+
     // 3. Pre-sweep dangling symlinks on the NFS skillsDir.
     // After a pod restart /tmp is wiped, leaving every dest → localBase symlink
     // dangling. Removing them up front means a download failure later won't
@@ -376,6 +378,14 @@ export class SkillManager {
         if (name.startsWith('.')) continue
         if (RESERVED_SKILL_NAMES.has(name)) continue
         if (this.isEditing(name)) continue
+        // Leave enabled skills alone: step 4 re-materialises each idempotently
+        // (`ln -sfn` to the canonical target). Sweeping it here would, under
+        // auto-scaling, delete a sibling replica's still-valid symlink just
+        // because THIS pod's /tmp hasn't extracted the content yet — churning
+        // (or, if this pod's download then fails, breaking) a skill the other
+        // replica already has. A dangling symlink left in place is harmless:
+        // listLocal() filters it and readKnownEtag() forces a full re-download.
+        if (enabledSet.has(name)) continue
         // Only symlinks are ours to sweep here: a real directory at destDir is
         // user-created content (dropped in by hand, never registered), which
         // the orphan cleanup below also preserves. Deleting it would eat data.
@@ -458,7 +468,6 @@ export class SkillManager {
     // downloaded, never marked) are therefore never auto-removed; the worst a
     // missing marker can do is leave a disabled skill on disk (harmless, and
     // self-healing on the next restart's pre-sweep).
-    const enabledSet = new Set(skills)
     let onDisk: string[] = []
     try {
       onDisk = await this.fs.readdir(this.skillsDir)
@@ -616,11 +625,16 @@ export class SkillManager {
     await this.fs.rm(local)
     await this.fs.rename(staging, local)
 
-    // Refresh symlink (idempotent under ln -sfn would be nicer, but our Shell
-    // interface doesn't model flags; rm-then-ln is what we have).
+    // Refresh the shared-home symlink idempotently. `ln -sfn` replaces an
+    // existing link in place: -f overwrites, -n treats an existing
+    // symlink-to-dir as a file so we don't nest inside it. This matters for
+    // auto-scaling — several replicas materialise the SAME shared skillsDir
+    // entry at once, and a plain `rm(dest); ln -s` would race (one replica's
+    // `ln` hits a dest another just created → EEXIST → the skill fails → the pod
+    // crash-loops at boot). `ln -sfn` is safe to run concurrently: last writer
+    // wins, and every writer sets the identical canonical target.
     if (this.useSymlink) {
-      await this.fs.rm(dest)
-      await this.shell.exec('ln', ['-s', local, dest])
+      await this.shell.exec('ln', ['-sfn', local, dest])
     }
 
     // Record the version we just extracted so the next load can skip an
@@ -738,15 +752,43 @@ export class SkillManager {
   // ── Platform skill ──
 
   /**
+   * A deterministic content version of the platform files. Every replica of a
+   * workspace renders identical platform content (same workspace id / user /
+   * agent kind), so they compute the same version and converge on skipping a
+   * redundant reinstall. Non-cryptographic (djb2) is fine here: a collision only
+   * risks skipping an install of byte-different content, and the input is our own
+   * rendered templates, not adversarial.
+   */
+  private static platformVersion(files: Record<string, string>): string {
+    let h = 5381
+    for (const k of Object.keys(files).sort()) {
+      const s = `${k} ${files[k]} `
+      for (let i = 0; i < s.length; i++) h = (Math.imul(h, 33) + s.charCodeAt(i)) | 0
+    }
+    return (h >>> 0).toString(16)
+  }
+
+  /** Sidecar recording the installed platform version (beside dest, hidden). */
+  private platformVersionPath(): string {
+    return `${this.skillsDir}/.__platform__.version`
+  }
+
+  /**
    * Stamp the platform-managed `__platform__` skill onto disk. Caller passes a
-   * map of relative paths → content; SkillManager owns the lifecycle:
+   * map of relative paths → content; SkillManager owns the lifecycle.
    *
-   *   1. Sweep any prior install (chmod u+w to undo prior readonly, then rm)
-   *      so OSS bumps refresh cleanly.
-   *   2. Write each file (parent dirs first).
-   *   3. Lock the entire tree readonly via `chmod -R a-w` — files end at 0444,
-   *      directories at 0555. Defense in depth on top of the route-level
-   *      reserved-name guards.
+   * Safe for concurrent callers sharing one skillsDir (auto-scaling replicas all
+   * boot and install at once):
+   *   1. Idempotent skip — if the recorded version already matches, do nothing.
+   *      Since all replicas render identical content they agree on the version,
+   *      so all-but-one skip and no one races the shared tree in steady state.
+   *   2. Otherwise build the whole tree in a per-pid staging dir on the same
+   *      filesystem, lock it readonly, then publish with a single atomic rename —
+   *      a reader never sees a half-written `__platform__`. A racer that
+   *      published first is detected (rename throws) and its identical content is
+   *      trusted; ours is discarded.
+   *   3. The version sidecar is written last, so a crash mid-install never marks
+   *      a partial tree as current.
    *
    * The skill name is hard-coded (`__platform__`) — intentionally non-
    * parametric so the protection model stays unambiguous. Caller renders any
@@ -755,17 +797,25 @@ export class SkillManager {
   async installPlatformSkill(files: Record<string, string>): Promise<void> {
     const name = '__platform__'
     const dest = this.destDir(name)
+    const version = SkillManager.platformVersion(files)
+    const verPath = this.platformVersionPath()
 
-    // Undo readonly from a previous install (no-op if first run).
-    try {
-      await this.shell.exec('chmod', ['-R', 'u+w', dest])
-    } catch {
-      // Path may not exist yet — fine.
+    // 1. Idempotent skip: this exact version is already installed (by us on a
+    // prior boot, or by a sibling replica in this cold-start wave).
+    if (this.fs.exists(dest)) {
+      let installed: string | null = null
+      try {
+        installed = (await this.fs.readFile(verPath)).toString().trim()
+      } catch {
+        // No sidecar — fall through and (re)install.
+      }
+      if (installed === version) return
     }
-    await this.fs.rm(dest)
-    await this.fs.mkdir(dest)
 
-    // Write parent dirs first so nested paths land cleanly.
+    // 2. Stage the full tree on the same filesystem as dest.
+    const staging = `${this.skillsDir}/.__platform__.staging-${process.pid}-${Date.now()}`
+    await this.fs.rm(staging) // clear a leaked staging from a crashed prior boot
+    await this.fs.mkdir(staging)
     const sorted = Object.entries(files).sort(
       ([a], [b]) => a.split('/').length - b.split('/').length,
     )
@@ -775,13 +825,34 @@ export class SkillManager {
       }
       const slash = rel.lastIndexOf('/')
       if (slash !== -1) {
-        await this.fs.mkdir(`${dest}/${rel.slice(0, slash)}`)
+        await this.fs.mkdir(`${staging}/${rel.slice(0, slash)}`)
       }
-      await this.fs.writeFile(`${dest}/${rel}`, content)
+      await this.fs.writeFile(`${staging}/${rel}`, content)
+    }
+    // Lock the staged tree readonly before publishing (files 0444, dirs 0555).
+    await this.shell.exec('chmod', ['-R', 'a-w', staging])
+
+    // 3. Publish. Clear any prior install (undo its readonly lock first), then
+    // rename the staged tree into place. The rm→rename window is cold-start-only
+    // and pre-serving. A sibling replica that published between our skip-check
+    // and here makes the rename throw; its content is identical, so discard ours.
+    try {
+      if (this.fs.exists(dest)) {
+        await this.shell.exec('chmod', ['-R', 'u+w', dest]).catch(() => {})
+        await this.fs.rm(dest)
+      }
+      await this.fs.rename(staging, dest)
+    } catch {
+      await this.fs.rm(staging).catch(() => {})
     }
 
-    // Lock down: clears write for owner/group/other on every file + dir.
-    await this.shell.exec('chmod', ['-R', 'a-w', dest])
+    // 4. Record the version last (best-effort: a missing marker only costs a
+    // redundant reinstall next boot).
+    try {
+      await this.fs.writeFile(verPath, version)
+    } catch {
+      // Best-effort.
+    }
   }
 
   async pack(name: string): Promise<Buffer> {


### PR DESCRIPTION
Stage **B3** of the auto-scaling series (→ `feat/auto-scaling-workspaces`). Makes agent cold-start safe when N replicas boot in parallel against one shared RWX home. Approach **A** (atomic + idempotent, no cross-node lock) as agreed — NFS advisory locks are weak across nodes.

## The three shared-home races (all fixed)
1. **`installPlatformSkill`** wrote `__platform__` content directly into the shared `skillsDir` + `chmod -R a-w` → parallel writers interleave (partial tree) or hit EACCES mid-chmod.
   **Fix:** idempotent **version-skip** (all replicas render identical content → agree on version → all-but-one skip), else build in a **per-pid staging dir**, lock readonly, **publish with one atomic rename**; a racer that won is detected (rename throws) and trusted; version marker written last.
2. **`extractAtomic` symlink** did `rm(dest); ln -s` → concurrent `ln` hits a dest another replica just created → EEXIST → skill fails → **pod crash-loops at boot**.
   **Fix:** `ln -sfn` — idempotent, concurrency-safe (last writer wins, identical canonical target).
3. **Pre-sweep** removed a dangling symlink for an **enabled** skill when this pod's `/tmp` lacked the content → deletes a sibling replica's still-valid symlink (and breaks it if this pod's download then fails).
   **Fix:** leave enabled skills for step 4 to re-materialise idempotently; a dangling symlink is harmless (`listLocal` filters it, `readKnownEtag` forces re-download).

## Safety
Static single-replica behaviour is **byte-unchanged** (version-skip installs first time; `ln -sfn` same target; pre-sweep still cleans truly-orphaned symlinks).

## Tests (`internal/agent-skills/src/index.test.ts`, +6)
`installPlatformSkill`: install+lock+version, **idempotent skip**, version-bump reinstall (drops stale files), path-traversal reject, **racer publishes first → discard staging, no throw**. Pre-sweep: **enabled skill's symlink preserved** when this pod has no local copy and its download fails. Also made the in-memory fake fs `rm` recursive to match `node rm({recursive:true})`. 37 agent-skills tests pass; biome + knip clean; typechecks via the codex consumer.

## Manual testing (pending, with you)
Needs a real multi-replica cold-start: create an auto-scaling ws (min/max ≥ 2), watch all replicas boot in parallel, confirm `__platform__` + skills materialise on every replica without EACCES / crash-loop / missing-skill, and that an OSS platform-skill bump reinstalls cleanly.