### PR TITLE
feat(skills): discard in-workspace skill edits and restore the published version

### DIFF
--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -396,6 +396,92 @@ describe('SkillManager', () => {
     })
   })
 
+  describe('discardChanges', () => {
+    const ETAG = '"v1"'
+
+    /**
+     * Manager with `name` loaded from CP at ETag `v1`, in editing mode, plus a
+     * stray file an agent wrote into the skill dir. `requests` records the
+     * If-None-Match header of every package fetch.
+     */
+    async function editedManager(name: string) {
+      const requests: (string | null)[] = []
+      const tarBuf = Buffer.from('published-tar-gz')
+      const fetchImpl = async (url: string, init?: { headers?: Record<string, string> }) => {
+        if (url.includes('/workspaces/ws-1/skills'))
+          return jsonResponse({ skills: [{ name, id: 'sk-1', editable: true }] })
+        if (url.includes('/_cp/skills/sk-1/package')) {
+          const inm = init?.headers?.['If-None-Match'] ?? null
+          requests.push(inm)
+          return inm === ETAG ? notModifiedResponse(ETAG) : binaryResponse(tarBuf, ETAG)
+        }
+        throw new Error(`Unexpected fetch: ${url}`)
+      }
+      const mgr = createManager(fetchImpl)
+      await mgr.load()
+      // The in-memory shell's `ln` is a no-op; materialize the dest so the
+      // ETag sidecar would be trusted (that's what discard has to defeat).
+      fs.dirs.add(`${SKILLS_DIR}/${name}`)
+      await mgr.startEditing(name)
+      fs.files.set(`${LOCAL_BASE}/skill-${name}/rogue.md`, 'written by the agent')
+      shell.calls.length = 0
+      return { mgr, requests }
+    }
+
+    test('restores the published version, dropping local edits and the lock', async () => {
+      const { mgr, requests } = await editedManager('test')
+
+      await mgr.discardChanges('test')
+
+      // Unconditional re-download: a 304 would have left the edits in place.
+      expect(requests).toEqual([null, null])
+      expect(fs.files.has('/tmp/skill-test/rogue.md')).toBe(false)
+      expect(mgr.isEditing('test')).toBe(false)
+      // Fresh extraction, and the ETag sidecar is back in sync.
+      expect(shell.calls.find((c) => c.cmd === 'tar' && c.args[0] === 'xzf')).toBeTruthy()
+      expect(fs.files.get('/tmp/.skill-etag-test')).toBe(ETAG)
+      expect(fs.files.has('/tmp/.skill-managed-test')).toBe(true)
+    })
+
+    test('rejects a skill CP does not know, keeping the only copy intact', async () => {
+      const mgr = createManager(async () => {
+        throw new Error('discardChanges must not fetch for an unpublished draft')
+      })
+      await mgr.createDraft('brand-new')
+
+      await expect(mgr.discardChanges('brand-new')).rejects.toThrow('No published version')
+      expect(fs.files.has('/tmp/skill-brand-new/SKILL.md')).toBe(true)
+      expect(mgr.isEditing('brand-new')).toBe(true)
+    })
+
+    test('rejects a reserved platform skill name', async () => {
+      const mgr = createManager(async () => { throw new Error('no fetch') })
+      await expect(mgr.discardChanges('__platform__')).rejects.toThrow('reserved')
+    })
+
+    test('leaves edits untouched when the download exhausts its retries', async () => {
+      const tarBuf = Buffer.from('published-tar-gz')
+      let failDownloads = false
+      const fetchImpl = async (url: string) => {
+        if (url.includes('/workspaces/ws-1/skills'))
+          return jsonResponse({ skills: [{ name: 'flaky', id: 'sk-1', editable: true }] })
+        if (url.includes('/_cp/skills/sk-1/package'))
+          return failDownloads ? errorResponse(503) : binaryResponse(tarBuf)
+        throw new Error(`Unexpected fetch: ${url}`)
+      }
+      const mgr = createManager(fetchImpl)
+      await mgr.load()
+      await mgr.startEditing('flaky')
+      fs.files.set('/tmp/skill-flaky/rogue.md', 'written by the agent')
+      failDownloads = true
+
+      await expect(mgr.discardChanges('flaky')).rejects.toThrow('Failed to fetch published version')
+      // Nothing was swapped out: the user still has their work and their lock.
+      expect(fs.files.get('/tmp/skill-flaky/rogue.md')).toBe('written by the agent')
+      expect(mgr.isEditing('flaky')).toBe(true)
+    })
+  })
+
   describe('createDraft', () => {
     test('creates directory with SKILL.md template and enters editing mode', async () => {
       const mgr = createManager(async () => { throw new Error('no fetch') })
@@ -777,6 +863,38 @@ describe('SkillManager draft persistence (draftBase)', () => {
     const tarCall = shell.calls.find((c) => c.cmd === 'tar' && c.args[0] === 'xzf')
     expect(tarCall!.args[1]).toMatch(/^\/tmp\/skill-done\.staging-/)
     expect(result.loaded).toEqual(['done'])
+  })
+
+  test('discardChanges reclaims the persistent draft of a git-imported skill', async () => {
+    const tarBuf = Buffer.from('published-tar-gz')
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/workspaces/ws-1/skills'))
+        return jsonResponse({
+          skills: [{ name: 'imported', id: 'sk-g', editable: true, gitSource: true }],
+        })
+      if (url.includes('/_cp/skills/sk-g/package')) return binaryResponse(tarBuf)
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    const mgr = createManager(fetchImpl)
+    await mgr.load()
+    fs.dirs.add('/workspace/.claude/skills/imported')
+    // Editing promotes the skill onto the persistent draftBase.
+    await mgr.startEditing('imported')
+    fs.files.set('/workspace/.skills-draft/skill-imported/rogue.md', 'written by the agent')
+    shell.calls.length = 0
+
+    await mgr.discardChanges('imported')
+
+    // Draft reclaimed; content re-materialised on tmpfs and re-symlinked there.
+    expect(fs.dirs.has('/workspace/.skills-draft/skill-imported')).toBe(false)
+    expect(fs.files.has('/workspace/.skills-draft/skill-imported/rogue.md')).toBe(false)
+    expect(shell.calls).toContainEqual({
+      cmd: 'ln',
+      args: ['-sfn', '/tmp/skill-imported', '/workspace/.claude/skills/imported'],
+    })
+    expect(mgr.isEditing('imported')).toBe(false)
+    // Restoring from CP doesn't change where the skill came from.
+    expect(mgr.isGitSource('imported')).toBe(true)
   })
 
   // installPlatformSkill runs on every agent boot. Under auto-scaling, N replicas

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -705,6 +705,62 @@ export class SkillManager {
     }
   }
 
+  /**
+   * Throw away in-container edits and restore the skill directory to the
+   * version currently published on CP.
+   *
+   * Deliberately reuses the normal load path (download → extractAtomic) rather
+   * than reimplementing fetch/unpack: the result is byte-identical to what a
+   * fresh pod would materialise for this skill. The only extra steps are
+   * dropping the ETag sidecar first — so an unchanged active version still
+   * comes back as a full package instead of a 304 that would leave the edited
+   * files in place — and reclaiming the persistent draft dir, so the skill
+   * ends up back on tmpfs as a plain published skill.
+   *
+   * A skill CP doesn't know about (a draft created locally and never
+   * published) has no version to restore to, so this rejects instead of
+   * silently wiping the user's only copy. Same for a download that exhausts
+   * its retries: the current content is left untouched.
+   *
+   * Afterwards the skill is no longer "editing" — the extracted package never
+   * contains the `.editing` lock (pack excludes it), and we clear any lock
+   * left over from a draft location.
+   */
+  async discardChanges(name: string): Promise<void> {
+    assertNotReserved(name)
+    if (!this._knownSkills.has(name)) {
+      throw new Error(`No published version to restore for skill: ${name}`)
+    }
+
+    // Force a full download: readKnownEtag would otherwise make CP answer 304
+    // for the version we are trying to restore.
+    try {
+      await this.fs.rm(this.etagPath(name))
+    } catch {
+      // Best-effort: a surviving sidecar only risks a redundant 304 below,
+      // which we surface as a failure rather than a silent no-op.
+    }
+
+    const res = await this.downloadWithRetry(name)
+    if (res.kind !== 'ok') {
+      throw new Error(`Failed to fetch published version for skill: ${name}`)
+    }
+
+    // Serialize disk mutations against a concurrent load()/pack() for the same
+    // name, exactly as load() does around its own extract.
+    await this.withNameLock(name, async () => {
+      if (this.draftBase && this.isDraft(name)) {
+        // Drop the persistent draft copy before extracting so localDir()
+        // resolves back to tmpfs and the symlink is re-pointed there.
+        await this.fs.rm(this.draftDir(name))
+        await this.fs.rm(this.destDir(name))
+      }
+      await this.extractAtomic(name, res.buf, res.etag)
+      await this.markManaged(name)
+      await this.stopEditing(name)
+    })
+  }
+
   // ── Create draft ──
 
   /** Create a new empty skill with a template SKILL.md. */

--- a/internal/agent-skills/src/routes.ts
+++ b/internal/agent-skills/src/routes.ts
@@ -83,6 +83,18 @@ export function registerSkillRoutes(
     }
   })
 
+  // Discard in-container edits: restore the skill from its published version
+  app.post(`${prefix}/:name/discard`, async (c: any) => {
+    try {
+      const name = c.req.param('name')
+      await mgr().discardChanges(name)
+      return c.json({ success: true })
+    } catch (e: any) {
+      console.error(`[skills] discard_failed name=${c.req.param('name')} error=${e?.message}`)
+      return c.json({ error: e.message }, 500)
+    }
+  })
+
   // Create a new draft skill
   app.post(`${prefix}`, async (c: any) => {
     try {

--- a/web/src/components/workspace/WorkspaceSkillsPanel.tsx
+++ b/web/src/components/workspace/WorkspaceSkillsPanel.tsx
@@ -14,6 +14,7 @@
  */
 import { AppHeaderButton } from '@/components/shell/windows/AppHeaderButton'
 import { Button } from '@/components/ui/button'
+import { ConfirmButton } from '@/components/ui/confirm-button'
 import {
   Dialog,
   DialogContent,
@@ -27,7 +28,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { isCommitEnter } from '@/lib/keyboard'
 import { skillsRefresh } from '@/plugins/skills'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Check, Plus, Trash2, Upload } from 'lucide-react'
+import { Check, Plus, RotateCcw, Trash2, Upload } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -102,19 +103,34 @@ export function WorkspaceSkillsPanel({ workspaceId, instanceId }: WorkspaceSkill
   // enabled skill — we keep both around because publish/remove still match
   // by name (the in-container filesystem identity), but the PUT body now
   // requires UUIDs.
+  const fetchEnabledSkillsResponse =
+    useCallback(async (): Promise<WorkspaceEnabledSkillsResponse> => {
+      const resp = await fetch(workspaceSkillUrls.workspaceSkills(workspaceId), {
+        credentials: 'include',
+      })
+      if (!resp.ok) return { skills: [] }
+      return resp.json()
+    }, [workspaceId])
+
   const fetchEnabledSkills = useCallback(async (): Promise<WorkspaceEnabledSkillEntry[]> => {
     const data = await qc.fetchQuery<WorkspaceEnabledSkillsResponse>({
       queryKey: enabledSkillsQueryKey(workspaceId),
-      queryFn: async () => {
-        const resp = await fetch(workspaceSkillUrls.workspaceSkills(workspaceId), {
-          credentials: 'include',
-        })
-        if (!resp.ok) return { skills: [] }
-        return resp.json()
-      },
+      queryFn: fetchEnabledSkillsResponse,
     })
     return data.skills ?? []
-  }, [qc, workspaceId])
+  }, [qc, workspaceId, fetchEnabledSkillsResponse])
+
+  // Skills the library has a published version of. Discard restores *that*
+  // version, so a locally created draft that was never published has nothing
+  // to restore from — the action stays disabled for it.
+  const enabledSkillsQuery = useQuery<WorkspaceEnabledSkillsResponse>({
+    queryKey: enabledSkillsQueryKey(workspaceId),
+    queryFn: fetchEnabledSkillsResponse,
+  })
+  const publishedNames = useMemo(
+    () => new Set((enabledSkillsQuery.data?.skills ?? []).map((s) => s.name)),
+    [enabledSkillsQuery.data],
+  )
 
   // ── lifecycle mutations ──────────────────────────────────────────────────
   const createDraftMutation = useMutation({
@@ -253,6 +269,32 @@ export function WorkspaceSkillsPanel({ workspaceId, instanceId }: WorkspaceSkill
     onError: (e: any) => toast.error(e.message),
   })
 
+  // Cache-buster for the open file: discard rewrites the skill directory in
+  // the container behind the viewer's back, so bump it to force a re-read.
+  const [viewerRefreshToken, setViewerRefreshToken] = useState(0)
+
+  const discardSkillMutation = useMutation({
+    mutationFn: async (name: string) => {
+      const resp = await fetch(
+        `${workspaceSkillUrls.skillsApi(workspaceId)}/${encodeURIComponent(name)}/discard`,
+        { method: 'POST', credentials: 'include' },
+      )
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}))
+        throw new Error(err.error || t('components.workspaceSkillsPanel.errors.discardFailed'))
+      }
+      return name
+    },
+    onSuccess: async (name) => {
+      // Whole namespace: the skill's editing flag, its file tree and every
+      // cached directory under it just changed on disk.
+      await qc.invalidateQueries({ queryKey: source.cacheNamespace })
+      setViewerRefreshToken((n) => n + 1)
+      toast.success(t('components.workspaceSkillsPanel.toasts.discarded', { name }))
+    },
+    onError: (e: any) => toast.error(e.message),
+  })
+
   const removingName = removeSkillMutation.isPending
     ? (removeSkillMutation.variables ?? null)
     : null
