### PR TITLE
feat(sessions): general facet filter for the session list

### DIFF
--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import {
   ApiK8sStatusSchema,
   ApiMessageSchema,
+  ApiSessionFacetsSchema,
   ApiSessionListSchema,
   ApiWorkspaceConfigSchema,
   ApiWorkspaceSchema,
@@ -10,7 +11,7 @@ import type { AppEnv } from '../../lib/types'
 import { getWorkspaceReplicaStatus } from '../../services/db/env-placements'
 import { listAttachmentsForWorkspace } from '../../services/db/memory'
 import { getMessagesWithBlocks } from '../../services/db/messages'
-import { listSessions } from '../../services/db/sessions'
+import { getSessionFacets, listSessions } from '../../services/db/sessions'
 import { getTagAssignmentsForUser } from '../../services/db/tags'
 import type { SessionWithPreview } from '../../services/db/types'
 import { getWorkspace, getWorkspaceConfig, listWorkspaces } from '../../services/db/workspaces'
@@ -134,6 +135,14 @@ const listSessionsRoute = createRoute({
       offset: z.coerce.number().int().min(0).default(0).optional(),
       // When 'true', restrict the list to starred sessions.
       starred: z.enum(['true', 'false']).optional(),
+      // Comma-separated sources to leave out, e.g. 'schedule,webhook'.
+      // Exclusion, not inclusion, so a saved filter can't hide a source type
+      // that didn't exist when it was saved.
+      exclude_sources: z.string().optional(),
+      // Comma-separated coarse statuses to keep: human | agent | idle.
+      status: z.string().optional(),
+      // ISO instant; keeps sessions active at or after it.
+      active_after: z.string().datetime().optional(),
     }),
   },
   responses: {
@@ -194,10 +203,27 @@ read.openapi(listMessagesRoute, async (c) => {
   )
 })
 
