### PR TITLE
fix(chat): release the admission slot on every setup exit, not just handoff

### DIFF
--- a/control-plane/src/services/chat/executeChat.test.ts
+++ b/control-plane/src/services/chat/executeChat.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Workspace } from '../db/types'
+
+// This suite guards the admission-slot lifecycle in executeChat: a turn is
+// admitted (acquireTurn) before setup work, and the slot must be released on
+// EVERY exit — including a throw during setup, before the streaming interceptor
+// takes ownership. A missed release silently shrinks an auto-scaling workspace's
+// capacity (readyReplicas × max_concurrency − leaked). We use the REAL turn gate
+// and replica router so the assertion is the actual in-memory active count.
+
+vi.mock('../workspace-autostart', () => ({
+  ensureWorkspaceRunning: vi.fn().mockResolvedValue(undefined),
+  WorkspaceStartError: class WorkspaceStartError extends Error {},
+}))
+vi.mock('../db/sessions', () => ({
+  getSession: vi.fn(),
+  transitionSessionStatus: vi.fn(),
+  takePendingMessage: vi.fn(),
+  restorePendingMessage: vi.fn(),
+}))
+vi.mock('../../lib/session-token', () => ({
+  ensureTokenForSession: vi.fn().mockResolvedValue('tok'),
+  mintToken: vi.fn().mockResolvedValue('tok'),
+}))
+vi.mock('../../lib/workspace-address', () => ({
+  resolveAgentAddress: vi.fn().mockReturnValue('http://agent'),
+}))
+vi.mock('../db/messages', () => ({
+  addMessage: vi.fn().mockResolvedValue({ id: 'm1' }),
+  insertUserMessageBlocks: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../db/teamwork', () => ({ addTeamworkSession: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../db/workspaces', () => ({ getWorkspace: vi.fn() }))
+vi.mock('../../lib/sse', () => ({
+  createInterceptedSSEResponse: vi.fn().mockReturnValue(new Response('ok')),
+}))
+
+const { executeChat } = await import('./executeChat')
+const { getSession, transitionSessionStatus } = await import('../db/sessions')
+const { turnDemand, __resetTurnGate } = await import('./turn-gate')
+const { syncReadyReplicas, __resetReplicaRouter } = await import('../replica-router')
+
+const WS = 'ws1'
+const workspace = { id: WS, status: 'running' } as unknown as Workspace
+
+// Seed the gate with a real, generous capacity so acquireTurn admits immediately
+// (readyReplicas 1 × perReplicaCapacity 5). turnDemand.active then reflects the
+// live slot count for this workspace.
+function seedCapacity() {
+  syncReadyReplicas(new Map([[WS, { ids: [0], perReplicaCapacity: 5 }]]))
+}
+
+// An SSE response, so executeChat takes the streaming path (past the setup
+// awaits that this suite makes throw / succeed).
+const sseResponse = () =>
+  new Response('data: {}\n\n', { headers: { 'Content-Type': 'text/event-stream' } })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetTurnGate()
+  __resetReplicaRouter()
+  seedCapacity()
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse()))
+  vi.mocked(getSession).mockResolvedValue({
+    id: 's1',
+    workspace_id: WS,
+    replica_ordinal: 0,
+  } as never)
+})
+
+describe('executeChat admission-slot release', () => {
+  it('releases the slot when a setup step throws after admission (no capacity leak)', async () => {
+    // Inject a transient failure at transitionSessionStatus — a setup await that
+    // runs after the slot is acquired but before the interceptor owns it.
+    vi.mocked(transitionSessionStatus).mockRejectedValueOnce(new Error('db blip'))
+
+    expect(turnDemand(WS).active).toBe(0)
+    await expect(
+      executeChat({ workspace, message: 'hi', sessionId: 's1', images: null, source: 'api' }),
+    ).rejects.toThrow('db blip')
+
+    // The slot must be back — a leak would leave active at 1 forever.
+    expect(turnDemand(WS).active).toBe(0)
+  })
+
+  it('keeps the slot held on the streaming handoff (interceptor owns onTurnEnd)', async () => {
+    vi.mocked(transitionSessionStatus).mockResolvedValue(undefined)
+
+    const resp = await executeChat({
+      workspace,
+      message: 'hi',
+      sessionId: 's1',
+      images: null,
+      source: 'api',
+    })
+
+    // Handed off to the interceptor: the finally must NOT release it here, or the
+    // gate would double-count capacity as free while the turn is still running.
+    expect(resp).toBeInstanceOf(Response)
+    expect(turnDemand(WS).active).toBe(1)
+  })
+
+  it('releases the slot on an early return (session belongs to another workspace)', async () => {
+    vi.mocked(getSession).mockResolvedValue({
+      id: 's1',
+      workspace_id: 'other-ws',
+      replica_ordinal: 0,
+    } as never)
+
+    const resp = await executeChat({
+      workspace,
+      message: 'hi',
+      sessionId: 's1',
+      images: null,
+      source: 'api',
+    })
+
+    expect(resp.status).toBe(400)
+    expect(turnDemand(WS).active).toBe(0)
+  })
+})

