### PR TITLE
fix(k8s-provider): exclude terminating pods from the ready-replica set

### DIFF
--- a/control-plane/src/services/k8s-deployment-spec.test.ts
+++ b/control-plane/src/services/k8s-deployment-spec.test.ts
@@ -326,4 +326,14 @@ describe('readyReplicaIdsFromPods', () => {
     ]
     expect(readyReplicaIdsFromPods(pods, 'tos-ws1')).toEqual([0])
   })
+
+  it('excludes a terminating pod even while its containers still report ready', () => {
+    // A StatefulSet pod deleted (or an ordinal being recreated) keeps a stale
+    // Ready condition for its whole grace period. It must not stay a routing
+    // target, or cp keeps sending turns to a dying agent and never rebinds.
+    const terminating = pod('tos-ws1-1', [true])
+    terminating.metadata!.deletionTimestamp = new Date('2026-07-27T07:00:18Z')
+    const pods = [pod('tos-ws1-0', [true]), terminating, pod('tos-ws1-2', [true])]
+    expect(readyReplicaIdsFromPods(pods, 'tos-ws1')).toEqual([0, 2])
+  })
 })

--- a/internal/k8s-provider/workspace-spec.ts
+++ b/internal/k8s-provider/workspace-spec.ts
@@ -446,12 +446,20 @@ function podReplicaOrdinal(podName: string, stsName: string): number | null {
 /**
  * The replica ids of the Ready pods of a StatefulSet — the readiness signal cp
  * routes on (reported via the endpoint's readyReplicaIds). Returned sorted.
+ *
+ * A pod being deleted is excluded even while its containers still report ready:
+ * once `deletionTimestamp` is set the pod is terminating (SIGTERM in flight, or
+ * a StatefulSet ordinal being recreated), but its Ready condition lingers for
+ * the whole grace period. Routing a turn there hits a dying agent (connection
+ * refused / 502) and, because the ordinal never leaves the ready set, cp never
+ * rebinds the session to a healthy replica. Kubernetes' own Endpoints controller
+ * drops terminating pods for exactly this reason — we mirror it.
  */
 export function readyReplicaIdsFromPods(pods: k8s.V1Pod[], stsName: string): number[] {
   const ids: number[] = []
   for (const pod of pods) {
     const ordinal = podReplicaOrdinal(pod.metadata?.name ?? '', stsName)
-    if (ordinal !== null && isPodReady(pod)) ids.push(ordinal)
+    if (ordinal !== null && isPodReady(pod) && !pod.metadata?.deletionTimestamp) ids.push(ordinal)
   }
   return ids.sort((a, b) => a - b)
 }


### PR DESCRIPTION
## Problem

For an auto-scaling (StatefulSet) workspace, the control plane routes a session's turns to a ready replica drawn from `endpoint.readyReplicaIds`. That set is computed by `readyReplicaIdsFromPods()`, which kept a pod as long as its containers reported ready — it ignored `metadata.deletionTimestamp`.

When a pod is deleted (crash recovery, or a StatefulSet ordinal being recreated) it enters `Terminating`, but its `Ready` condition lingers for the entire termination grace period. So the ordinal never left the ready set. The result:

- the control plane keeps routing turns to the dying agent → connection refused / **502**;
- because the ordinal stays "ready", the router never rebinds the session to a healthy replica.

### Reproduction

Delete the pod bound to an active session. A turn issued during the grace window returns `502 Agent unavailable` and is not rebound. Polling the placement shows the ready set stays `[0,1]` throughout — ordinal 0 never drops — while `kubectl get pod` shows that pod carrying both a `deletionTimestamp` and `Ready=true` container statuses simultaneously.

## Fix

Skip pods with `deletionTimestamp` set, mirroring the Kubernetes Endpoints controller (which drops terminating pods from Endpoints for exactly this reason). A terminating pod leaves the ready set immediately, so the router stops targeting it and rebinds the session to a healthy replica.

Scoped to the routing-target selector only; the general ready-pod count elsewhere is unchanged.

## Test

Adds a `readyReplicaIdsFromPods` case asserting a terminating-but-ready pod is excluded. Full file: 33 passing. `tsc --noEmit` clean for control-plane and the env-runner that consumes this package.