### PR TITLE
fix(cp): project built-in auto-scaling workspace status from observed_phase

### DIFF
--- a/control-plane/src/lib/reconcile.ts
+++ b/control-plane/src/lib/reconcile.ts
@@ -5,9 +5,9 @@ import {
   listAllUserCredentials,
   listUsersWithDeletingCredentials,
 } from '../services/db/credentials'
-import { getRemoteWorkspaceIds } from '../services/db/environments'
+import { getAutoScalingWorkspaceIds, getRemoteWorkspaceIds } from '../services/db/environments'
 import { getWorkspace, listAllWorkspaces, updateWorkspace } from '../services/db/workspaces'
-import { runEnvProjection } from '../services/env-projection'
+import { projectBuiltinAutoScalingStatus, runEnvProjection } from '../services/env-projection'
 import { runIdleWorkspaceGC } from '../services/idle-workspace-gc'
 import * as k8s from '../services/k8s'
 import { refreshReplicaRouter } from '../services/replica-router'
@@ -44,11 +44,16 @@ async function fullReconcile(): Promise<string> {
     // Workspaces on remote environments have no Deployment in cp's cluster —
     // their status is driven by the env projection (observed + heartbeat), not
     // this watch-k8s path. Skip them so resolveDeploymentStatus(undefined) never
-    // clobbers a remote workspace to 'stopped'.
+    // clobbers a remote workspace to 'stopped'. Auto-scaling workspaces are the
+    // same case for a different reason: they are StatefulSets, so they have no
+    // Deployment here either — their status is projected from the runner's
+    // observed_phase (projectBuiltinAutoScalingStatus). Both sets are empty for a
+    // plain static workspace, so its watch-k8s status path is unchanged.
     const remoteIds = await getRemoteWorkspaceIds()
+    const autoScalingIds = await getAutoScalingWorkspaceIds()
 
     for (const ws of allWorkspaces) {
-      if (remoteIds.has(ws.id)) continue
+      if (remoteIds.has(ws.id) || autoScalingIds.has(ws.id)) continue
       // A workspace mid-delete (inverted remote delete) is being reaped by the
       // projection once its placement clears — don't let watch-k8s clobber its
       // 'deleting' status to 'stopped' (which would strand it unreaped).
@@ -188,6 +193,19 @@ export function startReconcileLoop() {
   new Cron(ENV_PROJECTION_INTERVAL, { protect: true }, () =>
     runEnvProjection(ENV_HEARTBEAT_TIMEOUT_SEC).catch((e) =>
       console.error('[Reconcile] env projection error:', e instanceof Error ? e.message : e),
+    ),
+  )
+
+  // Built-in auto-scaling status projection: drive workspace.status from the
+  // runner's observed_phase for built-in auto-scaling (StatefulSet) workspaces,
+  // which the watch-k8s Deployment reconcile skips. Same 15s cadence; a cheap
+  // no-op while none is auto-scaling, and never touches static workspaces.
+  new Cron(ENV_PROJECTION_INTERVAL, { protect: true }, () =>
+    projectBuiltinAutoScalingStatus().catch((e) =>
+      console.error(
+        '[Reconcile] auto-scaling status projection error:',
+        e instanceof Error ? e.message : e,
+      ),
     ),
   )
 

--- a/control-plane/src/services/db/environments.ts
+++ b/control-plane/src/services/db/environments.ts
@@ -125,6 +125,43 @@ export async function getRemoteWorkspaceIds(): Promise<Set<string>> {
   return new Set(rows.map((r) => r.workspace_id as string))
 }
 
+/**
+ * Ids of auto-scaling workspaces (auto_scaling config present). Like remote
+ * ones, these have no Deployment for the watch-k8s reconcile to read — they are
+ * StatefulSets — so that reconcile skips them and their status comes from the
+ * runner-reported observed_phase (see {@link listBuiltinAutoScalingObservations}).
+ * Only auto-scaling workspaces are returned, so a static workspace is never
+ * affected: it stays on the watch-k8s status path, unchanged.
+ */
+export async function getAutoScalingWorkspaceIds(): Promise<Set<string>> {
+  const { rows } = await pool.query(
+    'SELECT workspace_id FROM workspace_config WHERE auto_scaling IS NOT NULL',
+  )
+  return new Set(rows.map((r) => r.workspace_id as string))
+}
+
+/**
+ * Observed state of every built-in auto-scaling workspace, for projecting
+ * workspace.status from the runner's observed_phase — the built-in counterpart
+ * of {@link listRemoteWorkspaceObservations}, minus the heartbeat/offline logic
+ * (the built-in runner shares cp's cluster). Scoped to auto_scaling IS NOT NULL,
+ * so static workspaces are never returned.
+ */
+export async function listBuiltinAutoScalingObservations(): Promise<
+  { workspace_id: string; observed_phase: string | null }[]
+> {
+  const { rows } = await pool.query(
+    `SELECT p.workspace_id, p.observed_phase
+       FROM workspace_placements p
+       JOIN environments e ON e.id = p.environment_id
+       JOIN workspace_config wc ON wc.workspace_id = p.workspace_id
+      WHERE e.is_builtin = true
+        AND wc.auto_scaling IS NOT NULL
+        AND p.desired_phase <> 'deleted'`,
+  )
+  return rows
+}
+
 interface RemoteObservation {
   workspace_id: string
   environment_id: string

--- a/control-plane/src/services/env-projection.test.ts
+++ b/control-plane/src/services/env-projection.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// projectBuiltinAutoScalingStatus drives workspace.status for built-in
+// auto-scaling (StatefulSet) workspaces from the runner's observed_phase, since
+// the watch-k8s Deployment reconcile has no Deployment for them and skips them.
+
+vi.mock('./db/environments', () => ({ listBuiltinAutoScalingObservations: vi.fn() }))
+vi.mock('./db/workspaces', () => ({ getWorkspace: vi.fn(), deleteWorkspace: vi.fn() }))
+vi.mock('../lib/workspace-status', () => ({ applyStatusChange: vi.fn() }))
+vi.mock('../lib/remote-proxy', () => ({
+  ensureRemoteProxy: vi.fn(),
+  dropRemoteProxy: vi.fn(),
+  syncReplicaProxies: vi.fn(),
+}))
+
+import { applyStatusChange } from '../lib/workspace-status'
+import { listBuiltinAutoScalingObservations } from './db/environments'
+import { getWorkspace } from './db/workspaces'
+import { projectBuiltinAutoScalingStatus } from './env-projection'
+
+const obs = vi.mocked(listBuiltinAutoScalingObservations)
+const getWs = vi.mocked(getWorkspace)
+const apply = vi.mocked(applyStatusChange)
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('projectBuiltinAutoScalingStatus', () => {
+  it('projects observed_phase → status when it differs from the current status', async () => {
+    // The bug this fixes: watch-k8s marked the running StatefulSet ws 'stopped'.
+    obs.mockResolvedValue([{ workspace_id: 'ws1', observed_phase: 'running' }])
+    getWs.mockResolvedValue({ id: 'ws1', status: 'stopped' } as never)
+
+    await projectBuiltinAutoScalingStatus()
+
+    expect(apply).toHaveBeenCalledWith('ws1', 'running', 'stopped')
+  })
+
+  it('is a no-op when the status already matches (no needless resetAllSessionsIdle churn)', async () => {
+    obs.mockResolvedValue([{ workspace_id: 'ws1', observed_phase: 'running' }])
+    getWs.mockResolvedValue({ id: 'ws1', status: 'running' } as never)
+
+    await projectBuiltinAutoScalingStatus()
+
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('maps phases (stopped/pending/error/unknown) through the shared mapping', async () => {
+    obs.mockResolvedValue([
+      { workspace_id: 'a', observed_phase: 'stopped' },
+      { workspace_id: 'b', observed_phase: 'pending' },
+      { workspace_id: 'c', observed_phase: 'error' },
+      { workspace_id: 'd', observed_phase: null },
+    ])
+    getWs.mockImplementation(async (id) => ({ id, status: 'running' }) as never)
+
+    await projectBuiltinAutoScalingStatus()
+
+    expect(apply).toHaveBeenCalledWith('a', 'stopped', 'running')
+    expect(apply).toHaveBeenCalledWith('b', 'starting', 'running')
+    expect(apply).toHaveBeenCalledWith('c', 'error', 'running')
+    expect(apply).toHaveBeenCalledWith('d', 'unknown', 'running')
+  })
+
+  it('does nothing when no built-in workspace is auto-scaling (static-only cluster)', async () => {
+    obs.mockResolvedValue([])
+    await projectBuiltinAutoScalingStatus()
+    expect(getWs).not.toHaveBeenCalled()
+    expect(apply).not.toHaveBeenCalled()
+  })
+})

--- a/control-plane/src/services/env-projection.ts
+++ b/control-plane/src/services/env-projection.ts
@@ -1,6 +1,7 @@
 import { dropRemoteProxy, ensureRemoteProxy, syncReplicaProxies } from '../lib/remote-proxy'
 import { type WorkspaceStatus, applyStatusChange } from '../lib/workspace-status'
 import {
+  listBuiltinAutoScalingObservations,
   listReapableWorkspaces,
   listRemoteWorkspaceObservations,
   markStaleEnvironmentsOffline,
@@ -75,6 +76,26 @@ export async function runEnvProjection(thresholdSec: number): Promise<void> {
       }
     } else {
       dropRemoteProxy(o.workspace_id)
+    }
+  }
+}
+
+/**
+ * Project workspace.status for BUILT-IN auto-scaling workspaces from the runner's
+ * observed_phase. They are StatefulSets, so the watch-k8s Deployment reconcile
+ * has no Deployment for them and skips them (see reconcile.ts); without this they
+ * would be stuck / wrongly 'stopped'. This is the built-in analogue of the remote
+ * projection above, minus proxies/heartbeat (the built-in runner shares cp's
+ * cluster and reaches pods via cluster DNS). Cheap no-op while no built-in
+ * workspace is auto-scaling (the query returns nothing) — static workspaces are
+ * never selected, so their status path is untouched.
+ */
+export async function projectBuiltinAutoScalingStatus(): Promise<void> {
+  for (const o of await listBuiltinAutoScalingObservations()) {
+    const status = mapObservedToStatus(o.observed_phase)
+    const ws = await getWorkspace(o.workspace_id)
+    if (ws && ws.status !== status) {
+      await applyStatusChange(o.workspace_id, status, ws.status)
     }
   }
 }


### PR DESCRIPTION
## Problem (found via dogfooding)
A built-in **auto-scaling** workspace is a StatefulSet, so the watch-k8s reconcile — which reads **Deployments** — finds none for it and `resolveDeploymentStatus(undefined)` marks it **`stopped`**, even while its pods are Running and the runner reports `observed_phase='running'`. Remote workspaces already avoid this (they're skipped and projected from observed state); built-in auto-scaling fell between the two paths and had **no correct status source**.

Confirmed live: `workspace.status=stopped` vs `placement.observed_phase=running`, `readyReplicaIds=[0,1]`, StatefulSet 2/2 Running.

Impact: the wrong `stopped` makes `ensureWorkspaceRunning` treat every turn as a cold start (redundant scale bumps that can **fight the autoscaler**) and triggers a spurious `resetAllSessionsIdle`.

## Fix (mirrors the remote handling)
- **Skip** auto-scaling workspaces in the watch-k8s reconcile (`getAutoScalingWorkspaceIds`), exactly as remote ones are skipped — no more clobbering.
- **Project** their status from the placement's `observed_phase` via a new 15s cron `projectBuiltinAutoScalingStatus` (built-in analogue of `runEnvProjection`, minus proxies/heartbeat — the built-in runner shares cp's cluster).

## Static safety
Both the skip set and the projection query are scoped to `auto_scaling IS NOT NULL`. A static workspace is never in either → stays entirely on the existing watch-k8s Deployment status path, **byte-identical**.

## Tests
`env-projection.test.ts` (+4): projects on change, no-op when already matching (avoids reset churn), phase mapping (stopped/pending/error/unknown), and no-op when no built-in ws is auto-scaling. Full cp unit suite: 322 passing. tsc / knip / biome clean.