--- a/control-plane/src/services/chat/executeChat.ts
+++ b/control-plane/src/services/chat/executeChat.ts
@@ -66,11 +66,7 @@ export async function executeChat(opts: ExecuteChatOpts): Promise<Response> {
 
   // Admit the turn before doing any work. Auto-scaling workspaces are capped at
   // readyReplicas × target (queue / 503 over the cap); static workspaces are
-  // only accounted, never blocked. The slot must be released exactly once when
-  // the turn ends: the streaming path hands it to the interceptor (onTurnEnd),
-  // and EVERY early return below releases it inline first. release() is
-  // idempotent, so any belt-and-suspenders double-release is harmless — but a
-  // missed one leaks capacity, so a new early return must release too.
+  // only accounted, never blocked.
   let slot: TurnSlot
   try {
     slot = await acquireTurn(workspaceId)
@@ -81,165 +77,178 @@ export async function executeChat(opts: ExecuteChatOpts): Promise<Response> {
     throw e
   }
 
-  // Auto-start a stopped workspace before dispatching the turn. Covers every
-  // trigger source that funnels through executeChat — interactive chat,
-  // scheduled jobs, connector events, batch. Blocks until the agent /health
-  // passes (cold-start budget ~90s). Honors the per-workspace auto_start
-  // opt-out and fails fast on the error state.
+  // The slot must be released exactly once. On the streaming path the
+  // interceptor takes ownership (onTurnEnd) and releases when the turn ends;
+  // every other exit — an early return OR a thrown error during setup (a
+  // transient DB failure in getSession / ensureTokenForSession /
+  // transitionSessionStatus / addMessage would otherwise reach neither the
+  // handoff nor an inline release, silently leaking a unit of capacity) —
+  // funnels through this finally. `handedOff` is set true right before the
+  // interceptor return so only that path skips the release here.
+  let handedOff = false
   try {
-    await ensureWorkspaceRunning(workspace)
-  } catch (e) {
-    slot.release()
-    if (e instanceof WorkspaceStartError) {
-      return jsonError(e.message, 503)
+    // Auto-start a stopped workspace before dispatching the turn. Covers every
+    // trigger source that funnels through executeChat — interactive chat,
+    // scheduled jobs, connector events, batch. Blocks until the agent /health
+    // passes (cold-start budget ~90s). Honors the per-workspace auto_start
+    // opt-out and fails fast on the error state.
+    try {
+      await ensureWorkspaceRunning(workspace)
+    } catch (e) {
+      if (e instanceof WorkspaceStartError) {
+        return jsonError(e.message, 503)
+      }
+      console.error(`[chat] auto-start failed workspace=${workspaceId}:`, e)
+      return jsonError('Failed to start workspace', 503)
     }
-    console.error(`[chat] auto-start failed workspace=${workspaceId}:`, e)
-    return jsonError('Failed to start workspace', 503)
-  }
 
-  // Reject cross-workspace session ids before we touch the agent. Without
-  // this a caller could drive messages belonging to another workspace's
-  // session, or create orphan rows with `session_id` pointing at a
-  // session that lives under a different workspace_id.
-  let boundReplica: number | undefined
-  if (sessionId) {
-    const session = await getSession(sessionId)
-    if (!session || session.workspace_id !== workspaceId) {
-      slot.release()
-      return jsonError('Session not found for this workspace', 400)
-    }
-    boundReplica = session.replica_ordinal ?? undefined
-  }
-
-  // For an auto-scaling workspace, pin this turn to a specific replica: keep the
-  // session's existing binding while its replica is still ready, else rebind /
-  // pick fresh (a new session, or a replica that dropped out). Static workspaces
-  // report no ready set → undefined → the workspace's default address,
-  // byte-identical to before. The chosen id is threaded to the interceptor so
-  // `session.started` persists the binding for the session's next turns.
-  const replicaId = pickReplicaForTurn(workspaceId, boundReplica)
-  const address = resolveAgentAddress(workspaceId, { sessionId, replicaId })
-
-  // Mint (or look up) the session_token before dispatching. For a resume
-  // the same token follows the session across turns; for a new session we
-  // mint with NULL session_id and the persist plugin binds the SDK-revealed
-  // id on `session.started`. The agent threads this through to the MCP
-  // transport as `X-Session-Token`.
-  const sessionToken = sessionId
-    ? await ensureTokenForSession(workspaceId, sessionId)
-    : await mintToken({ workspaceId })
-
-  const agentBody = JSON.stringify(
-    buildAgentChatBody({
-      message: userMessageText,
-      sessionId,
-      images,
-      source,
-      sessionToken,
-    }),
-  )
-
-  // 24-hour hard cap. Deliberately decoupled from the client's signal —
-  // see `createInterceptedSSEResponse` for why: the agent turn is
-  // broadcast to any client attached via cp-reconnect, so losing the
-  // initiating client shouldn't kill the turn.
-  const fetchSignal = AbortSignal.timeout(24 * 60 * 60 * 1000)
-
-  const agentHeaders: Record<string, string> = {
-    'Content-Type': 'application/json',
-  }
-
-  let response: Response
-  try {
-    response = await fetch(`${address}/chat`, {
-      method: 'POST',
-      headers: agentHeaders,
-      body: agentBody,
-      signal: fetchSignal,
-    })
-  } catch (e: any) {
-    console.error(`[chat] Agent fetch failed workspace=${workspaceId}:`, e.message)
-    slot.release()
+    // Reject cross-workspace session ids before we touch the agent. Without
+    // this a caller could drive messages belonging to another workspace's
+    // session, or create orphan rows with `session_id` pointing at a
+    // session that lives under a different workspace_id.
+    let boundReplica: number | undefined
     if (sessionId) {
-      await transitionSessionStatus(sessionId, 'idle').catch(() => {})
+      const session = await getSession(sessionId)
+      if (!session || session.workspace_id !== workspaceId) {
+        return jsonError('Session not found for this workspace', 400)
+      }
+      boundReplica = session.replica_ordinal ?? undefined
     }
-    return jsonError('Agent unavailable', 502)
-  }
 
-  if (!response.headers.get('Content-Type')?.includes('text/event-stream')) {
-    // Non-SSE error from the agent (e.g. 4xx/5xx JSON). Pass the body
-    // through so the caller can see what the agent said.
-    slot.release()
-    const text = await response.text().catch(() => '')
-    return new Response(text || JSON.stringify({ error: 'Agent returned non-SSE response' }), {
-      status: response.status || 502,
-      headers: {
-        'Content-Type': response.headers.get('Content-Type') || 'application/json',
+    // For an auto-scaling workspace, pin this turn to a specific replica: keep
+    // the session's existing binding while its replica is still ready, else
+    // rebind / pick fresh (a new session, or a replica that dropped out). Static
+    // workspaces report no ready set → undefined → the workspace's default
+    // address, byte-identical to before. The chosen id is threaded to the
+    // interceptor so `session.started` persists the binding for later turns.
+    const replicaId = pickReplicaForTurn(workspaceId, boundReplica)
+    const address = resolveAgentAddress(workspaceId, { sessionId, replicaId })
+
+    // Mint (or look up) the session_token before dispatching. For a resume
+    // the same token follows the session across turns; for a new session we
+    // mint with NULL session_id and the persist plugin binds the SDK-revealed
+    // id on `session.started`. The agent threads this through to the MCP
+    // transport as `X-Session-Token`.
+    const sessionToken = sessionId
+      ? await ensureTokenForSession(workspaceId, sessionId)
+      : await mintToken({ workspaceId })
+
+    const agentBody = JSON.stringify(
+      buildAgentChatBody({
+        message: userMessageText,
+        sessionId,
+        images,
+        source,
+        sessionToken,
+      }),
+    )
+
+    // 24-hour hard cap. Deliberately decoupled from the client's signal —
+    // see `createInterceptedSSEResponse` for why: the agent turn is
+    // broadcast to any client attached via cp-reconnect, so losing the
+    // initiating client shouldn't kill the turn.
+    const fetchSignal = AbortSignal.timeout(24 * 60 * 60 * 1000)
+
+    const agentHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+
+    let response: Response
+    try {
+      response = await fetch(`${address}/chat`, {
+        method: 'POST',
+        headers: agentHeaders,
+        body: agentBody,
+        signal: fetchSignal,
+      })
+    } catch (e: any) {
+      console.error(`[chat] Agent fetch failed workspace=${workspaceId}:`, e.message)
+      if (sessionId) {
+        await transitionSessionStatus(sessionId, 'idle').catch(() => {})
+      }
+      return jsonError('Agent unavailable', 502)
+    }
+
+    if (!response.headers.get('Content-Type')?.includes('text/event-stream')) {
+      // Non-SSE error from the agent (e.g. 4xx/5xx JSON). Pass the body
+      // through so the caller can see what the agent said.
+      const text = await response.text().catch(() => '')
+      return new Response(text || JSON.stringify({ error: 'Agent returned non-SSE response' }), {
+        status: response.status || 502,
+        headers: {
+          'Content-Type': response.headers.get('Content-Type') || 'application/json',
+        },
+      })
+    }
+
+    if (sessionId) {
+      await transitionSessionStatus(sessionId, 'agent')
+      // Eagerly persist the user message while the agent turn is running,
+      // so a page refresh can't lose it. For new sessions we defer to
+      // `createInterceptedSSEResponse`, which stores the message once
+      // `session.started` assigns an id.
+      if (userMessageText) {
+        const blocks = buildUserMessageBlocks(userMessageText, images)
+        const msg = await addMessage(workspaceId, sessionId, 'user', userMessageText)
+        await insertUserMessageBlocks(msg.id, sessionId, blocks)
+        userMessageText = null // prevent the interceptor from persisting a duplicate
+      }
+    }
+
+    // Teamwork: when resuming an existing session that wasn't yet registered
+    // (e.g. an older session pre-dating this code path), ensure the row is
+    // present so MCP-time reverse lookup succeeds on the first tool call.
+    // Idempotent: `addTeamworkSession` is INSERT ... ON CONFLICT DO NOTHING.
+    if (opts.taskId && sessionId) {
+      const tid = opts.taskId
+      addTeamworkSession(tid, sessionId, 'coordinator', null).catch((e) => {
+        console.warn(
+          `[chat] teamwork coordinator registration (resume) failed task=${tid} session=${sessionId}:`,
+          e,
+        )
+      })
+    }
+    const taskIdForHook = opts.taskId
+    const onNewSession = taskIdForHook
+      ? async (newSid: string) => {
+          await addTeamworkSession(taskIdForHook, newSid, 'coordinator', null)
+        }
+      : undefined
+
+    const intercepted = createInterceptedSSEResponse(response, {
+      workspaceId,
+      userMessageText,
+      existingSessionId: sessionId,
+      userImages: images,
+      callerUserId,
+      source,
+      reconnectFactory: async (sid) => {
+        try {
+          const resp = await fetch(`${address}/sessions/${encodeURIComponent(sid)}/reconnect`, {
+            method: 'POST',
+          })
+          if (!resp.ok) return null
+          return resp
+        } catch (e) {
+          console.error(`[chat] reconnect fetch failed workspace=${workspaceId} session=${sid}:`, e)
+          return null
+        }
       },
+      sessionToken,
+      onNewSession,
+      replicaId,
+      // Hand the admission slot to the interceptor: it releases exactly once when
+      // the turn terminates (clean end, error, interrupt, or pod death), which is
+      // the single point that also frees the accounting for the autoscaler.
+      onTurnEnd: () => slot.release(),
     })
+    handedOff = true
+    return intercepted
+  } finally {
+    // Released here for every non-handoff exit (early return or thrown error);
+    // the streaming path sets handedOff and lets the interceptor own it.
+    if (!handedOff) slot.release()
   }
-
-  if (sessionId) {
-    await transitionSessionStatus(sessionId, 'agent')
-    // Eagerly persist the user message while the agent turn is running,
-    // so a page refresh can't lose it. For new sessions we defer to
-    // `createInterceptedSSEResponse`, which stores the message once
-    // `session.started` assigns an id.
-    if (userMessageText) {
-      const blocks = buildUserMessageBlocks(userMessageText, images)
-      const msg = await addMessage(workspaceId, sessionId, 'user', userMessageText)
-      await insertUserMessageBlocks(msg.id, sessionId, blocks)
-      userMessageText = null // prevent the interceptor from persisting a duplicate
-    }
-  }
-
-  // Teamwork: when resuming an existing session that wasn't yet registered
-  // (e.g. an older session pre-dating this code path), ensure the row is
-  // present so MCP-time reverse lookup succeeds on the first tool call.
-  // Idempotent: `addTeamworkSession` is INSERT ... ON CONFLICT DO NOTHING.
-  if (opts.taskId && sessionId) {
-    const tid = opts.taskId
-    addTeamworkSession(tid, sessionId, 'coordinator', null).catch((e) => {
-      console.warn(
-        `[chat] teamwork coordinator registration (resume) failed task=${tid} session=${sessionId}:`,
-        e,
-      )
-    })
-  }
-  const taskIdForHook = opts.taskId
-  const onNewSession = taskIdForHook
-    ? async (newSid: string) => {
-        await addTeamworkSession(taskIdForHook, newSid, 'coordinator', null)
-      }
-    : undefined
-
-  return createInterceptedSSEResponse(response, {
-    workspaceId,
-    userMessageText,
-    existingSessionId: sessionId,
-    userImages: images,
-    callerUserId,
-    source,
-    reconnectFactory: async (sid) => {
-      try {
-        const resp = await fetch(`${address}/sessions/${encodeURIComponent(sid)}/reconnect`, {
-          method: 'POST',
-        })
-        if (!resp.ok) return null
-        return resp
-      } catch (e) {
-        console.error(`[chat] reconnect fetch failed workspace=${workspaceId} session=${sid}:`, e)
-        return null
-      }
-    },
-    sessionToken,
-    onNewSession,
-    replicaId,
-    // Hand the admission slot to the interceptor: it releases exactly once when
-    // the turn terminates (clean end, error, interrupt, or pod death), which is
-    // the single point that also frees the accounting for the autoscaler.
-    onTurnEnd: () => slot.release(),
-  })
 }
 
 /**


### PR DESCRIPTION
## Problem

`executeChat` acquires a turn-gate admission slot **before** doing setup work, then hands it to the streaming interceptor (`onTurnEnd`) which releases it when the turn ends. Every early *return* released the slot inline — but a **thrown error during setup** reached neither the inline releases nor the interceptor:

- `getSession`, `ensureTokenForSession`, `transitionSessionStatus`, `addMessage`, `insertUserMessageBlocks` are all `await`ed after admission and before the handoff. A transient DB/network failure in any of them propagates out of `executeChat` with the slot still held.

For an **auto-scaling** workspace the leak is permanent and cumulative: effective capacity becomes `readyReplicas × max_concurrency − leaked`. Observed while dogfooding — with `max_concurrency = 3` and 2 ready replicas (capacity should be 6), sustained load admitted a stable **5**, with **no** session left `chat_status = 'agent'` in the DB. The missing unit is an in-memory `activeTurns` slot that was acquired and never released. (Static workspaces are unaffected — their capacity is `Infinity`, so a leaked count never blocks.)

## Fix

Wrap the post-admission setup in `try/finally` with a `handedOff` flag:

- the `finally` releases the slot on **any** non-handoff exit — an early return or a thrown error;
- the streaming path sets `handedOff = true` immediately before returning the intercepted response, so the interceptor keeps sole ownership and the `finally` skips it.

The four inline `slot.release()` calls are removed — release is now centralized in one place, which also retires the module's standing hazard ("a new early return must release too").

## Test

New `executeChat.test.ts` drives all three lifecycles against the **real** turn gate + replica router, asserting the live slot count via `turnDemand`:

- setup throw (`transitionSessionStatus` rejects) → `executeChat` rejects and `active` returns to 0 (the leak);
- streaming handoff → `active` stays 1 (slot owned by the interceptor, not double-released);
- early return (cross-workspace session) → 400 and `active` returns to 0.

61 passing across `chat/` + autoscaler + k8s-spec. `tsc --noEmit` and biome clean.