+/** Splits a comma-separated query param, dropping blanks. */
+function csv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined
+  const parts = value
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean)
+  return parts.length ? parts : undefined
+}
+
 read.openapi(listSessionsRoute, async (c) => {
   const currentUser = c.get('user')
   const { id } = c.req.valid('param')
-  const { limit = 20, offset = 0, starred } = c.req.valid('query')
+  const {
+    limit = 20,
+    offset = 0,
+    starred,
+    exclude_sources,
+    status,
+    active_after,
+  } = c.req.valid('query')
   const workspace = await getWorkspace(id)
   if (!workspace || !canManage(workspace, currentUser)) {
     return c.json({ error: 'Workspace not found' }, 404)
@@ -206,8 +232,40 @@ read.openapi(listSessionsRoute, async (c) => {
     limit,
     offset,
     starredOnly: starred === 'true',
+    excludeSources: csv(exclude_sources),
+    statuses: csv(status),
+    activeAfter: active_after,
   })
   return c.json({ items: items.map(toApiSession), total }, 200)
+})
+
+const sessionFacetsRoute = createRoute({
+  method: 'get',
+  path: '/{id}/sessions/facets',
+  tags: ['workspaces'],
+  summary: 'Session counts per filter facet',
+  security: [{ bearerAuth: [] }],
+  request: { params: WorkspaceIdParam },
+  responses: {
+    200: {
+      description: 'Counts per source and status, plus starred and total',
+      content: { 'application/json': { schema: ApiSessionFacetsSchema } },
+    },
+    404: {
+      description: 'Workspace not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+read.openapi(sessionFacetsRoute, async (c) => {
+  const currentUser = c.get('user')
+  const { id } = c.req.valid('param')
+  const workspace = await getWorkspace(id)
+  if (!workspace || !canManage(workspace, currentUser)) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+  return c.json(await getSessionFacets(id), 200)
 })
 
 read.openapi(getConfigRoute, async (c) => {

--- a/control-plane/src/services/db/sessions-filter.test.ts
+++ b/control-plane/src/services/db/sessions-filter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildSessionListWhere } from './sessions'
+
+describe('buildSessionListWhere', () => {
+  it('scopes to the workspace and active sessions when unfiltered', () => {
+    const { where, params } = buildSessionListWhere('ws-1', undefined)
+    expect(where).toBe(`s.workspace_id = $1 AND s.status = 'active'`)
+    expect(params).toEqual(['ws-1'])
+  })
+
+  it('numbers placeholders in the order params are pushed', () => {
+    const { where, params } = buildSessionListWhere('ws-1', {
+      excludeSources: ['schedule'],
+      statuses: ['human'],
+      activeAfter: '2026-07-01T00:00:00.000Z',
+    })
+    expect(where).toContain('s.source <> ALL($2)')
+    expect(where).toContain('= ANY($3)')
+    expect(where).toContain('s.last_active_at >= $4')
+    expect(params).toEqual(['ws-1', ['schedule'], ['human'], '2026-07-01T00:00:00.000Z'])
+  })
+
+  it('keeps placeholder numbering dense when earlier facets are absent', () => {
+    // The page query appends LIMIT/OFFSET after these params, so a gap here
+    // would shift them and silently mis-page the list.
+    const { where, params } = buildSessionListWhere('ws-1', {
+      activeAfter: '2026-07-01T00:00:00.000Z',
+    })
+    expect(where).toContain('s.last_active_at >= $2')
+    expect(params).toHaveLength(2)
+  })
+
+  it('treats an empty facet selection as no filter', () => {
+    const { where, params } = buildSessionListWhere('ws-1', {
+      excludeSources: [],
+      statuses: [],
+      starredOnly: false,
+    })
+    expect(where).toBe(`s.workspace_id = $1 AND s.status = 'active'`)
+    expect(params).toEqual(['ws-1'])
+  })
+
+  it('filters starred without consuming a placeholder', () => {
+    const { where, params } = buildSessionListWhere('ws-1', { starredOnly: true })
+    expect(where).toContain('s.starred_at IS NOT NULL')
+    expect(params).toEqual(['ws-1'])
+  })
+})

--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -29,16 +29,78 @@ export async function getSession(id: string): Promise<Session | null> {
   return (rows[0] as Session) ?? null
 }
 
+/**
+ * View filter for the session list. Every facet is applied server-side: the
+ * list is paginated, so filtering client-side would only ever narrow the pages
+ * already fetched — a facet that excludes most rows would return a near-empty
+ * list while infinite scroll kept paging.
+ */
+interface SessionListFilter {
+  /** Restrict to starred sessions. */
+  starredOnly?: boolean
+  /**
+   * Sources to leave out. Exclusion rather than inclusion so a filter saved
+   * today doesn't silently hide a connector type added tomorrow.
+   */
+  excludeSources?: string[]
+  /**
+   * Coarse statuses to keep — 'human' (needs you), 'agent' (running), 'idle'.
+   * Empty/undefined means all. Anything not 'agent'/'human' counts as idle,
+   * mirroring how the client classifies chat_status.
+   */
+  statuses?: string[]
+  /** Only sessions active at or after this instant. */
+  activeAfter?: string
+}
+
+/** SQL expression collapsing chat_status into the three coarse buckets. */
+const STATUS_BUCKET_SQL = `CASE WHEN s.chat_status IN ('agent', 'human') THEN s.chat_status ELSE 'idle' END`
+
+/**
+ * Builds the shared WHERE predicate for every session-list query. The page
+ * query, the total count and the facet counts must all agree, so they take
+ * their conditions from here rather than each assembling their own.
+ *
+ * Returns the clause plus the positional params it consumed; callers append
+ * their own params (limit/offset) after these.
+ *
+ * Exported for tests: a drift between the page query's placeholders and the
+ * params array is silent at type level and only shows up as a wrong list.
+ */
+export function buildSessionListWhere(
+  workspaceId: string,
+  filter: SessionListFilter | undefined,
+): { where: string; params: unknown[] } {
+  const params: unknown[] = [workspaceId]
+  let where = `s.workspace_id = $1 AND s.status = 'active'`
+
+  if (filter?.starredOnly) where += ' AND s.starred_at IS NOT NULL'
+
+  if (filter?.excludeSources?.length) {
+    params.push(filter.excludeSources)
+    where += ` AND s.source <> ALL($${params.length})`
+  }
+
+  if (filter?.statuses?.length) {
+    params.push(filter.statuses)
+    where += ` AND ${STATUS_BUCKET_SQL} = ANY($${params.length})`
+  }
+
+  if (filter?.activeAfter) {
+    params.push(filter.activeAfter)
+    where += ` AND s.last_active_at >= $${params.length}`
+  }
+
+  return { where, params }
+}
+
 export async function listSessions(
   workspaceId: string,
-  opts?: { limit?: number; offset?: number; starredOnly?: boolean },
+  opts?: { limit?: number; offset?: number } & SessionListFilter,
 ): Promise<PaginatedSessions> {
   const limit = opts?.limit ?? 20
   const offset = opts?.offset ?? 0
-  // When set, restricts the list to starred sessions. Filtering happens
-  // server-side so "show all my starred" stays complete regardless of how many
-  // pages the client has scrolled.
-  const starredClause = opts?.starredOnly ? ' AND s.starred_at IS NOT NULL' : ''
+  const { where, params } = buildSessionListWhere(workspaceId, opts)
 
   const [{ rows }, countResult] = await Promise.all([
     pool.query(
@@ -57,21 +119,61 @@ export async function listSessions(
          ORDER BY m.created_at ASC LIMIT 1
        ) fm ON true
        LEFT JOIN workspaces cw ON cw.id = s.caller_workspace_id
-       WHERE s.workspace_id = $1 AND s.status = 'active'${starredClause}
+       WHERE ${where}
        ORDER BY s.last_active_at DESC
-       LIMIT $2 OFFSET $3`,
-      [workspaceId, limit, offset],
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset],
     ),
-    pool.query(
-      `SELECT COUNT(*)::int AS total FROM sessions s
-       WHERE s.workspace_id = $1 AND s.status = 'active'${starredClause}`,
-      [workspaceId],
-    ),
+    pool.query(`SELECT COUNT(*)::int AS total FROM sessions s WHERE ${where}`, params),
   ])
 
   return {
     items: rows as SessionWithPreview[],
     total: countResult.rows[0]?.total ?? 0,
+  }
+}
+
+interface SessionFacetCounts {
+  source: Record<string, number>
+  status: Record<string, number>
+  starred: number
+  total: number
+}
+
+/**
+ * Per-facet session counts for the filter menu. Counts are unconditioned
+ * beyond the workspace itself — they answer "what is in this workspace", which
+ * is what makes the menu explain a crowded list. Conditioning each facet on
+ * the *other* active filters would cost one query per facet; not worth it
+ * until someone asks.
+ */
+export async function getSessionFacets(workspaceId: string): Promise<SessionFacetCounts> {
+  const { where, params } = buildSessionListWhere(workspaceId, undefined)
+
+  const [bySource, byStatus, starred] = await Promise.all([
+    pool.query(
+      `SELECT s.source AS key, COUNT(*)::int AS n FROM sessions s WHERE ${where} GROUP BY 1`,
+      params,
+    ),
+    pool.query(
+      `SELECT ${STATUS_BUCKET_SQL} AS key, COUNT(*)::int AS n FROM sessions s WHERE ${where} GROUP BY 1`,
+      params,
+    ),
+    pool.query(
+      `SELECT COUNT(*)::int AS n FROM sessions s WHERE ${where} AND s.starred_at IS NOT NULL`,
+      params,
+    ),
+  ])
+
+  const tally = (rows: { key: string; n: number }[]) =>
+    Object.fromEntries(rows.map((r) => [r.key, r.n]))
+
+  const source = tally(bySource.rows)
+  return {
+    source,
+    status: tally(byStatus.rows),
+    starred: starred.rows[0]?.n ?? 0,
+    total: Object.values(source).reduce((a, b) => a + b, 0),
   }
 }
 

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -242,6 +242,20 @@ export const ApiSessionListSchema = z.object({
 export type ApiSessionList = z.infer<typeof ApiSessionListSchema>
 
 /**
+ * Session counts per filter facet, used to label the session-list filter menu.
+ * Keys are open (source is whatever connector types the workspace has seen),
+ * so both maps are plain records rather than enums.
+ */
+export const ApiSessionFacetsSchema = z.object({
+  source: z.record(z.string(), z.number().int()),
+  status: z.record(z.string(), z.number().int()),
+  starred: z.number().int(),
+  total: z.number().int(),
+})
+
+export type ApiSessionFacets = z.infer<typeof ApiSessionFacetsSchema>
+
+/**
  * Lightweight session shape returned by the single-session GET. Strict subset
  * of ApiSession plus a `preview` snippet derived from the first user message.
  * Used by the sidebar — does not include workspace_id, created_at, message_count, etc.

--- a/web/src/components/workspace/SessionFilterMenu.tsx
+++ b/web/src/components/workspace/SessionFilterMenu.tsx
@@ -1,0 +1,214 @@
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useSessionFacets } from '@/hooks/useSessions'
+import {
+  EMPTY_SESSION_FILTER,
+  SESSION_STATUS_BUCKETS,
+  SESSION_TIME_WINDOWS,
+  type SessionFilter,
+  type SessionStatusBucket,
+  type SessionTimeWindow,
+  activeFacetCount,
+  normalizeStatuses,
+} from '@/lib/session-filter'
+import { sortSources, sourceVisual } from '@/lib/session-source'
+import { cn } from '@/lib/utils'
+import { Filter, Star } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface SessionFilterMenuProps {
+  workspaceId: string
+  filter: SessionFilter
+  onChange: (next: SessionFilter) => void
+}
+
+/** Keeps the menu open when a facet is toggled, so several can be set in one visit. */
+const keepOpen = (e: Event) => e.preventDefault()
+
+/**
+ * Filter entry for the session list: one button, one menu, facets in
+ * submenus. The parent menu stays visible while a submenu is open, so
+ * switching facets is a horizontal move rather than a back-and-forth, and it
+ * doesn't grow taller as connector types are added.
+ *
+ * Active state is a numeric badge — how many facets deviate from the default.
+ * A generated summary ("hiding scheduled and 2 others") would need
+ * per-language pluralization and inverted phrasing for an exclusion-based
+ * filter; a number needs neither and stays correct as facets are added.
+ */
+export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilterMenuProps) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  // Counts describe the whole workspace, so they're only worth fetching while
+  // the menu is on screen.
+  const { data: facets } = useSessionFacets(workspaceId, open)
+
+  const count = activeFacetCount(filter)
+  const knownSources = sortSources(Object.keys(facets?.source ?? {}))
+
+  const toggleSource = (source: string, keep: boolean) => {
+    const excluded = new Set(filter.excludedSources)
+    if (keep) excluded.delete(source)
+    else excluded.add(source)
+    onChange({ ...filter, excludedSources: [...excluded] })
+  }
+
+  const toggleStatus = (status: SessionStatusBucket, keep: boolean) => {
+    // Empty means "all", so an untouched filter starts from the full set the
+    // moment the user unchecks their first status.
+    const current = filter.statuses.length ? filter.statuses : SESSION_STATUS_BUCKETS
+    const next = keep ? [...current, status] : current.filter((s) => s !== status)
+    onChange({ ...filter, statuses: normalizeStatuses(next) })
+  }
+
+  const facetSummary = (kept: number, total: number) =>
+    kept === total ? t('components.sessions.filter.all') : `${kept}/${total}`
+
+  const statusesKept = filter.statuses.length || SESSION_STATUS_BUCKETS.length
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={
+            count > 0
+              ? t('components.sessions.filter.activeLabel', { count })
+              : t('components.sessions.filter.title')
+          }
+          title={t('components.sessions.filter.title')}
+          className={cn(
+            'relative flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors',
+            count > 0 || open
+              ? 'bg-primary/15 text-primary'
+              : 'bg-foreground/[0.04] text-muted-foreground/70 hover:bg-foreground/[0.07] hover:text-foreground',
+          )}
+        >
+          <Filter className="h-3.5 w-3.5" strokeWidth={2} />
+          {count > 0 && (
+            <span className="-top-1 -right-1 absolute flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 font-bold text-[9px] text-primary-foreground tabular-nums ring-2 ring-card">
+              {count}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span>{t('components.sessions.filter.source')}</span>
+            <span className="ml-auto text-muted-foreground text-xs tabular-nums">
+              {facetSummary(
+                knownSources.length - filter.excludedSources.length,
+                knownSources.length,
+              )}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-48">
+            {knownSources.map((source) => {
+              const { Icon, labelKey } = sourceVisual(source)
+              return (
+                <DropdownMenuCheckboxItem
+                  key={source}
+                  className="gap-2"
+                  checked={!filter.excludedSources.includes(source)}
+                  onCheckedChange={(keep) => toggleSource(source, keep === true)}
+                  onSelect={keepOpen}
+                >
+                  <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={2} />
+                  <span className="truncate">{t(`components.sessions.source.${labelKey}`)}</span>
+                  <span className="ml-auto text-muted-foreground text-xs tabular-nums">
+                    {facets?.source[source] ?? 0}
+                  </span>
+                </DropdownMenuCheckboxItem>
+              )
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span>{t('components.sessions.filter.status')}</span>
+            <span className="ml-auto text-muted-foreground text-xs tabular-nums">
+              {facetSummary(statusesKept, SESSION_STATUS_BUCKETS.length)}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-48">
+            {SESSION_STATUS_BUCKETS.map((status) => (
+              <DropdownMenuCheckboxItem
+                key={status}
+                checked={!filter.statuses.length || filter.statuses.includes(status)}
+                onCheckedChange={(keep) => toggleStatus(status, keep === true)}
+                onSelect={keepOpen}
+              >
+                <span className="truncate">
+                  {t(`components.sessions.filter.statusValue.${status}`)}
+                </span>
+                <span className="ml-auto text-muted-foreground text-xs tabular-nums">
+                  {facets?.status[status] ?? 0}
+                </span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span>{t('components.sessions.filter.time')}</span>
+            <span className="ml-auto text-muted-foreground text-xs">
+              {t(`components.sessions.filter.timeValue.${filter.time}`)}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-48">
+            <DropdownMenuRadioGroup
+              value={filter.time}
+              onValueChange={(value) => onChange({ ...filter, time: value as SessionTimeWindow })}
+            >
+              {SESSION_TIME_WINDOWS.map((window) => (
+                <DropdownMenuRadioItem key={window} value={window} onSelect={keepOpen}>
+                  {t(`components.sessions.filter.timeValue.${window}`)}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuCheckboxItem
+          className="gap-2"
+          checked={filter.starredOnly}
+          onCheckedChange={(next) => onChange({ ...filter, starredOnly: next === true })}
+          onSelect={keepOpen}
+        >
+          <Star className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={2} />
+          <span className="truncate">{t('components.sessions.filterStarred')}</span>
+          <span className="ml-auto text-muted-foreground text-xs tabular-nums">
+            {facets?.starred ?? 0}
+          </span>
+        </DropdownMenuCheckboxItem>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          disabled={count === 0}
+          onSelect={() => onChange({ ...EMPTY_SESSION_FILTER })}
+        >
+          {t('components.sessions.filter.clear')}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/src/components/workspace/WorkspaceSessionsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSessionsPanel.tsx
@@ -1,9 +1,11 @@
 import { AppHeaderButton } from '@/components/shell/windows/AppHeaderButton'
 import { useAppHeaderSlot } from '@/components/shell/windows/AppWindow'
+import { Button } from '@/components/ui/button'
 import { EmptyHero } from '@/components/ui/empty-hero'
 import { EmptyIllustration } from '@/components/ui/empty-illustration'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
+import { SessionFilterMenu } from '@/components/workspace/SessionFilterMenu'
 import { ShareSessionButton } from '@/components/workspace/ShareSessionButton'
 import { sessionKeys, useInvalidateSessions, useSessions } from '@/hooks/useSessions'
 import { useMarkSeen, useUnreadCount } from '@/hooks/useUnread'
@@ -11,29 +13,19 @@ import { api } from '@/lib/api/client'
 import type { Session } from '@/lib/api/types'
 import { isCommitEnter } from '@/lib/keyboard'
 import { formatFullTime, formatRelativeTime } from '@/lib/relative-time'
+import {
+  EMPTY_SESSION_FILTER,
+  type SessionFilter,
+  activeFacetCount,
+  normalizeSessionFilter,
+} from '@/lib/session-filter'
+import { sourceVisual } from '@/lib/session-source'
 import { cleanSessionPreview } from '@/lib/session-utils'
 import { cn } from '@/lib/utils'
 import { useActiveSession } from '@/stores/active-session-store'
-import { useInstanceState } from '@/stores/instance-state-store'
+import { useInstancePersistentState, useInstanceState } from '@/stores/instance-state-store'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import {
-  Bot,
-  CalendarClock,
-  Check,
-  CheckCheck,
-  Globe,
-  type LucideIcon,
-  MessageCircle,
-  Pencil,
-  Search,
-  Share2,
-  Slack,
-  SquarePen,
-  Star,
-  Trash2,
-  Webhook,
-  X,
-} from 'lucide-react'
+import { Check, CheckCheck, Pencil, Search, Share2, SquarePen, Star, Trash2, X } from 'lucide-react'
 import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
@@ -49,27 +41,6 @@ function classifyStatus(chatStatus: string): SessionStatus {
   if (s === 'agent') return 'running'
   if (s.includes('error') || s.includes('fail')) return 'error'
   return 'idle'
-}
-
-// Per-source leading icon. Every row carries one so titles stay left-aligned.
-// Literal switch (not `icons[source]`) keeps each source greppable and lets
-// new connector types fail loudly into the muted fallback.
-function sourceVisual(source: string): { Icon: LucideIcon; labelKey: string } {
-  switch (source) {
-    case 'schedule':
-      return { Icon: CalendarClock, labelKey: 'schedule' }
-    case 'slack':
-      return { Icon: Slack, labelKey: 'slack' }
-    case 'wecom':
-      return { Icon: MessageCircle, labelKey: 'wecom' }
-    case 'webhook':
-      return { Icon: Webhook, labelKey: 'webhook' }
-    case 'agent':
-      return { Icon: Bot, labelKey: 'agent' }
-    default:
-      // 'web' (manual) and any unknown source.
-      return { Icon: Globe, labelKey: 'web' }
-  }
 }
 
 type Bucket = 'today' | 'week' | 'month' | 'earlier'
@@ -394,20 +365,26 @@ export function WorkspaceSessionsPanel({ workspaceId, instanceId }: WorkspaceSes
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const headerSlot = useAppHeaderSlot()
-  // Starred-only filter. Memory instance state — survives a layout switch but
-  // resets on refresh, so reopening the panel always shows the full list.
-  const [starredOnly, setStarredOnly] = useInstanceState<boolean>(
+  // Filter is view config, so it persists (workspace_profile) rather than
+  // resetting on refresh: someone who never wants scheduled sessions in their
+  // list unchecks that source once instead of us guessing a default for
+  // everyone. The badge on the filter button keeps the state visible.
+  const [storedFilter, setFilter] = useInstancePersistentState<SessionFilter>(
     instanceId,
-    'starredOnly',
-    () => false,
+    'sessionFilter',
+    () => EMPTY_SESSION_FILTER,
   )
+  // The stored value round-trips through jsonb and may predate the current
+  // facet set, so it's coerced before it can reach a query key.
+  const filter = useMemo(() => normalizeSessionFilter(storedFilter), [storedFilter])
+  const filtering = activeFacetCount(filter) > 0
   const {
     data: sessions,
     isLoading,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useSessions(workspaceId, { starred: starredOnly })
+  } = useSessions(workspaceId, filter)
   const invalidateSessions = useInvalidateSessions()
   const activeSessionId = useActiveSession((s) =>
     s.workspaceId === workspaceId ? s.sessionId : undefined,
@@ -527,7 +504,7 @@ export function WorkspaceSessionsPanel({ workspaceId, instanceId }: WorkspaceSes
   const handleToggleStar = useCallback(
     async (session: Session) => {
       const next = !session.starred_at
-      const key = sessionKeys.listVariant(workspaceId, starredOnly)
+      const key = sessionKeys.listVariant(workspaceId, filter)
       // Optimistic: flip the flag in cache so the star reacts instantly. When
       // the starred-only filter is on, un-starring drops the row outright.
       await queryClient.cancelQueries({ queryKey: key })
@@ -539,7 +516,7 @@ export function WorkspaceSessionsPanel({ workspaceId, instanceId }: WorkspaceSes
           pages: old.pages.map((p: any) => ({
             ...p,
             items:
-              starredOnly && !next
+              filter.starredOnly && !next
                 ? p.items.filter((s: Session) => s.id !== session.id)
                 : p.items.map((s: Session) =>
                     s.id === session.id
@@ -561,7 +538,7 @@ export function WorkspaceSessionsPanel({ workspaceId, instanceId }: WorkspaceSes
         invalidateSessions(workspaceId)
       }
     },
-    [workspaceId, starredOnly, queryClient, invalidateSessions],
+    [workspaceId, filter, queryClient, invalidateSessions],
   )
 
   const { human: unreadCount } = useUnreadCount({ kind: 'ws', workspaceId })
@@ -650,21 +627,7 @@ export function WorkspaceSessionsPanel({ workspaceId, instanceId }: WorkspaceSes
             </button>
           )}
         </div>
-        <button
-          type="button"
-          aria-label={t('components.sessions.filterStarred')}
-          title={t('components.sessions.filterStarred')}
-          aria-pressed={starredOnly}
-          onClick={() => setStarredOnly(!starredOnly)}
-          className={cn(
-            'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors',
-            starredOnly
-              ? 'bg-warning/15 text-warning'
-              : 'bg-foreground/[0.04] text-muted-foreground/70 hover:bg-foreground/[0.07] hover:text-foreground',
-          )}
-        >
-          <Star className={cn('h-3.5 w-3.5', starredOnly && 'fill-current')} strokeWidth={2} />
-        </button>
+        <SessionFilterMenu workspaceId={workspaceId} filter={filter} onChange={setFilter} />
       </div>
 
       {isLoading ? (
@@ -675,20 +638,35 @@ export function WorkspaceSessionsPanel({ workspaceId, instanceId }: WorkspaceSes
       ) : filteredSessions.length === 0 ? (
         <div className="flex flex-1 items-center justify-center">
           <EmptyHero
-            illustration={<EmptyIllustration src={query ? 'search' : 'sessions'} size="h-32" />}
+            illustration={
+              <EmptyIllustration src={query || filtering ? 'search' : 'sessions'} size="h-32" />
+            }
             title={
               query
                 ? t('components.sessions.noMatch.title')
-                : starredOnly
-                  ? t('components.sessions.starredEmpty.title')
+                : filtering
+                  ? t('components.sessions.filteredEmpty.title')
                   : t('components.sessions.empty.title')
             }
             description={
               query
                 ? t('components.sessions.noMatch.description')
-                : starredOnly
-                  ? t('components.sessions.starredEmpty.description')
+                : filtering
+                  ? t('components.sessions.filteredEmpty.description')
                   : t('components.sessions.empty.description')
+            }
+            action={
+              !query && filtering ? (
+                // Without a chip row, a filtered-empty list is the one state
+                // with no visible way back — this is that way back.
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setFilter({ ...EMPTY_SESSION_FILTER })}
+                >
+                  {t('components.sessions.filter.clear')}
+                </Button>
+              ) : undefined
             }
           />
         </div>

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -1,6 +1,7 @@
 import { api } from '@/lib/api/client'
 import type { Session } from '@/lib/api/types'
-import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
+import { EMPTY_SESSION_FILTER, type SessionFilter, timeWindowStart } from '@/lib/session-filter'
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo } from 'react'
 
 const PAGE_SIZE = 20
@@ -8,19 +9,27 @@ const PAGE_SIZE = 20
 export const sessionKeys = {
   all: ['sessions'] as const,
   // Prefix shared by every session-list query of a workspace. Invalidating
-  // this key matches all variants (starred-filtered and not) by prefix.
+  // this key matches all filter variants by prefix.
   list: (workspaceId: string | undefined) => ['sessions', workspaceId] as const,
   // Exact key of one list variant — needed for optimistic cache writes.
-  listVariant: (workspaceId: string | undefined, starred: boolean) =>
-    ['sessions', workspaceId, { starred }] as const,
+  listVariant: (workspaceId: string | undefined, filter: SessionFilter) =>
+    ['sessions', workspaceId, filter] as const,
+  facets: (workspaceId: string | undefined) => ['session-facets', workspaceId] as const,
 }
 
-export function useSessions(workspaceId: string | undefined, opts?: { starred?: boolean }) {
-  const starred = opts?.starred ?? false
+export function useSessions(workspaceId: string | undefined, filter?: SessionFilter) {
+  const effective = filter ?? EMPTY_SESSION_FILTER
   const query = useInfiniteQuery({
-    queryKey: sessionKeys.listVariant(workspaceId, starred),
+    queryKey: sessionKeys.listVariant(workspaceId, effective),
     queryFn: ({ pageParam = 0 }) =>
-      api.getSessions(workspaceId!, { limit: PAGE_SIZE, offset: pageParam, starred }),
+      api.getSessions(workspaceId!, {
+        limit: PAGE_SIZE,
+        offset: pageParam,
+        starred: effective.starredOnly,
+        excludeSources: effective.excludedSources,
+        statuses: effective.statuses,
+        activeAfter: timeWindowStart(effective.time),
+      }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
       const nextOffset = lastPageParam + PAGE_SIZE
@@ -44,12 +53,27 @@ export function useSessions(workspaceId: string | undefined, opts?: { starred?: 
   }
 }
 
+/**
+ * Session counts per facet, for labelling the filter menu. Deliberately
+ * unfiltered: they describe the whole workspace, which is what lets the menu
+ * explain a crowded list before the user has filtered anything.
+ */
+export function useSessionFacets(workspaceId: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: sessionKeys.facets(workspaceId),
+    queryFn: () => api.getSessionFacets(workspaceId!),
+    enabled: !!workspaceId && enabled,
+    staleTime: 30_000,
+  })
+}
+
 /** Returns a callback that invalidates the session list for a given workspace. */
 export function useInvalidateSessions() {
   const queryClient = useQueryClient()
   return useCallback(
     (workspaceId: string) => {
       queryClient.invalidateQueries({ queryKey: sessionKeys.list(workspaceId) })
+      queryClient.invalidateQueries({ queryKey: sessionKeys.facets(workspaceId) })
     },
     [queryClient],
   )

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -80,6 +80,7 @@ import type {
   SandboxListResponse,
   Schedule,
   Session,
+  SessionFacets,
   SkillDependents,
   SkillGrant,
   SkillSourceKind,
@@ -330,14 +331,28 @@ class ApiClient {
   // Sessions
   async getSessions(
     workspaceId: string,
-    opts?: { limit?: number; offset?: number; starred?: boolean },
+    opts?: {
+      limit?: number
+      offset?: number
+      starred?: boolean
+      excludeSources?: string[]
+      statuses?: string[]
+      activeAfter?: string
+    },
   ): Promise<{ items: Session[]; total: number }> {
     const params = new URLSearchParams()
     if (opts?.limit != null) params.set('limit', String(opts.limit))
     if (opts?.offset != null) params.set('offset', String(opts.offset))
     if (opts?.starred) params.set('starred', 'true')
+    if (opts?.excludeSources?.length) params.set('exclude_sources', opts.excludeSources.join(','))
+    if (opts?.statuses?.length) params.set('status', opts.statuses.join(','))
+    if (opts?.activeAfter) params.set('active_after', opts.activeAfter)
     const qs = params.toString()
     return this.request(`/workspaces/${workspaceId}/sessions${qs ? `?${qs}` : ''}`)
+  }
+
+  async getSessionFacets(workspaceId: string): Promise<SessionFacets> {
+    return this.request(`/workspaces/${workspaceId}/sessions/facets`)
   }
 
   async getSession(

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -24,6 +24,8 @@ export type { ApiTag as Tag } from '@neutree-ai/types'
 
 export type { ApiSession as Session, ApiK8sStatus as K8sResourceStatus } from '@neutree-ai/types'
 
+export type { ApiSessionFacets as SessionFacets } from '@neutree-ai/types'
+
 export type { ApiMessage } from '@neutree-ai/types'
 
 export interface ChatImageAttachment {

--- a/web/src/lib/session-filter.test.ts
+++ b/web/src/lib/session-filter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EMPTY_SESSION_FILTER,
+  activeFacetCount,
+  normalizeSessionFilter,
+  normalizeStatuses,
+  timeWindowStart,
+} from './session-filter'
+
+describe('activeFacetCount', () => {
+  it('is zero for the default filter', () => {
+    expect(activeFacetCount(EMPTY_SESSION_FILTER)).toBe(0)
+  })
+
+  it('counts facets, not selections within a facet', () => {
+    expect(
+      activeFacetCount({
+        ...EMPTY_SESSION_FILTER,
+        excludedSources: ['schedule', 'webhook'],
+      }),
+    ).toBe(1)
+  })
+
+  it('adds up across facets', () => {
+    expect(
+      activeFacetCount({
+        excludedSources: ['schedule'],
+        statuses: ['human'],
+        time: '7d',
+        starredOnly: true,
+      }),
+    ).toBe(4)
+  })
+})
+
+describe('normalizeStatuses', () => {
+  it('collapses a full selection to "no filter"', () => {
+    expect(normalizeStatuses(['human', 'agent', 'idle'])).toEqual([])
+  })
+
+  it('keeps a partial selection', () => {
+    expect(normalizeStatuses(['human'])).toEqual(['human'])
+  })
+})
+
+describe('timeWindowStart', () => {
+  // Local-time constructors: the window is snapped to the *viewer's* day, so
+  // fixing an instant in UTC would make these assertions timezone-dependent.
+  const now = new Date(2026, 6, 27, 9, 30)
+
+  it('has no lower bound for "any"', () => {
+    expect(timeWindowStart('any', now)).toBeUndefined()
+  })
+
+  it('snaps to a local day boundary so the react-query key is stable', () => {
+    const today = timeWindowStart('today', now)
+    const laterSameDay = timeWindowStart('today', new Date(2026, 6, 27, 23, 59))
+    expect(today).toBe(laterSameDay)
+    expect(new Date(today!).getHours()).toBe(0)
+  })
+
+  it('counts the window inclusive of today', () => {
+    const start = new Date(timeWindowStart('7d', now)!)
+    const today = new Date(now)
+    today.setHours(0, 0, 0, 0)
+    const days = Math.round((today.getTime() - start.getTime()) / 86_400_000)
+    expect(days).toBe(6)
+  })
+})
+
+describe('normalizeSessionFilter', () => {
+  it('reads a missing or partial stored value as "not filtering"', () => {
+    expect(normalizeSessionFilter(undefined)).toEqual(EMPTY_SESSION_FILTER)
+    expect(normalizeSessionFilter({ starredOnly: true })).toEqual({
+      ...EMPTY_SESSION_FILTER,
+      starredOnly: true,
+    })
+  })
+
+  it('drops values this build no longer knows', () => {
+    const filter = normalizeSessionFilter({
+      statuses: ['human', 'retired-bucket'] as never,
+      time: 'last-quarter' as never,
+    })
+    expect(filter.statuses).toEqual(['human'])
+    expect(filter.time).toBe('any')
+  })
+})

--- a/web/src/lib/session-filter.ts
+++ b/web/src/lib/session-filter.ts
@@ -1,0 +1,94 @@
+/**
+ * View filter for the session list.
+ *
+ * Every facet is applied server-side. The list is paginated, so a client-side
+ * filter would only narrow the pages already fetched — in a workspace whose
+ * sessions are mostly scheduled runs, that returns a near-empty list while
+ * infinite scroll keeps paging.
+ */
+
+/** Coarse status buckets, matching how the list classifies `chat_status`. */
+export type SessionStatusBucket = 'human' | 'agent' | 'idle'
+
+export const SESSION_STATUS_BUCKETS: SessionStatusBucket[] = ['human', 'agent', 'idle']
+
+/** Time window, evaluated against `last_active_at`. */
+export type SessionTimeWindow = 'any' | 'today' | '7d' | '30d'
+
+export const SESSION_TIME_WINDOWS: SessionTimeWindow[] = ['any', 'today', '7d', '30d']
+
+export interface SessionFilter {
+  /**
+   * Sources to leave out. Stored as an exclusion set — not the sources to
+   * keep — so a filter saved today can't hide a connector type that ships
+   * tomorrow.
+   */
+  excludedSources: string[]
+  /** Statuses to keep. Empty means all; never stores the full set. */
+  statuses: SessionStatusBucket[]
+  time: SessionTimeWindow
+  starredOnly: boolean
+}
+
+export const EMPTY_SESSION_FILTER: SessionFilter = {
+  excludedSources: [],
+  statuses: [],
+  time: 'any',
+  starredOnly: false,
+}
+
+/**
+ * Coerces a persisted filter back into shape. The value round-trips through
+ * `workspace_profile` jsonb, so it can be older than this build — a missing
+ * facet must read as "not filtering", never as undefined leaking into a query.
+ */
+export function normalizeSessionFilter(
+  raw: Partial<SessionFilter> | undefined | null,
+): SessionFilter {
+  return {
+    excludedSources: Array.isArray(raw?.excludedSources) ? raw.excludedSources : [],
+    statuses: Array.isArray(raw?.statuses)
+      ? raw.statuses.filter((s): s is SessionStatusBucket =>
+          SESSION_STATUS_BUCKETS.includes(s as SessionStatusBucket),
+        )
+      : [],
+    time: SESSION_TIME_WINDOWS.includes(raw?.time as SessionTimeWindow)
+      ? (raw?.time as SessionTimeWindow)
+      : 'any',
+    starredOnly: raw?.starredOnly === true,
+  }
+}
+
+/**
+ * How many facets deviate from the default. Drives the badge on the filter
+ * button — a number needs no translation and stays correct as facets are
+ * added, unlike a generated summary of what is currently hidden.
+ */
+export function activeFacetCount(f: SessionFilter): number {
+  return (
+    (f.excludedSources.length ? 1 : 0) +
+    (f.statuses.length ? 1 : 0) +
+    (f.time !== 'any' ? 1 : 0) +
+    (f.starredOnly ? 1 : 0)
+  )
+}
+
+/** Normalizes a status selection: keeping everything is the same as no filter. */
+export function normalizeStatuses(next: SessionStatusBucket[]): SessionStatusBucket[] {
+  return next.length === SESSION_STATUS_BUCKETS.length ? [] : next
+}
+
+/**
+ * Start of the window as an ISO instant, or undefined for 'any'.
+ *
+ * Snapped to a local day boundary: the value lands in a react-query key, and
+ * a rolling millisecond would invalidate the list on every render.
+ */
+export function timeWindowStart(window: SessionTimeWindow, now = new Date()): string | undefined {
+  if (window === 'any') return undefined
+  const start = new Date(now)
+  start.setHours(0, 0, 0, 0)
+  if (window === '7d') start.setDate(start.getDate() - 6)
+  if (window === '30d') start.setDate(start.getDate() - 29)
+  return start.toISOString()
+}

--- a/web/src/lib/session-source.ts
+++ b/web/src/lib/session-source.ts
@@ -1,0 +1,52 @@
+import {
+  Bot,
+  CalendarClock,
+  Globe,
+  type LucideIcon,
+  MessageCircle,
+  Slack,
+  Webhook,
+} from 'lucide-react'
+
+/**
+ * Per-source leading icon and label key, shared by the session rows and the
+ * filter menu so a source looks the same wherever it is named.
+ *
+ * Literal switch (not `icons[source]`) keeps each source greppable and lets
+ * new connector types fail loudly into the muted fallback.
+ */
+export function sourceVisual(source: string): { Icon: LucideIcon; labelKey: string } {
+  switch (source) {
+    case 'schedule':
+      return { Icon: CalendarClock, labelKey: 'schedule' }
+    case 'slack':
+      return { Icon: Slack, labelKey: 'slack' }
+    case 'wecom':
+      return { Icon: MessageCircle, labelKey: 'wecom' }
+    case 'webhook':
+      return { Icon: Webhook, labelKey: 'webhook' }
+    case 'agent':
+      return { Icon: Bot, labelKey: 'agent' }
+    default:
+      // 'web' (manual) and any unknown source.
+      return { Icon: Globe, labelKey: 'web' }
+  }
+}
+
+/**
+ * Source order in the filter menu. Anything the workspace has seen but that
+ * isn't listed here (a connector type newer than this build) sorts last rather
+ * than disappearing.
+ */
+const SOURCE_ORDER = ['web', 'schedule', 'slack', 'wecom', 'webhook', 'agent']
+
+export function sortSources(sources: string[]): string[] {
+  return [...sources].sort((a, b) => {
+    const ai = SOURCE_ORDER.indexOf(a)
+    const bi = SOURCE_ORDER.indexOf(b)
+    if (ai === -1 && bi === -1) return a.localeCompare(b)
+    if (ai === -1) return 1
+    if (bi === -1) return -1
+    return ai - bi
+  })
+}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3473,6 +3473,26 @@
       "unstar": "Unstar",
       "starred": "Starred",
       "filterStarred": "Show starred only",
+      "filter": {
+        "title": "Filter",
+        "activeLabel": "Filter ({{count}} active)",
+        "source": "Source",
+        "status": "Status",
+        "time": "Time",
+        "all": "All",
+        "clear": "Clear all filters",
+        "statusValue": {
+          "human": "Needs you",
+          "agent": "Running",
+          "idle": "Idle"
+        },
+        "timeValue": {
+          "any": "Any time",
+          "today": "Today",
+          "7d": "Last 7 days",
+          "30d": "Last 30 days"
+        }
+      },
       "unreadCount_one": "{{count}} needs you",
       "unreadCount_other": "{{count}} need you",
       "locateUnread": "Jump to next session that needs you",
@@ -3486,9 +3506,9 @@
         "title": "No matching sessions",
         "description": "Try a different search term."
       },
-      "starredEmpty": {
-        "title": "No starred sessions",
-        "description": "Star a session to keep it within easy reach."
+      "filteredEmpty": {
+        "title": "No sessions match these filters",
+        "description": "Adjust or clear the filters to see other sessions."
       },
       "toasts": {
         "renamed": "Session renamed",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3497,6 +3497,26 @@
       "unstar": "取消收藏",
       "starred": "已收藏",
       "filterStarred": "只看收藏",
+      "filter": {
+        "title": "筛选",
+        "activeLabel": "筛选（已启用 {{count}} 项）",
+        "source": "来源",
+        "status": "状态",
+        "time": "时间",
+        "all": "全部",
+        "clear": "清除全部筛选",
+        "statusValue": {
+          "human": "待你回复",
+          "agent": "运行中",
+          "idle": "空闲"
+        },
+        "timeValue": {
+          "any": "不限",
+          "today": "今天",
+          "7d": "近 7 天",
+          "30d": "近 30 天"
+        }
+      },
       "unreadCount_one": "{{count}} 个待回复",
       "unreadCount_other": "{{count}} 个待回复",
       "locateUnread": "跳转到下一个待回复会话",
@@ -3510,9 +3530,9 @@
         "title": "没有匹配的会话",
         "description": "请尝试其他搜索词。"
       },
-      "starredEmpty": {
-        "title": "还没有收藏的会话",
-        "description": "收藏会话后，可在这里快速找到。"
+      "filteredEmpty": {
+        "title": "没有符合筛选条件的会话",
+        "description": "调整或清除筛选条件即可看到其他会话。"
       },
       "toasts": {
         "renamed": "会话已重命名",


### PR DESCRIPTION
Closes #184.

Sessions started by a person get buried under connector- and schedule-triggered ones. This adds a general filter over the session list — source, status, time window, starred — rather than a special case for scheduled sessions, since any connector type can dominate a workspace.

## Why it has to be server-side

The list is paginated (20/page, ordered by `last_active_at`). Collapsing or filtering the loaded pages leaves the hidden rows consuming page slots: the user sees a near-empty list while infinite scroll keeps fetching. Every facet reaches the SQL.

## control-plane

- `buildSessionListWhere()` — the page query, the `COUNT`, and the facet counts now take their predicate from one place. They each assembled their own before, and a `total` that disagrees with the list is invisible until someone scrolls to the end.
- `chat_status` collapses into three buckets in SQL (`agent` / `human` / everything-else-is-idle), matching the client's classification, so an unrecognized status stays visible rather than falling out of every bucket.
- `GET /workspaces/{id}/sessions` gains `exclude_sources`, `status`, `active_after`.
- `GET /workspaces/{id}/sessions/facets` returns counts per source and status, plus starred and total.

## web

- `SessionFilterMenu` — one funnel button; source / status / time are `DropdownMenuSub` submenus, "starred only" is a toggle in the parent. The parent menu stays visible while a submenu is open, so switching facets is a horizontal move, and the menu doesn't grow taller as connector types are added.
- Counts sit next to each option. This is the part that makes the feature explain itself: seeing `132` scheduled against `12` manual tells the user why their list is crowded and what filtering will do.
- Active state is a **numeric badge** on the funnel, not a chip row. An exclusion-based filter produces inverted phrasing ("hiding scheduled and 2 others") that needs per-language pluralization and grows with every new source type; a number needs neither and stays correct as facets are added.
- The standalone star toggle folds into the menu, so filter state has exactly one entry point and one indicator.
- Filter state persists in `workspace_profile` (view config, per the persistence rule in `web/docs/new-ux.md`). That's what removes the need for a product-level default: we ship "show everything", and whoever doesn't want scheduled runs unchecks them once. Stored values are normalized on read, since they can predate the current facet set.
- Filtered-empty gets its own state with a "clear filters" action — without a chip row it's the one place with no visible way back.

Source filtering is an **exclusion** list on the wire and in storage. An inclusion whitelist would silently hide any connector type added after the user saved their filter.

## Deliberately out of scope

- The session switcher dropdown in the chat panel shares `useSessions` and is equally crowded, but filter state lives on the sessions-panel instance. Unifying means lifting it to the workspace level.
- Facet counts are unconditioned (they describe the workspace, not the current filter). Conditioning each facet on the others costs one query per facet.
- Custom date ranges.
- The auto-select hook deliberately keeps reading the unfiltered list, so a session that just finished can't become unselectable.

## Verification

`tsc --noEmit` clean in both packages; knip clean; biome clean on touched files. Full suites pass — web 155, control-plane 329, including 10 new cases covering placeholder numbering (a gap there would mis-page the list), facet-count semantics, timezone-independent time windows, and downgrading a stored filter this build no longer understands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSdtMT7BxkcgDfNMaTQ9XL
