### PR TITLE
perf(cp): move session liveness beat off sessions.last_active_at

### DIFF
--- a/control-plane/migrations/128_session_activity.sql
+++ b/control-plane/migrations/128_session_activity.sql
@@ -1,0 +1,26 @@
+-- Session liveness heartbeat, split out of sessions.last_active_at.
+--
+-- `sessions.last_active_at` carries two unrelated signals: a durable "when did
+-- this session last do anything" (session list ordering, admin weekly-active
+-- aggregates, the daily-stats matviews) and a sub-minute liveness pulse used to
+-- tell a working agent apart from a stalled one. The pulse was written every 10s
+-- per live session, and because it lands on an indexed column of a wide row it
+-- could never take the HOT path: each beat rewrote the whole sessions tuple and
+-- all four of its indexes, through WAL and synchronous replication, to record a
+-- fact that is worthless a minute later.
+--
+-- The pulse moves here. The durable column stays where it is and keeps advancing
+-- on real events (message persist, turn start).
+--
+-- Deliberately no index on last_active_at. Readers filter it, but this table is
+-- one narrow row per session and a seq scan is cheaper than what an index would
+-- cost: indexing the written column is exactly what disqualified HOT on
+-- `sessions`, and repeating that here would defeat the point of the split.
+CREATE TABLE session_activity (
+    session_id text PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    last_active_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+-- No backfill. Readers coalesce to sessions.last_active_at when a session has no
+-- row yet, so behaviour on the first deploy is identical to before and rows
+-- appear as sessions become active.

--- a/control-plane/migrations/129_reindex_sessions.sql
+++ b/control-plane/migrations/129_reindex_sessions.sql
@@ -1,0 +1,22 @@
+-- Reclaim the index bloat left by the pre-128 liveness write pattern.
+--
+-- Every 10s beat on sessions.last_active_at was a non-HOT update, and a non-HOT
+-- update writes a new entry into *all* of the table's indexes — not just the one
+-- on the column being written. So all four bloated together: on a deployment
+-- running since early 2026, idx_sessions_last_active_at had reached ~15x and
+-- sessions_pkey ~4x the size their row counts warrant. Autovacuum does not
+-- shrink an already-bloated btree; only a rebuild does.
+--
+-- Ordering matters: 128 has to have moved the beat off this table first, or the
+-- rebuild starts re-bloating immediately. Migrations run in filename order at
+-- control-plane boot, so 128 precedes this within the same startup.
+--
+-- Plain REINDEX, not CONCURRENTLY: the runner wraps every migration in a
+-- transaction and CONCURRENTLY cannot run inside one. The lock this takes is
+-- SHARE on sessions (plus ACCESS EXCLUSIVE on each index), so reads continue and
+-- only writes to sessions pause. `sessions` holds one narrow row per session and
+-- the whole table with its indexes is tens of MB, making the rebuild
+-- sub-second — bounded, and paid once at boot.
+--
+-- A fresh install has nothing to reclaim and this is a no-op there.
+REINDEX TABLE public.sessions;

--- a/control-plane/migrations/README.md
+++ b/control-plane/migrations/README.md
@@ -28,7 +28,7 @@ It contains **pure schema only**. Bootstrap rows (the internal `system` user and
 
 Rules of thumb:
 
-- **Filename**: `NNN_snake_case_description.sql`, three-digit zero-padded, strictly increasing. Next free number is **115**.
+- **Filename**: `NNN_snake_case_description.sql`, three-digit zero-padded, strictly increasing. Next free number is **130**.
 - **Never rename or edit an applied migration.** To change something already shipped, add a new migration.
 - Each file runs once, in its own transaction. Write it to succeed against the schema as produced by every migration before it.
 - **No seed/bootstrap data here** — schema only. Data that every install needs goes into `scripts/seed-admin.ts` (idempotent, `ON CONFLICT DO NOTHING`).

--- a/control-plane/src/lib/sse.ts
+++ b/control-plane/src/lib/sse.ts
@@ -7,6 +7,7 @@ import {
   updateMessageContent,
   upsertEvent,
 } from '../services/db/messages'
+import { touchSessionActivity } from '../services/db/session-activity'
 import {
   createSession,
   setSessionReplicaOrdinal,
@@ -500,11 +501,17 @@ export function createInterceptedSSEResponse(
   // the shared queue before broadcast's deferred emits, ensuring emits
   // observe a consistent DB state.
   // Tap the raw agent stream: any byte from the agent — a real event OR the
-  // acp-adapter heartbeat comment — proves the session is alive, so bump
-  // last_active_at (throttled). Previously last_active_at only advanced when a
+  // acp-adapter heartbeat comment — proves the session is alive, so record a
+  // liveness beat (throttled). Previously liveness only advanced when a
   // message/tool_result was persisted, so a single long operation (a slow tool,
   // a long inference with no streamed text) starved it and looked "stalled" to
   // the orchestrator's stall detector even while the agent was working.
+  //
+  // The beat goes to session_activity, not sessions.last_active_at: it fires
+  // every 10s per live session and the durable column is indexed, so writing it
+  // here defeated HOT and put this on the hot WAL/sync-replication path for a
+  // fact that expires in a minute. The durable column still advances on message
+  // persist and at turn start.
   let lastActivityTouchAt = 0
   const ACTIVITY_TOUCH_THROTTLE_MS = 10_000
   const tapActivity = (resp: Response | null): Response | null => {
@@ -515,7 +522,7 @@ export function createInterceptedSSEResponse(
         const now = Date.now()
         if (sid && now - lastActivityTouchAt >= ACTIVITY_TOUCH_THROTTLE_MS) {
           lastActivityTouchAt = now
-          void updateSessionActivity(sid).catch(() => {})
+          touchSessionActivity(sid)
         }
         controller.enqueue(chunk)
       },

--- a/control-plane/src/services/db/session-activity.ts
+++ b/control-plane/src/services/db/session-activity.ts
@@ -1,0 +1,69 @@
+import { pool } from './pool'
+
+/**
+ * Session liveness pulse, coalesced.
+ *
+ * The SSE tap proves a session is alive on every byte from the agent, throttled
+ * to one beat per 10s per session. Sending that straight to Postgres meant one
+ * statement — and one commit round-trip through synchronous replication — per
+ * live session per beat, which made it the second largest consumer of cumulative
+ * execution time in the database.
+ *
+ * Beats accumulate in memory instead and land as a single multi-row upsert per
+ * flush, so the statement count is driven by the flush interval rather than by
+ * how many sessions are streaming. Losing up to one interval of beats on a crash
+ * is fine: readers coalesce to `sessions.last_active_at`, and the next beat is
+ * never more than the throttle window away.
+ *
+ * Each control-plane replica keeps its own map. A session is served by whichever
+ * replica holds its stream, so overlap is rare, and the upsert takes GREATEST to
+ * make a late flush from another replica harmless.
+ */
+
+const FLUSH_MS = Number(process.env.SESSION_ACTIVITY_FLUSH_MS) || 10_000
+
+const pending = new Map<string, Date>()
+let timer: NodeJS.Timeout | null = null
+
+/**
+ * Record that `sessionId` is alive now. Returns immediately — the write happens
+ * on the next flush. Safe to call on every chunk; callers do not need to
+ * throttle for the database's sake, only to bound this map.
+ */
+export function touchSessionActivity(sessionId: string): void {
+  pending.set(sessionId, new Date())
+  if (!timer) {
+    timer = setInterval(() => void flushSessionActivity(), FLUSH_MS)
+    // Don't hold the process open on shutdown for a heartbeat.
+    timer.unref()
+  }
+}
+
+/**
+ * Write every pending beat as one statement.
+ *
+ * The join against `sessions` filters out sessions deleted since their last
+ * beat. Without it a single stale id would fail the foreign key and take the
+ * whole batch — including every live session in it — down with it.
+ */
+async function flushSessionActivity(): Promise<void> {
+  if (pending.size === 0) return
+  const batch = [...pending.entries()]
+  pending.clear()
+
+  try {
+    await pool.query(
+      `INSERT INTO session_activity (session_id, last_active_at)
+       SELECT u.id, u.ts
+         FROM unnest($1::text[], $2::timestamptz[]) AS u(id, ts)
+         JOIN sessions s ON s.id = u.id
+       ON CONFLICT (session_id) DO UPDATE
+         SET last_active_at = GREATEST(session_activity.last_active_at, EXCLUDED.last_active_at)`,
+      [batch.map(([id]) => id), batch.map(([, ts]) => ts)],
+    )
+  } catch (e) {
+    // Dropped beats are recoverable by definition — the next one is one throttle
+    // window away, and readers fall back to sessions.last_active_at meanwhile.
+    console.error('[SessionActivity] flush failed:', e instanceof Error ? e.message : e)
+  }
+}

--- a/control-plane/src/services/db/sessions.ts
+++ b/control-plane/src/services/db/sessions.ts
@@ -378,13 +378,19 @@ export async function listActiveSessionIds(workspaceId: string): Promise<string[
  * to skip workspaces a user is actively streaming with, so a rollout doesn't
  * kill a live turn. `withinInterval` is a Postgres interval literal
  * (e.g. '10 minutes'), bound as a parameter.
+ *
+ * Reads the liveness beat, falling back to the durable column for sessions that
+ * have no beat yet. The distinction matters here: a turn spent inside one long
+ * tool call persists no messages, so the durable column alone would report it
+ * idle and the sweep would rebuild the pod out from under a live turn.
  */
 export async function listStreamingWorkspaceIds(withinInterval: string): Promise<string[]> {
   const { rows } = await pool.query(
-    `SELECT DISTINCT workspace_id FROM sessions
-      WHERE status = 'active'
-        AND chat_status = 'agent'
-        AND last_active_at >= NOW() - $1::interval`,
+    `SELECT DISTINCT s.workspace_id FROM sessions s
+       LEFT JOIN session_activity a ON a.session_id = s.id
+      WHERE s.status = 'active'
+        AND s.chat_status = 'agent'
+        AND COALESCE(a.last_active_at, s.last_active_at) >= NOW() - $1::interval`,
     [withinInterval],
   )
   return rows.map((r: { workspace_id: string }) => r.workspace_id)

--- a/scheduler/src/db.ts
+++ b/scheduler/src/db.ts
@@ -386,6 +386,12 @@ interface TitleGenCandidate {
  * exchange (a first user message and at least one assistant reply). Restricted
  * to sessions quiet for `quietSeconds` so we don't title a half-finished first
  * turn. Returns the session id plus its first user message (the title source).
+ *
+ * Quietness comes from the liveness beat (session_activity), falling back to the
+ * durable column when a session has no beat yet. `quietSeconds` is well under a
+ * minute, and the durable column only advances on message persist — so reading
+ * it alone would call a turn quiet while the agent is still inside a long tool
+ * call and title a half-finished exchange.
  */
 export async function getTitleGenCandidates(
   limit: number,
@@ -394,6 +400,7 @@ export async function getTitleGenCandidates(
   const { rows } = await pool.query(
     `SELECT s.id, fm.content AS first_user_message
        FROM sessions s
+       LEFT JOIN session_activity a ON a.session_id = s.id
        JOIN LATERAL (
          SELECT content FROM messages m
          WHERE m.session_id = s.id AND m.role = 'user'
@@ -401,7 +408,7 @@ export async function getTitleGenCandidates(
        ) fm ON true
       WHERE s.name = ''
         AND s.status = 'active'
-        AND s.last_active_at < now() - make_interval(secs => $1)
+        AND COALESCE(a.last_active_at, s.last_active_at) < now() - make_interval(secs => $1)
         AND EXISTS (
           SELECT 1 FROM messages m
           WHERE m.session_id = s.id AND m.role = 'assistant'


### PR DESCRIPTION
Closes #191.

`sessions.last_active_at` carries two unrelated signals:

- **durable** "last activity" — session list ordering, admin weekly-active aggregates, the daily-stats matviews
- **liveness** — a sub-minute pulse that tells a working agent apart from a stalled one

The pulse fires every 10s per live session, and it lands on an indexed column of a wide row, so it can never take the HOT path. Every beat rewrites the whole `sessions` tuple and all four of its indexes, through WAL and synchronous replication, to record a fact that is worthless a minute later and costs nothing to lose. See #191 for the measurements.

## What changed

Split by purpose, not by table.

**`session_activity` (new, migration 128)** — `session_id` PK plus a timestamp, carrying the pulse. Deliberately **no index on `last_active_at`**: the table is one narrow row per session, a seq scan is cheaper than what an index would cost, and indexing the written column is the exact mistake this PR undoes.

**Coalesced writes** — beats accumulate in memory in the control-plane and land as a single multi-row upsert per flush interval (`SESSION_ACTIVITY_FLUSH_MS`, default 10s). Statement count is now driven by the flush interval instead of by how many sessions are streaming. The upsert takes `GREATEST` so a late flush from another replica can't move a timestamp backwards, and joins `sessions` so one id deleted mid-batch can't fail the foreign key and take every live session in the batch with it.

**No new durable writer** — `sessions.last_active_at` already advances on message persist (`services/db/messages.ts`) and at turn start, which is what "last activity" should mean. It stays logged, indexed and durable; only the pulse leaves.

## Readers

Both sub-minute readers take the beat and coalesce to the durable column when a session has no beat yet:

- `listStreamingWorkspaceIds` — the admin rebuild sweep's 10-minute "don't rebuild a workspace mid-turn" guard. A turn spent inside one long tool call persists no messages, so the durable column alone would report it idle and the sweep would rebuild the pod out from under a live turn.
- `getTitleGenCandidates` — the 30s quiet gate. Same shape: it would title a half-finished exchange.

Every other reader (list ordering, `max(last_active_at)` admin columns, the matviews) is durable by nature and is untouched.

## Rollout

No backfill and no coordination needed. The `COALESCE` fallback means an empty `session_activity` behaves exactly like today, and rows appear as sessions become active. Reverting is equally safe — the durable column was never stopped.

Existing bloat is reclaimed by migration 129, in the same startup. A non-HOT update writes into *every* index on the table, so all four bloated together — the rebuild is `REINDEX TABLE`, not a single index. Ordering is what makes it correct: 128 moves the beat off `sessions` before 129 rebuilds, otherwise the rebuild would start re-bloating immediately.

It runs as a migration rather than a documented one-off so self-host installs get it without manual `psql`. Plain `REINDEX`, not `CONCURRENTLY`, because the runner wraps every migration in a transaction (verified `REINDEX TABLE` is legal in a transaction block on PG 16). The lock is `SHARE` on `sessions` plus `ACCESS EXCLUSIVE` per index — reads continue, only writes to `sessions` pause, and the table is tens of MB including indexes, so this is sub-second and bounded. A fresh install has nothing to reclaim and it is a no-op there.

## Not done

Making `session_activity` `UNLOGGED` would take the pulse off WAL and synchronous replication entirely. It was considered and deferred: an unlogged table is empty after a failover, which hands both readers above a new failure mode (every session looks idle at once) for a comparatively small additional gain. It remains a one-line DDL change on top of this if the numbers justify it later.

## Testing

- `npx tsc --noEmit` clean in `control-plane` and `scheduler`
- `npm test` in `control-plane`: 333 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zNcyoifytz65B5TQNfHd4
