### PR TITLE
fix(autoscaling): reach a cold-starting workspace via its headless Service

### DIFF
--- a/control-plane/src/lib/workspace-address.test.ts
+++ b/control-plane/src/lib/workspace-address.test.ts
@@ -5,10 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // resolveAgentAddress must stay identity-equal to getWorkspaceAddress for
 // every route context while workspaces are single-replica.
 
-const { getRemoteProxyPortMock, anyReadyReplicaMock, readyReplicaIdsMock } = vi.hoisted(() => ({
+const {
+  getRemoteProxyPortMock,
+  anyReadyReplicaMock,
+  readyReplicaIdsMock,
+  isAutoScalingWorkspaceMock,
+} = vi.hoisted(() => ({
   getRemoteProxyPortMock: vi.fn<(workspaceId: string, replicaId?: number) => number | undefined>(),
   anyReadyReplicaMock: vi.fn<(workspaceId: string) => number | undefined>(),
   readyReplicaIdsMock: vi.fn<(workspaceId: string) => readonly number[]>(),
+  isAutoScalingWorkspaceMock: vi.fn<(workspaceId: string) => boolean>(),
 }))
 
 vi.mock('./remote-proxy', () => ({
@@ -18,6 +24,7 @@ vi.mock('./remote-proxy', () => ({
 vi.mock('../services/replica-router', () => ({
   anyReadyReplica: anyReadyReplicaMock,
   readyReplicaIds: readyReplicaIdsMock,
+  isAutoScalingWorkspace: isAutoScalingWorkspaceMock,
 }))
 
 import {
@@ -31,6 +38,7 @@ beforeEach(() => {
   getRemoteProxyPortMock.mockReturnValue(undefined)
   anyReadyReplicaMock.mockReturnValue(undefined) // static: no ready replicas
   readyReplicaIdsMock.mockReturnValue([])
+  isAutoScalingWorkspaceMock.mockReturnValue(false) // static unless a test says otherwise
 })
 
 afterEach(() => {
@@ -56,10 +64,26 @@ describe('getWorkspaceAddress', () => {
 
   it('resolves a built-in auto-scaling workspace (no replica) to any ready replica', () => {
     // no ClusterIP Service exists → the bare name would not resolve; pick a ready one
+    isAutoScalingWorkspaceMock.mockReturnValue(true)
     anyReadyReplicaMock.mockReturnValue(1)
     expect(getWorkspaceAddress('ws1')).toBe(
       'http://tos-ws1-1.tos-ws1-hl.default.svc.cluster.local:3001',
     )
+  })
+
+  it('resolves a cold-starting auto-scaling workspace (no ready replica) to its headless Service, not the absent ClusterIP', () => {
+    // scaled to zero / cold-starting: no ready replica yet. The ClusterIP name an
+    // auto-scaling workspace never has would NXDOMAIN for the whole cold-start
+    // budget; the headless Service resolves to pods as they become ready.
+    isAutoScalingWorkspaceMock.mockReturnValue(true)
+    anyReadyReplicaMock.mockReturnValue(undefined)
+    expect(getWorkspaceAddress('ws1')).toBe('http://tos-ws1-hl.default.svc.cluster.local:3001')
+  })
+
+  it('a static workspace with no ready replica still falls back to its ClusterIP Service', () => {
+    // isAutoScalingWorkspace=false (default) → unchanged bare-name behaviour.
+    anyReadyReplicaMock.mockReturnValue(undefined)
+    expect(getWorkspaceAddress('ws1')).toBe('http://tos-ws1.default.svc.cluster.local:3001')
   })
 })
 

--- a/control-plane/src/lib/workspace-address.ts
+++ b/control-plane/src/lib/workspace-address.ts
@@ -1,5 +1,13 @@
-import { builtinReplicaAddress, defaultCfg } from '../../../internal/k8s-provider'
-import { anyReadyReplica, readyReplicaIds } from '../services/replica-router'
+import {
+  builtinHeadlessAddress,
+  builtinReplicaAddress,
+  defaultCfg,
+} from '../../../internal/k8s-provider'
+import {
+  anyReadyReplica,
+  isAutoScalingWorkspace,
+  readyReplicaIds,
+} from '../services/replica-router'
 import { getRemoteProxyPort } from './remote-proxy'
 
 /**
@@ -26,14 +34,21 @@ import { getRemoteProxyPort } from './remote-proxy'
  * With no `replicaId`, a workspace-scoped call (health, reload, usage, export):
  * a static workspace resolves to its single Service (unchanged); a built-in
  * auto-scaling one has NO ClusterIP Service — only per-ordinal headless DNS — so
- * it resolves to any one ready replica (all share the volume). Falls back to the
- * bare name only when no replica is ready (scaled to zero / not yet observed),
- * where nothing is reachable anyway.
+ * it resolves to any one ready replica (all share the volume). When no replica is
+ * ready yet (scaled to zero / cold-starting / not yet observed) an auto-scaling
+ * workspace resolves to its HEADLESS Service, whose DNS names the ready pods as
+ * k8s adds them — so a cold-start /health poll and the first turn become
+ * reachable the moment a pod is ready, without waiting for cp's ready-set
+ * observation to catch up. A static workspace keeps falling back to its Service
+ * (which exists), byte-identical to before.
  */
 export function getWorkspaceAddress(workspaceId: string, replicaId?: number): string {
   const remotePort = getRemoteProxyPort(workspaceId, replicaId)
   if (remotePort !== undefined) return `http://127.0.0.1:${remotePort}`
   const id = replicaId ?? anyReadyReplica(workspaceId)
+  if (id === undefined && isAutoScalingWorkspace(workspaceId)) {
+    return builtinHeadlessAddress(defaultCfg, workspaceId)
+  }
   return builtinReplicaAddress(defaultCfg, workspaceId, id)
 }
 

--- a/control-plane/src/services/k8s-deployment-spec.test.ts
+++ b/control-plane/src/services/k8s-deployment-spec.test.ts
@@ -4,6 +4,7 @@ import {
   buildHeadlessServiceSpec,
   buildStatefulSetSpec,
   buildWorkspacePodTemplate,
+  builtinHeadlessAddress,
   builtinReplicaAddress,
   readyReplicaIdsFromPods,
   resolveStatefulSetStatus,
@@ -272,6 +273,14 @@ describe('builtinReplicaAddress', () => {
     )
     expect(builtinReplicaAddress(baseCfg, 'ws1', 2)).toBe(
       'http://nap-ws1-2.nap-ws1-hl.nap.svc.cluster.local:3001',
+    )
+  })
+})
+
+describe('builtinHeadlessAddress', () => {
+  it('resolves to the headless Service (all ready pods), no ordinal', () => {
+    expect(builtinHeadlessAddress(baseCfg, 'ws1')).toBe(
+      'http://nap-ws1-hl.nap.svc.cluster.local:3001',
     )
   })
 })

--- a/control-plane/src/services/replica-router.test.ts
+++ b/control-plane/src/services/replica-router.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   __resetReplicaRouter,
+  isAutoScalingWorkspace,
   perReplicaCapacity,
   pickReplicaForTurn,
   readyReplicaIds,
   setDraining,
+  syncAutoScalingIds,
   syncReadyReplicas,
 } from './replica-router'
 
@@ -19,6 +21,23 @@ beforeEach(() => {
 
 const snapshot = (entries: Record<string, number[]>) =>
   new Map(Object.entries(entries).map(([ws, ids]) => [ws, { ids }]))
+
+describe('isAutoScalingWorkspace / syncAutoScalingIds', () => {
+  it('tracks auto-scaling ids independently of the ready set (survives scale to zero)', () => {
+    expect(isAutoScalingWorkspace('ws1')).toBe(false)
+    syncAutoScalingIds(['ws1', 'ws2'])
+    expect(isAutoScalingWorkspace('ws1')).toBe(true)
+    expect(isAutoScalingWorkspace('ws2')).toBe(true)
+    expect(isAutoScalingWorkspace('ws3')).toBe(false)
+    // still auto-scaling even with no reported replicas (scaled to zero)
+    syncReadyReplicas(snapshot({}))
+    expect(isAutoScalingWorkspace('ws1')).toBe(true)
+    // a full replace drops one no longer configured as auto-scaling
+    syncAutoScalingIds(['ws2'])
+    expect(isAutoScalingWorkspace('ws1')).toBe(false)
+    expect(isAutoScalingWorkspace('ws2')).toBe(true)
+  })
+})
 
 describe('pickReplicaForTurn', () => {
   it('returns undefined for a workspace with no reported replicas (static)', () => {

--- a/control-plane/src/services/replica-router.ts
+++ b/control-plane/src/services/replica-router.ts
@@ -25,6 +25,7 @@
 // ordinal); the router assumes nothing about it being contiguous or ordered.
 
 import { listWorkspaceReplicaSets } from './db/env-placements'
+import { getAutoScalingWorkspaceIds } from './db/environments'
 
 /** Per-workspace snapshot of one observation: ready replicas + capacity input. */
 interface ReplicaSnapshot {
@@ -52,6 +53,15 @@ const rrCursor = new Map<string, number>()
  * so a replica that has actually left ready also leaves draining.
  */
 const drainingReplicas = new Map<string, Set<number>>()
+/**
+ * Workspaces whose config has an auto_scaling block — kept independently of the
+ * ready set so it survives a scale to zero, when {@link readyReplicas} is empty
+ * but the workspace is still auto-scaling. Lets the address seam pick the
+ * headless-Service fallback (which exists) over the ClusterIP one (which an
+ * auto-scaling workspace never has) during a cold start. Populated every refresh
+ * from workspace_config, so it includes stopped/starting auto-scaling workspaces.
+ */
+const autoScalingIds = new Set<string>()
 
 /**
  * Replace the whole ready-replica picture from one observation snapshot (every
@@ -95,7 +105,10 @@ export function syncReadyReplicas(snapshot: ReadonlyMap<string, ReplicaSnapshot>
  * workspace is auto-scaling (the query returns nothing).
  */
 export async function refreshReplicaRouter(): Promise<void> {
-  const rows = await listWorkspaceReplicaSets()
+  const [rows, asIds] = await Promise.all([
+    listWorkspaceReplicaSets(),
+    getAutoScalingWorkspaceIds(),
+  ])
   syncReadyReplicas(
     new Map(
       rows.map((r) => [
@@ -104,6 +117,22 @@ export async function refreshReplicaRouter(): Promise<void> {
       ]),
     ),
   )
+  syncAutoScalingIds(asIds)
+}
+
+/**
+ * Replace the set of auto-scaling workspace ids (a full replace). Kept separate
+ * from the ready-set sync because it must include auto-scaling workspaces that
+ * currently report no replicas (scaled to zero / cold-starting).
+ */
+export function syncAutoScalingIds(ids: Iterable<string>): void {
+  autoScalingIds.clear()
+  for (const id of ids) autoScalingIds.add(id)
+}
+
+/** Whether a workspace is auto-scaling — true even while it is scaled to zero. */
+export function isAutoScalingWorkspace(workspaceId: string): boolean {
+  return autoScalingIds.has(workspaceId)
 }
 
 /**
@@ -217,4 +246,5 @@ export function __resetReplicaRouter(): void {
   perReplicaCap.clear()
   rrCursor.clear()
   drainingReplicas.clear()
+  autoScalingIds.clear()
 }

--- a/internal/k8s-provider/index.ts
+++ b/internal/k8s-provider/index.ts
@@ -20,6 +20,7 @@ export {
   buildHeadlessServiceSpec,
   buildStatefulSetSpec,
   buildWorkspacePodTemplate,
+  builtinHeadlessAddress,
   builtinReplicaAddress,
   deploymentTemplateVersion,
   readyReplicaIdsFromPods,

--- a/internal/k8s-provider/workspace-spec.ts
+++ b/internal/k8s-provider/workspace-spec.ts
@@ -389,6 +389,21 @@ export function builtinReplicaAddress(
 }
 
 /**
+ * The base URL of an auto-scaling workspace's HEADLESS Service (not per-ordinal).
+ * A headless Service's DNS resolves to the IPs of its READY pods, so this reaches
+ * any one ready replica the moment k8s adds it to the endpoints — no dependency
+ * on cp's ready-set observation catching up. This is the address to use for a
+ * workspace-scoped call (health, reload) on an auto-scaling workspace that has no
+ * ready replica in cp's router yet — most importantly the cold-start /health poll
+ * when scaling up from zero, where {@link builtinReplicaAddress}'s ordinal-less
+ * form would name the ClusterIP Service that an auto-scaling workspace never has.
+ */
+export function builtinHeadlessAddress(cfg: K8sConfig, workspaceId: string): string {
+  const base = `${cfg.namePrefix}-${workspaceId}`
+  return `http://${base}-hl.${cfg.namespace}.svc.cluster.local:${AGENT_PORT}`
+}
+
+/**
  * Batch-check K8s deployment statuses for active workspaces.
  * Returns a map of workspaceId → resolved status.
  * Uses a single listNamespacedDeployment call (O(1) K8s API).


### PR DESCRIPTION
## Problem

An auto-scaling workspace is a StatefulSet + **headless** Service (per-ordinal DNS) with **no ClusterIP Service**. But `getWorkspaceAddress()`'s no-replica fallback returned the ClusterIP name (`builtinReplicaAddress` with no ordinal, e.g. `nap-<ws>.<ns>.svc`), which **NXDOMAINs** for an auto-scaling workspace.

So while a workspace is scaled to zero or cold-starting — no ready replica in cp's router yet — the autostart `/health` poll *and* the first turn's dispatch target an unresolvable name for the **entire 90s budget**, until cp's ready-set observation catches up (env-runner observe + router refresh, ~30s *after* a pod is already Ready). Scaling up from zero routinely blew the budget: the triggering turn failed with `Workspace did not become ready within 90s` even though the pod was healthy. (Reproduced by enabling `scale_to_zero_idle_seconds`, letting the workspace stop, then sending a turn.)

Static workspaces are unaffected — their ClusterIP Service exists and routes to the pod via k8s endpoints, no dependence on cp's observation.

## Fix

Resolve an auto-scaling workspace that has no ready replica to its **headless Service** (`<ws>-hl`) instead of the absent ClusterIP name. A headless Service's DNS names its **ready** pods, so the poll and the first turn become reachable the moment k8s adds a pod to the endpoints — no wait on cp's observation lag. Once the router observes the ready set, normal per-ordinal routing resumes.

Detection is data-driven, mirroring the rest of the router (never a `runtime_mode` column): the router keeps a set of auto-scaling workspace ids sourced from `workspace_config` and refreshed every cycle, so it **survives a scale to zero** (when the ready set is empty). A static workspace is never in the set, so it keeps falling back to its ClusterIP Service — byte-identical to before.

- `k8s-provider`: add `builtinHeadlessAddress(cfg, ws)`.
- `replica-router`: track auto-scaling ids (`syncAutoScalingIds` / `isAutoScalingWorkspace`), populated in `refreshReplicaRouter` from `getAutoScalingWorkspaceIds()`.
- `workspace-address`: headless fallback when no replica resolves *and* the workspace is auto-scaling.

## Test

337 passing. New cases: the headless address format; `getWorkspaceAddress` returns the headless Service for a cold-starting auto-scaling workspace and still the ClusterIP for a static one; the auto-scaling id registry survives an empty ready-set sync. `tsc --noEmit` clean for control-plane and the env-runner.

## Note

This is a control-plane fix (runtime address resolution). No env-runner change; `refreshReplicaRouter` runs in cp.