@@ -300,13 +342,15 @@ export function WorkspaceSkillsPanel({ workspaceId, instanceId }: WorkspaceSkill
           const tooltipText = selectedSkill.gitSource
             ? t('components.workspaceSkillsPanel.tooltips.publishGitSource')
             : t('components.workspaceSkillsPanel.tooltips.publish')
+          const hasPublished = publishedNames.has(selectedSkill.name)
+          const discarding = discardSkillMutation.isPending
           return (
-            <div className="border-b border-foreground/[0.06] px-2 py-1.5">
+            <div className="flex items-center gap-1.5 border-b border-foreground/[0.06] px-2 py-1.5">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     size="sm"
-                    className="h-7 w-full text-xs gap-1.5"
+                    className="h-7 flex-1 text-xs gap-1.5"
                     disabled={packingName === selectedSkill.name}
                     onClick={() => publishSkillMutation.mutate(selectedSkill.name)}
                   >
@@ -322,6 +366,35 @@ export function WorkspaceSkillsPanel({ workspaceId, instanceId }: WorkspaceSkill
                   {tooltipText}
                 </TooltipContent>
               </Tooltip>
+              {/* Destructive: arm-then-confirm, same as the remove button. The
+                  tooltip lives outside ConfirmButton (rather than using its
+                  own `tooltip` prop) because a disabled button swallows the
+                  hover events — and "nothing published yet" is exactly the
+                  case we most need to explain. */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <ConfirmButton
+                      size="sm"
+                      variant="outline"
+                      className="h-7 px-2 text-xs gap-1.5"
+                      disabled={!hasPublished || discarding}
+                      icon={
+                        discarding ? <Spinner size="sm" /> : <RotateCcw className="h-3.5 w-3.5" />
+                      }
+                      confirmLabel={t('components.workspaceSkillsPanel.actions.discardConfirm')}
+                      onConfirm={() => discardSkillMutation.mutate(selectedSkill.name)}
+                    >
+                      {t('components.workspaceSkillsPanel.actions.discard')}
+                    </ConfirmButton>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-64 text-xs">
+                  {hasPublished
+                    ? t('components.workspaceSkillsPanel.tooltips.discard')
+                    : t('components.workspaceSkillsPanel.tooltips.discardNoPublished')}
+                </TooltipContent>
+              </Tooltip>
             </div>
           )
         }}
@@ -330,6 +403,7 @@ export function WorkspaceSkillsPanel({ workspaceId, instanceId }: WorkspaceSkill
             workspaceId={workspaceId}
             instanceId={instanceId}
             filePath={fileLocator}
+            refreshToken={viewerRefreshToken}
             // FileViewer's save PUTs the file directly through agent dufs
             // (bypassing source.writes). We splice markEditing in here so
             // the .editing lockfile stays fresh on every save, matching

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2644,13 +2644,17 @@
       "actions": {
         "newDraft": "New draft",
         "publish": "Publish",
+        "discard": "Discard changes",
+        "discardConfirm": "Click again to confirm",
         "remove": "Remove",
         "removeConfirm": "Click again to confirm"
       },
       "tooltips": {
         "publish": "Publish changes to the library so other workspaces can use the updated version.",
         "publishGitSource": "Publish changes to the library. Warning: this Skill was imported from Git, and publishing will be overwritten on the next Git sync.",
-        "remove": "Remove this Skill from the workspace. The Skill stays in your library."
+        "remove": "Remove this Skill from the workspace. The Skill stays in your library.",
+        "discard": "Throw away the in-container edits and restore this Skill to the version published in the library.",
+        "discardNoPublished": "This Skill has never been published, so there is no version to restore. Publish it first, or remove it."
       },
       "empty": {
         "noSkills": {
@@ -2674,6 +2678,7 @@
         "renamed": "Renamed to {{name}}",
         "createdDraft": "Draft \"{{name}}\" created",
         "published": "Published {{name}}",
+        "discarded": "Restored {{name}} to its published version",
         "removed": "Removed {{name}}"
       },
       "errors": {
@@ -2681,6 +2686,7 @@
         "createFolderFailed": "Failed to create folder: {{status}}",
         "createDraftFailed": "Failed to create draft",
         "packFailed": "Failed to pack Skill",
+        "discardFailed": "Failed to discard changes",
         "uploadFailed": "Failed to upload Skill",
         "removeFailed": "Failed to remove Skill"
       }

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2668,13 +2668,17 @@
       "actions": {
         "newDraft": "新建草稿",
         "publish": "发布",
+        "discard": "丢弃改动",
+        "discardConfirm": "再点一次确认",
         "remove": "移除",
         "removeConfirm": "再点一次确认"
       },
       "tooltips": {
         "publish": "将修改发布到资源库，其他工作空间即可使用更新后的版本。",
         "publishGitSource": "将修改发布到资源库。注意：该 Skill 来自 Git 导入，下一次 Git 同步时会覆盖发布结果。",
-        "remove": "从当前工作空间移除该 Skill；资源库中的 Skill 不会被删除。"
+        "remove": "从当前工作空间移除该 Skill；资源库中的 Skill 不会被删除。",
+        "discard": "放弃容器内的改动，把该 Skill 恢复成资源库中已发布的版本。",
+        "discardNoPublished": "该 Skill 尚未发布过，没有可恢复的版本。请先发布，或直接移除。"
       },
       "empty": {
         "noSkills": {
@@ -2698,6 +2702,7 @@
         "renamed": "已重命名为 {{name}}",
         "createdDraft": "已创建草稿“{{name}}”",
         "published": "已发布 {{name}}",
+        "discarded": "已将 {{name}} 恢复为已发布版本",
         "removed": "已移除 {{name}}"
       },
       "errors": {
@@ -2705,6 +2710,7 @@
         "createFolderFailed": "创建文件夹失败：{{status}}",
         "createDraftFailed": "创建草稿失败",
         "packFailed": "打包 Skill 失败",
+        "discardFailed": "丢弃改动失败",
         "uploadFailed": "上传 Skill 失败",
         "removeFailed": "移除 Skill 失败"
       }


### PR DESCRIPTION
## Problem

The workspace skill panel only offers **Publish**. Once an agent has rewritten files under `.claude/skills/<name>/` in the container, a user who doesn't want those edits has to fix the files by hand or remove the skill and re-add it.

## What this adds

A **Discard changes** action that restores the skill directory to the version currently published in the library.

- `SkillManager.discardChanges()` reuses the existing load path (`downloadWithRetry` → `extractAtomic`) rather than reimplementing fetch/unpack, so the result is byte-identical to what a fresh pod would materialise. Two extras: the ETag sidecar is dropped first (otherwise the control plane answers 304 for the very version we're restoring and the edits survive), and the persistent draft dir is reclaimed so the skill lands back on tmpfs as a plain published skill, symlink re-pointed. The skill leaves editing mode as a result.
- Edge cases are refusals, not silent damage: a skill the control plane doesn't know (a local draft never published) has no version to restore, so it throws instead of wiping the user's only copy; a download that exhausts its retries leaves the current content *and* the editing lock untouched.
- Git-imported skills work the same way — the published package is what gets restored, and the skill's git provenance is unchanged.
- New agent route `POST /skills/:name/discard`.

## UI

A two-click confirm button (`ConfirmButton`, matching the remove button's arm-then-confirm) sits next to Publish in the skill tree header. For a skill that was never published the button is disabled with a tooltip explaining why. The open file is re-read afterwards, since discard rewrites the tree behind the viewer's back. Copy added to both `zh-CN` and `en-US`.

## Tests

5 new cases in `internal/agent-skills`: restore drops local edits + the lock and forces an unconditional re-download; unknown skill rejects and keeps its content; reserved platform name rejects; retry exhaustion is non-destructive; git-imported skill reclaims its persistent draft and keeps `gitSource`.

- `internal/agent-skills`: `bunx vitest run` — 44 passed
- `web`: `npx tsc --noEmit` clean, `npx vitest run` — 159 passed
- `agents/claude-code`: `npx tsc --noEmit` clean (consumer of the changed package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQKgW1NphAmZjTHzP1xd4k