### PR TITLE
fix(sessions): name every session source, and align the filter menu

### DIFF
--- a/web/src/components/workspace/SessionFilterMenu.tsx
+++ b/web/src/components/workspace/SessionFilterMenu.tsx
@@ -22,9 +22,9 @@ import {
   activeFacetCount,
   normalizeStatuses,
 } from '@/lib/session-filter'
-import { sortSources, sourceVisual } from '@/lib/session-source'
+import { sortSources, sourceLabel, sourceVisual } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
-import { Filter, Star } from 'lucide-react'
+import { Filter } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -107,7 +107,7 @@ export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilt
 
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
+          <DropdownMenuSubTrigger inset>
             <span>{t('components.sessions.filter.source')}</span>
             <span className="ml-auto text-muted-foreground text-xs tabular-nums">
               {facetSummary(
@@ -118,7 +118,7 @@ export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilt
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-48">
             {knownSources.map((source) => {
-              const { Icon, labelKey } = sourceVisual(source)
+              const { Icon } = sourceVisual(source)
               return (
                 <DropdownMenuCheckboxItem
                   key={source}
@@ -128,7 +128,7 @@ export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilt
                   onSelect={keepOpen}
                 >
                   <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={2} />
-                  <span className="truncate">{t(`components.sessions.source.${labelKey}`)}</span>
+                  <span className="truncate">{sourceLabel(source, t)}</span>
                   <span className="ml-auto text-muted-foreground text-xs tabular-nums">
                     {facets?.source[source] ?? 0}
                   </span>
@@ -139,7 +139,7 @@ export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilt
         </DropdownMenuSub>
 
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
+          <DropdownMenuSubTrigger inset>
             <span>{t('components.sessions.filter.status')}</span>
             <span className="ml-auto text-muted-foreground text-xs tabular-nums">
               {facetSummary(statusesKept, SESSION_STATUS_BUCKETS.length)}
@@ -165,7 +165,7 @@ export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilt
         </DropdownMenuSub>
 
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
+          <DropdownMenuSubTrigger inset>
             <span>{t('components.sessions.filter.time')}</span>
             <span className="ml-auto text-muted-foreground text-xs">
               {t(`components.sessions.filter.timeValue.${filter.time}`)}
@@ -188,12 +188,10 @@ export function SessionFilterMenu({ workspaceId, filter, onChange }: SessionFilt
         <DropdownMenuSeparator />
 
         <DropdownMenuCheckboxItem
-          className="gap-2"
           checked={filter.starredOnly}
           onCheckedChange={(next) => onChange({ ...filter, starredOnly: next === true })}
           onSelect={keepOpen}
         >
-          <Star className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={2} />
           <span className="truncate">{t('components.sessions.filterStarred')}</span>
           <span className="ml-auto text-muted-foreground text-xs tabular-nums">
             {facets?.starred ?? 0}

--- a/web/src/components/workspace/WorkspaceSessionsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSessionsPanel.tsx
@@ -19,7 +19,7 @@ import {
   activeFacetCount,
   normalizeSessionFilter,
 } from '@/lib/session-filter'
-import { sourceVisual } from '@/lib/session-source'
+import { sourceLabel, sourceVisual } from '@/lib/session-source'
 import { cleanSessionPreview } from '@/lib/session-utils'
 import { cn } from '@/lib/utils'
 import { useActiveSession } from '@/stores/active-session-store'
@@ -90,8 +90,8 @@ function SessionRow({
   const { t, i18n } = useTranslation()
   const status = classifyStatus(session.chat_status)
   const starred = !!session.starred_at
-  const { Icon: SourceIcon, labelKey: sourceLabelKey } = sourceVisual(session.source)
-  const sourceLabel = t(`components.sessions.source.${sourceLabelKey}`)
+  const { Icon: SourceIcon } = sourceVisual(session.source)
+  const sourceText = sourceLabel(session.source, t)
   const relTime = useMemo(
     () => formatRelativeTime(session.created_at, i18n.language),
     [session.created_at, i18n.language],
@@ -221,9 +221,9 @@ function SessionRow({
       <SourceIcon
         className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50"
         strokeWidth={2}
-        aria-label={sourceLabel}
+        aria-label={sourceText}
       >
-        <title>{sourceLabel}</title>
+        <title>{sourceText}</title>
       </SourceIcon>
       <div className="min-w-0 flex-1">{titleNode}</div>
       {starred && (

--- a/web/src/lib/session-source.test.ts
+++ b/web/src/lib/session-source.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { sortSources, sourceLabel, sourceVisual } from './session-source'
+
+// Stand-in for i18next's `t`: returns the last key segment so assertions read
+// as the label key that would have been looked up.
+const t = (key: string) => key.split('.').pop() ?? key
+
+describe('sourceVisual', () => {
+  it('gives every known source its own label key', () => {
+    const known = [
+      'web',
+      'schedule',
+      'slack',
+      'wecom',
+      'webhook',
+      'agent',
+      'api',
+      'batch',
+      'teamwork',
+    ]
+    const keys = known.map((s) => sourceVisual(s).labelKey)
+    expect(new Set(keys).size).toBe(known.length)
+  })
+
+  it('does not fold an unknown source into the manual label', () => {
+    // Two sources rendering under the same name are indistinguishable in the
+    // filter menu — the bug this guards.
+    expect(sourceVisual('some-future-connector').labelKey).toBeNull()
+    expect(sourceLabel('some-future-connector', t)).toBe('some-future-connector')
+    expect(sourceLabel('web', t)).toBe('web')
+  })
+})
+
+describe('sortSources', () => {
+  it('sorts known sources into a fixed order', () => {
+    expect(sortSources(['agent', 'web', 'slack'])).toEqual(['web', 'slack', 'agent'])
+  })
+
+  it('puts unknown sources last rather than dropping them', () => {
+    expect(sortSources(['zzz-new', 'web'])).toEqual(['web', 'zzz-new'])
+  })
+})

--- a/web/src/lib/session-source.ts
+++ b/web/src/lib/session-source.ts
@@ -1,10 +1,14 @@
 import {
   Bot,
   CalendarClock,
+  CircleDashed,
   Globe,
+  Layers,
   type LucideIcon,
   MessageCircle,
   Slack,
+  Terminal,
+  Users,
   Webhook,
 } from 'lucide-react'
 
@@ -12,11 +16,15 @@ import {
  * Per-source leading icon and label key, shared by the session rows and the
  * filter menu so a source looks the same wherever it is named.
  *
- * Literal switch (not `icons[source]`) keeps each source greppable and lets
- * new connector types fail loudly into the muted fallback.
+ * Literal switch (not `icons[source]`) keeps each source greppable. A source
+ * this build doesn't know gets `labelKey: null` and is rendered under its raw
+ * value — folding it into 'web' would print two identically-labelled entries
+ * in the filter menu with no way to tell them apart.
  */
-export function sourceVisual(source: string): { Icon: LucideIcon; labelKey: string } {
+export function sourceVisual(source: string): { Icon: LucideIcon; labelKey: string | null } {
   switch (source) {
+    case 'web':
+      return { Icon: Globe, labelKey: 'web' }
     case 'schedule':
       return { Icon: CalendarClock, labelKey: 'schedule' }
     case 'slack':
@@ -27,10 +35,21 @@ export function sourceVisual(source: string): { Icon: LucideIcon; labelKey: stri
       return { Icon: Webhook, labelKey: 'webhook' }
     case 'agent':
       return { Icon: Bot, labelKey: 'agent' }
+    case 'api':
+      return { Icon: Terminal, labelKey: 'api' }
+    case 'batch':
+      return { Icon: Layers, labelKey: 'batch' }
+    case 'teamwork':
+      return { Icon: Users, labelKey: 'teamwork' }
     default:
-      // 'web' (manual) and any unknown source.
-      return { Icon: Globe, labelKey: 'web' }
+      return { Icon: CircleDashed, labelKey: null }
   }
+}
+
+/** Display name for a source: the translated label, or the raw value if unknown. */
+export function sourceLabel(source: string, t: (key: string) => string): string {
+  const { labelKey } = sourceVisual(source)
+  return labelKey ? t(`components.sessions.source.${labelKey}`) : source
 }
 
 /**
@@ -38,7 +57,17 @@ export function sourceVisual(source: string): { Icon: LucideIcon; labelKey: stri
  * isn't listed here (a connector type newer than this build) sorts last rather
  * than disappearing.
  */
-const SOURCE_ORDER = ['web', 'schedule', 'slack', 'wecom', 'webhook', 'agent']
+const SOURCE_ORDER = [
+  'web',
+  'schedule',
+  'slack',
+  'wecom',
+  'webhook',
+  'agent',
+  'api',
+  'batch',
+  'teamwork',
+]
 
 export function sortSources(sources: string[]): string[] {
   return [...sources].sort((a, b) => {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3531,7 +3531,10 @@
         "schedule": "Scheduled",
         "slack": "Slack",
         "wecom": "WeCom",
-        "webhook": "Webhook"
+        "webhook": "Webhook",
+        "api": "API",
+        "batch": "Batch",
+        "teamwork": "Teamwork"
       }
     },
     "automation": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3555,7 +3555,10 @@
         "schedule": "计划任务",
         "slack": "Slack",
         "wecom": "企业微信",
-        "webhook": "Webhook"
+        "webhook": "Webhook",
+        "api": "API 调用",
+        "batch": "批量任务",
+        "teamwork": "协作任务"
       }
     },
     "automation": {


### PR DESCRIPTION
Follow-up to #185, from testing the menu against real data.

## Two entries named "manual"

`sourceVisual`'s default branch mapped every unrecognized source onto the `web` label. This deployment stores nine distinct values, and three of them — `api`, `batch`, `teamwork` — were never in the switch, so they all rendered as "manual" with nothing to tell them apart.

- Those three get their own icon and label.
- The fallback now returns `labelKey: null`, and callers render the raw source value under a neutral icon. A source we haven't named yet should look unnamed rather than look like a different source — silently borrowing a neighbour's label is how this bug stayed invisible.
- Both call sites (filter menu, session row tooltip) go through a shared `sourceLabel()` helper so they can't drift.

## Starred toggle out of line

In the parent menu the three submenu rows had no left gutter while the starred checkbox reserved one for its indicator, so its label sat further right than the rest. The submenu triggers are inset to match, and the star glyph is gone — the check indicator already carries the state, and the icon pushed the label out of the column again.

## Verification

`tsc --noEmit` clean, biome clean, web suite 159 pass (4 new: every known source resolves to a distinct label, an unknown source does not fold into the manual label, ordering keeps unknown sources last instead of dropping them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSdtMT7BxkcgDfNMaTQ9XL
