### PR TITLE
fix(skills): target git re-imports by id, and stop history blocking deletes

### DIFF
--- a/control-plane/src/routes/skills.ts
+++ b/control-plane/src/routes/skills.ts
@@ -515,6 +515,7 @@ skills.openapi(fromGitRoute, async (c) => {
       description: body.description,
       visibility: body.visibility ?? 'private',
       category: body.category ?? null,
+      skillId: body.skill_id,
     })
     return c.json(ownerSkillMetaToApi(skill), 201)
   } catch (e) {

--- a/control-plane/src/services/__tests__/in-memory-skill-repository.ts
+++ b/control-plane/src/services/__tests__/in-memory-skill-repository.ts
@@ -59,6 +59,9 @@ interface TeamRow {
 interface TemplateVersionRef {
   template_version_id: string
   skill_id: string
+  /** Version superseded by a newer one on the same template. Such rows are
+   *  history: they never block a delete, and remove() prunes them. */
+  superseded: boolean
 }
 
 export class InMemorySkillRepository implements SkillRepository {
@@ -86,8 +89,12 @@ export class InMemorySkillRepository implements SkillRepository {
   seedWorkspace(ws: Workspace): void {
     this.workspaces.set(ws.id, ws)
   }
-  seedTemplateVersionSkill(templateVersionId: string, skillId: string): void {
-    this.templateVersionSkills.push({ template_version_id: templateVersionId, skill_id: skillId })
+  seedTemplateVersionSkill(templateVersionId: string, skillId: string, superseded = false): void {
+    this.templateVersionSkills.push({
+      template_version_id: templateVersionId,
+      skill_id: skillId,
+      superseded,
+    })
   }
 
   /**
@@ -302,12 +309,20 @@ export class InMemorySkillRepository implements SkillRepository {
       if (sid === skillId) workspaceIds.push(wsId)
     }
     const templateVersionIds = this.templateVersionSkills
-      .filter((r) => r.skill_id === skillId)
+      .filter((r) => r.skill_id === skillId && !r.superseded)
       .map((r) => r.template_version_id)
     return {
       workspace_ids: workspaceIds,
       template_version_ids: templateVersionIds,
     }
+  }
+
+  async pruneSupersededTemplateRefs(skillId: string): Promise<number> {
+    const before = this.templateVersionSkills.length
+    this.templateVersionSkills = this.templateVersionSkills.filter(
+      (r) => !(r.skill_id === skillId && r.superseded),
+    )
+    return before - this.templateVersionSkills.length
   }
 
   async getSkillDependents(skillId: string, ownerId: string): Promise<SkillDependents> {
@@ -323,7 +338,7 @@ export class InMemorySkillRepository implements SkillRepository {
     }
     ownWorkspaces.sort((a, b) => a.name.localeCompare(b.name))
     const templateVersionCount = this.templateVersionSkills.filter(
-      (r) => r.skill_id === skillId,
+      (r) => r.skill_id === skillId && !r.superseded,
     ).length
     return {
       own_workspaces: ownWorkspaces,

--- a/control-plane/src/services/skill-repository.ts
+++ b/control-plane/src/services/skill-repository.ts
@@ -121,6 +121,7 @@ export interface SkillRepository {
 
   /** Pre-flight for DELETE: any workspace / template_version still using this skill? */
   getDeleteBlockers(skillId: string): Promise<SkillDeleteBlockers>
+  pruneSupersededTemplateRefs(skillId: string): Promise<number>
 
   /** Occupancy preview for the owner: own workspaces by name, others by count. */
   getSkillDependents(skillId: string, ownerId: string): Promise<SkillDependents>
@@ -174,6 +175,19 @@ const VERSION_COLS = `id, skill_id, source_id, content_hash, commit_sha, note,
  * category "uncategorized" is unambiguous (they'd pass the column's NULL).
  */
 export const UNCATEGORIZED_SENTINEL = 'uncategorized'
+
+/**
+ * Template versions that still reference a skill AND are the version their
+ * template currently hands out. Superseded versions are deliberately excluded:
+ * they are immutable history with no edit affordance in the UI, so counting
+ * them makes a skill permanently undeletable once any template ever used it.
+ * `remove()` clears those stale rows instead (they FK with RESTRICT).
+ */
+const CURRENT_TEMPLATE_REFS_SQL = `SELECT tvs.template_version_id
+   FROM template_version_skills tvs
+   JOIN template_versions tv ON tv.id = tvs.template_version_id
+   JOIN templates t ON t.id = tv.template_id AND t.latest_version = tv.version
+  WHERE tvs.skill_id = $1`
 
 export class PgSkillRepository implements SkillRepository {
   // ─── skills (read) ───────────────────────────────────────────────────────
@@ -396,18 +410,34 @@ export class PgSkillRepository implements SkillRepository {
   // ─── delete blockers ─────────────────────────────────────────────────────
 
   async getDeleteBlockers(skillId: string): Promise<SkillDeleteBlockers> {
+    // Only CURRENT template versions block — see CURRENT_TEMPLATE_REFS_SQL.
     const { rows: wsRows } = await pool.query(
       'SELECT workspace_id FROM workspace_skills WHERE skill_id = $1',
       [skillId],
     )
-    const { rows: tvRows } = await pool.query(
-      'SELECT template_version_id FROM template_version_skills WHERE skill_id = $1',
-      [skillId],
-    )
+    const { rows: tvRows } = await pool.query(CURRENT_TEMPLATE_REFS_SQL, [skillId])
     return {
       workspace_ids: wsRows.map((r) => r.workspace_id),
       template_version_ids: tvRows.map((r) => r.template_version_id),
     }
+  }
+
+  /**
+   * Drop a skill's rows from superseded template versions so the RESTRICT FK
+   * doesn't block the delete. Call only once getDeleteBlockers has cleared —
+   * the current version's row (if any) is left alone and would still block.
+   */
+  async pruneSupersededTemplateRefs(skillId: string): Promise<number> {
+    const { rowCount } = await pool.query(
+      `DELETE FROM template_version_skills tvs
+        USING template_versions tv, templates t
+        WHERE tvs.skill_id = $1
+          AND tv.id = tvs.template_version_id
+          AND t.id = tv.template_id
+          AND t.latest_version <> tv.version`,
+      [skillId],
+    )
+    return rowCount ?? 0
   }
 
   async getSkillDependents(skillId: string, ownerId: string): Promise<SkillDependents> {
@@ -424,14 +454,11 @@ export class PgSkillRepository implements SkillRepository {
         WHERE ws.skill_id = $1 AND w.user_id != $2`,
       [skillId, ownerId],
     )
-    const { rows: tvRows } = await pool.query(
-      'SELECT COUNT(*) AS count FROM template_version_skills WHERE skill_id = $1',
-      [skillId],
-    )
+    const { rows: tvRows } = await pool.query(CURRENT_TEMPLATE_REFS_SQL, [skillId])
     return {
       own_workspaces: ownRows.map((r) => ({ id: r.id as string, name: r.name as string })),
       other_workspace_count: Number.parseInt(otherRows[0].count, 10),
-      template_version_count: Number.parseInt(tvRows[0].count, 10),
+      template_version_count: tvRows.length,
     }
   }
 

--- a/control-plane/src/services/skills-content.ts
+++ b/control-plane/src/services/skills-content.ts
@@ -142,6 +142,9 @@ export interface ImportFromGitInput {
   description?: string
   visibility: 'private' | 'team' | 'public'
   category?: string | null
+  /** Re-import in place: target this skill instead of resolving one from
+   *  `(source, subpath)`. Set by the edit flow. */
+  skill_id?: string
 }
 
 /**

--- a/control-plane/src/services/skills-service.test.ts
+++ b/control-plane/src/services/skills-service.test.ts
@@ -509,6 +509,25 @@ describe('SkillsService.remove', () => {
     expect(vi.mocked(scsDeleteSkill)).not.toHaveBeenCalled()
   })
 
+  // A template version the user has since replaced is immutable history with
+  // no edit affordance — counting it would make the skill undeletable forever.
+  it('deletes past a superseded template version, pruning its stale ref', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 's' })
+    h.repo.seedTemplateVersionSkill('tv-1', skill.id, true)
+
+    vi.mocked(scsDeleteSkill).mockResolvedValue(ok({ ok: true }))
+    await h.service.remove('alice', skill.id)
+
+    expect(vi.mocked(scsDeleteSkill)).toHaveBeenCalledWith(skill.id)
+    // Pruned, or scs's delete would hit the RESTRICT FK on the stale row.
+    expect(await h.repo.getDeleteBlockers(skill.id)).toEqual({
+      workspace_ids: [],
+      template_version_ids: [],
+    })
+    expect(await h.repo.pruneSupersededTemplateRefs(skill.id)).toBe(0)
+  })
+
   it('rejects non-owner', async () => {
     const h = setup()
     h.repo.seedUser({ id: 'bob', display_name: 'Bob' })
@@ -570,6 +589,16 @@ describe('SkillsService.getDependents', () => {
       { id: 'w-a2', name: 'Beta' },
     ])
     expect(dep.other_workspace_count).toBe(2)
+    expect(dep.template_version_count).toBe(1)
+  })
+
+  it('counts only current template versions as dependents', async () => {
+    const h = setup()
+    const { skill } = seedSkill(h.repo, { name: 's' })
+    h.repo.seedTemplateVersionSkill('tv-1', skill.id, true)
+    h.repo.seedTemplateVersionSkill('tv-2', skill.id)
+
+    const dep = await h.service.getDependents('alice', skill.id)
     expect(dep.template_version_count).toBe(1)
   })
 

--- a/control-plane/src/services/skills-service.ts
+++ b/control-plane/src/services/skills-service.ts
@@ -114,6 +114,8 @@ interface ImportSkillInput {
   description?: string
   visibility: SkillVisibility
   category?: string | null
+  /** Re-import in place: the skill being edited. Absent = plain import. */
+  skillId?: string
 }
 
 interface SwitchSkillToGitInput {
@@ -255,6 +257,7 @@ export class SkillsService {
       description: input.description,
       visibility: input.visibility,
       category: input.category ?? null,
+      skill_id: input.skillId,
     }
     const result = await scsImportFromGit(body)
     this.unwrap(result)
@@ -554,6 +557,10 @@ export class SkillsService {
     if (blockers.workspace_ids.length > 0 || blockers.template_version_ids.length > 0) {
       throw new ConflictError(this.formatDeleteBlockers(blockers))
     }
+    // Nothing current references it. Superseded template versions still can,
+    // and they FK with RESTRICT — clear them or scs's delete fails on a
+    // constraint the user has no way to satisfy.
+    await this.repo.pruneSupersededTemplateRefs(skillId)
 
     const result = await scsDeleteSkill(skillId)
     this.unwrap(result)

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -619,6 +619,13 @@ export const SkillImportFromGitBodySchema = z.object({
   description: z.string().optional(),
   visibility: SkillVisibilitySchema.optional(),
   category: z.string().nullable().optional(),
+  /**
+   * Re-import an existing skill in place. The edit dialog sends the skill it
+   * is editing; the server then appends a version to THAT row instead of
+   * resolving a target from `(source, subpath)` — which retargets the wrong
+   * skill when a repo has several source rows (ref unset vs ref 'main').
+   */
+  skill_id: z.string().optional(),
 })
 
 /**

--- a/skills-content-service/src/from-git.test.ts
+++ b/skills-content-service/src/from-git.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => {
   const findSkillByOwnerName = vi.fn()
   const findSkillBySourceSubpath = vi.fn()
   const getActiveVersionHash = vi.fn()
+  const getSkillById = vi.fn()
   const getSourceById = vi.fn()
   const insertSkill = vi.fn()
   const insertSkillSource = vi.fn()
@@ -30,6 +31,7 @@ const mocks = vi.hoisted(() => {
     findSkillByOwnerName,
     findSkillBySourceSubpath,
     getActiveVersionHash,
+    getSkillById,
     getSourceById,
     insertSkill,
     insertSkillSource,
@@ -54,6 +56,7 @@ vi.mock('./db', () => ({
   findSkillByOwnerName: mocks.findSkillByOwnerName,
   findSkillBySourceSubpath: mocks.findSkillBySourceSubpath,
   getActiveVersionHash: mocks.getActiveVersionHash,
+  getSkillById: mocks.getSkillById,
   getSourceById: mocks.getSourceById,
   insertSkill: mocks.insertSkill,
   insertSkillSource: mocks.insertSkillSource,
@@ -183,6 +186,128 @@ describe('importFromGit', () => {
     })
     expect(r.ok).toBe(true)
     expect(mocks.insertSkillSource).not.toHaveBeenCalled()
+  })
+
+  // The edit flow's target is the row being edited, NOT whatever sits at the
+  // resolved (source, subpath). A repo with two source rows — one imported
+  // with ref unset, one with 'main' — used to send an edit into the other
+  // row's skill, silently forking content away from the one on screen.
+  it('appends to the skill named by skillId, not the one at (source, subpath)', async () => {
+    mocks.fetchTarball.mockResolvedValueOnce(await singleSkillTarball())
+    mocks.fetchCommitSha.mockResolvedValueOnce(null)
+    mocks.getSkillById.mockResolvedValueOnce({
+      id: 'sk-target',
+      user_id: 'u1',
+      name: 'target',
+      source_id: 'src1',
+      subpath: '',
+    })
+    mocks.findGitSource.mockResolvedValueOnce({ id: 'src1', kind: 'git' })
+    mocks.findSkillBySourceSubpath.mockResolvedValueOnce(null)
+    mocks.insertVersion.mockResolvedValueOnce({
+      version: { id: 'v2', skill_id: 'sk-target', source_id: 'src1', content_hash: 'h' },
+      created: true,
+    })
+    mocks.setActiveVersion.mockResolvedValueOnce({ id: 'sk-target', active_version_id: 'v2' })
+
+    const r = await importFromGit({
+      userId: 'u1',
+      url: 'https://github.com/owner/repo',
+      subpath: '',
+      visibility: 'private',
+      nameOverride: 'target',
+      skillId: 'sk-target',
+    })
+
+    expect(r.ok).toBe(true)
+    expect(mocks.insertSkill).not.toHaveBeenCalled()
+    expect(mocks.findSkillByOwnerName).not.toHaveBeenCalled()
+    expect(mocks.insertVersion).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ skillId: 'sk-target', note: 're-import from git' }),
+    )
+  })
+
+  it('refuses when another skill already tracks the resolved subpath', async () => {
+    mocks.fetchTarball.mockResolvedValueOnce(await singleSkillTarball())
+    mocks.fetchCommitSha.mockResolvedValueOnce(null)
+    mocks.getSkillById.mockResolvedValueOnce({
+      id: 'sk-target',
+      user_id: 'u1',
+      name: 'target',
+      source_id: 'src0',
+      subpath: '',
+    })
+    mocks.findGitSource.mockResolvedValueOnce({ id: 'src1', kind: 'git' })
+    mocks.findSkillBySourceSubpath.mockResolvedValueOnce({ id: 'sk-other', name: 'other' })
+
+    const r = await importFromGit({
+      userId: 'u1',
+      url: 'https://github.com/owner/repo',
+      subpath: '',
+      visibility: 'private',
+      skillId: 'sk-target',
+    })
+
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.status).toBe(409)
+    expect(r.error).toContain('other')
+    expect(mocks.insertVersion).not.toHaveBeenCalled()
+  })
+
+  it('rejects a skillId owned by someone else before fetching the repo', async () => {
+    mocks.getSkillById.mockResolvedValueOnce({ id: 'sk-target', user_id: 'u2', name: 'target' })
+
+    const r = await importFromGit({
+      userId: 'u1',
+      url: 'https://github.com/owner/repo',
+      subpath: '',
+      visibility: 'private',
+      skillId: 'sk-target',
+    })
+
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.status).toBe(404)
+    expect(mocks.fetchTarball).not.toHaveBeenCalled()
+  })
+
+  it('re-points the target row when the edit changed ref or subpath', async () => {
+    const query = vi.fn()
+    mocks.withTx.mockImplementation(async (fn) => fn({ query }))
+    mocks.fetchTarball.mockResolvedValueOnce(await singleSkillTarball())
+    mocks.fetchCommitSha.mockResolvedValueOnce(null)
+    mocks.getSkillById.mockResolvedValueOnce({
+      id: 'sk-target',
+      user_id: 'u1',
+      name: 'target',
+      source_id: 'src-old',
+      subpath: '',
+    })
+    mocks.findGitSource.mockResolvedValueOnce({ id: 'src-new', kind: 'git' })
+    mocks.findSkillBySourceSubpath.mockResolvedValueOnce(null)
+    mocks.insertVersion.mockResolvedValueOnce({
+      version: { id: 'v2', skill_id: 'sk-target', source_id: 'src-new', content_hash: 'h' },
+      created: true,
+    })
+    mocks.setActiveVersion.mockResolvedValueOnce({ id: 'sk-target', active_version_id: 'v2' })
+
+    const r = await importFromGit({
+      userId: 'u1',
+      url: 'https://github.com/owner/repo',
+      ref: 'main',
+      subpath: '',
+      visibility: 'private',
+      skillId: 'sk-target',
+    })
+
+    expect(r.ok).toBe(true)
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('UPDATE skills SET source_id'), [
+      'src-new',
+      '',
+      'sk-target',
+    ])
   })
 
   it('returns 400 when SKILL.md is missing at the subpath', async () => {

--- a/skills-content-service/src/from-git.ts
+++ b/skills-content-service/src/from-git.ts
@@ -162,6 +162,12 @@ interface ImportFromGitArgs {
   descriptionOverride?: string
   visibility: 'private' | 'team' | 'public'
   category?: string | null
+  /** Re-import in place: the caller is editing THIS skill, so it is the
+   *  target no matter what `(source, subpath)` resolves to. Without it we
+   *  fall back to locating the row by coordinates, which silently retargets
+   *  a different skill when the same repo has more than one source row
+   *  (e.g. one imported with ref unset, one with ref 'main'). */
+  skillId?: string
 }
 
 interface ImportFromGitResult {
@@ -178,6 +184,17 @@ interface ImportFromGitResult {
 export async function importFromGit(
   args: ImportFromGitArgs,
 ): Promise<{ ok: true; data: ImportFromGitResult } | { ok: false; status: number; error: string }> {
+  // Ownership guard for the in-place path, before we spend a repo fetch. cp
+  // gates ACL upstream; re-check here so a forged id can't append a version
+  // to someone else's skill.
+  let target: SkillMeta | null = null
+  if (args.skillId) {
+    target = await getSkillById(args.skillId)
+    if (!target || target.user_id !== args.userId) {
+      return { ok: false, status: 404, error: 'Skill not found' }
+    }
+  }
+
   const fetched = await fetchRepo({
     url: args.url,
     type: args.type,
@@ -248,10 +265,20 @@ export async function importFromGit(
     }
   }
 
-  // If a skill already exists at this (source_id, subpath), append a new
-  // version instead of creating a duplicate skill. Pre-existing rows can land
-  // here when the same monorepo is re-imported at the same subpath.
-  const existingSkill = await findSkillBySourceSubpath(source.id, subpath)
+  // The edit flow names its target explicitly. Otherwise fall back to the
+  // coordinates: if a skill already exists at this (source_id, subpath),
+  // append a new version instead of creating a duplicate skill. Pre-existing
+  // rows can land here when the same monorepo is re-imported at the same
+  // subpath.
+  const occupant = await findSkillBySourceSubpath(source.id, subpath)
+  if (target && occupant && occupant.id !== target.id) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Another skill ("${occupant.name}") already tracks subpath "${subpath}" at this ref. Point one of them elsewhere first.`,
+    }
+  }
+  const existingSkill = target ?? occupant
 
   // Name-collision pre-flight: a skill with this `name` may already exist
   // under a DIFFERENT source (e.g. same url + different ref → new source
@@ -283,6 +310,16 @@ export async function importFromGit(
         visibility: args.visibility,
         category: args.category ?? null,
       })
+    } else if (skill.source_id !== ensuredSource.id || skill.subpath !== subpath) {
+      // In-place re-import where the user changed the ref or subpath: move
+      // the row onto the resolved coordinates so it stays findable there.
+      // Only reachable via the explicit-target path — the coordinate lookup
+      // returns a row that already matches by construction.
+      await client.query(
+        'UPDATE skills SET source_id = $1, subpath = $2, updated_at = NOW() WHERE id = $3',
+        [ensuredSource.id, subpath, skill.id],
+      )
+      skill = { ...skill, source_id: ensuredSource.id, subpath }
     }
     const { version } = await insertVersion(client, {
       skillId: skill.id,

--- a/skills-content-service/src/index.ts
+++ b/skills-content-service/src/index.ts
@@ -317,6 +317,9 @@ const ImportGitBody = z.object({
   description: z.string().optional(),
   visibility: VisibilityEnum,
   category: z.string().nullable().optional(),
+  // Re-import in place: the edit flow's target skill. Absent = plain import,
+  // target resolved from (source, subpath).
+  skill_id: z.string().optional(),
 })
 
 const importGitRoute = createRoute({
@@ -359,9 +362,11 @@ app.openapi(importGitRoute, async (c) => {
       descriptionOverride: body.description,
       visibility: body.visibility,
       category: body.category ?? null,
+      skillId: body.skill_id,
     })
     if (!r.ok) {
       if (r.status === 400) return c.json({ error: r.error }, 400)
+      if (r.status === 404) return c.json({ error: r.error }, 404 as never)
       if (r.status === 409) return c.json({ error: r.error }, 409)
       if (r.status === 413) return c.json({ error: r.error }, 413)
       if (r.status === 502) return c.json({ error: r.error }, 502)

--- a/web/src/components/library/SkillsSection.tsx
+++ b/web/src/components/library/SkillsSection.tsx
@@ -266,7 +266,10 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
           token: form.tokenSource === 'manual' ? form.gitToken.trim() || undefined : undefined,
           credential_name:
             form.tokenSource === 'credential' ? form.selectedCredential || undefined : undefined,
-          name: form.name.trim() || undefined,
+          // On edit, send the CURRENT name and the row's id: the name is not
+          // the selector (the id is), and sending the new one would make a
+          // fresh import under it if the id path ever falls through.
+          name: (editingSkill ? editingSkill.name : form.name.trim()) || undefined,
           description: form.description.trim() || undefined,
           visibility: editingSkill?.visibility ?? 'private',
           // SkillsSection's git form is a re-import / single-skill path (Edit
@@ -274,6 +277,7 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
           // picked subpath; multi-select lives in CreateSkillDialog. Guarded
           // non-empty above, so this is always a concrete string ('' = root).
           subpath: form.subpaths[0],
+          skill_id: editingSkill?.id,
         })
         // Category isn't part of the from-git body — server doesn't take it
         // on insert. Fold it into a follow-up PATCH when the user picked one

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -818,6 +818,8 @@ class ApiClient {
     grants?: SkillGrant[]
     subpath: string
     ref?: string
+    /** Re-import in place — the skill being edited. Omit for new imports. */
+    skill_id?: string
   }): Promise<ApiSkill> {
     return this.request<ApiSkill>('/skills/from-git', {
       method: 'POST',


### PR DESCRIPTION
Two independent bugs surfaced by users editing and deleting skills.

## 1. Git-mode edit could write to the wrong skill

The edit dialog's git-mode save resolved its target from `(source, subpath)` — coordinates, not identity. A repo imported twice (once with `ref` unset, once with `ref: 'main'`) has **two** `skill_sources` rows, so the save landed on whichever skill owned the *other* row: content forked into a different skill while the one on screen stayed untouched. When the coordinates matched nothing, it inserted a brand-new skill under the new name instead, leaving the original — and all its mounts — behind.

Renaming just made this visible. Any git-mode edit could hit it.

**Fix**: `from-git` takes an optional `skill_id`. The edit flow sends the row it is editing (and its *current* name — the name is not a selector), ownership is re-checked service-side, and a subpath already tracked by a different skill returns 409 instead of silently forking. A target whose ref or subpath changed is re-pointed onto the resolved coordinates.

## 2. Superseded template versions blocked deletes forever

Delete blockers counted every template version referencing a skill, including superseded ones. Those are immutable history with no edit affordance in the UI, so a skill any template ever used could never be deleted — the dialog kept reporting a reference the user had already removed from the template.

**Fix**: only the version a template currently hands out blocks. `remove()` prunes the stale rows (they FK with `RESTRICT`) once nothing current references the skill.

## Testing

- `skills-content-service`: 4 new cases covering id-targeting, the 409 on a taken subpath, cross-user rejection before the repo fetch, and the ref/subpath re-point
- `control-plane`: 2 new cases covering delete-past-superseded (with prune) and dependent counting
- Full suites green in both, plus `web` typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQKgW1NphAmZjTHzP1xd4k