### PR TITLE
fix(agent-skills): don't leak readonly __platform__ staging dirs on the shared volume

### DIFF
--- a/internal/agent-skills/src/index.test.ts
+++ b/internal/agent-skills/src/index.test.ts
@@ -952,9 +952,39 @@ describe('SkillManager draft persistence (draftBase)', () => {
         return realRename(from, to)
       }
       await expect(mgr().installPlatformSkill({ 'SKILL.md': 'body' })).resolves.toBeUndefined()
+      // The staged tree was chmod'd readonly before the failed publish, so the
+      // loser MUST restore write before removing it — otherwise the readonly
+      // dirs make rm fail and it leaks an undeletable staging on the shared
+      // volume every racy cold-start.
+      const restoredWrite = shell.calls.find(
+        (c) =>
+          c.cmd === 'chmod' &&
+          c.args.includes('u+w') &&
+          c.args.some((a) => a.includes('.__platform__.staging-')),
+      )
+      expect(restoredWrite).toBeTruthy()
       expect([...fs.dirs].some((d) => d.includes('.__platform__.staging-'))).toBe(false)
       expect([...fs.files.keys()].some((k) => k.includes('.__platform__.staging-'))).toBe(false)
       fs.rename = realRename
+    })
+
+    test('sweeps an orphaned stale staging dir but keeps a fresh sibling one', async () => {
+      // A prior race/crash left a readonly staging behind; a sibling replica is
+      // mid-install right now (fresh timestamp). Install should reap the orphan
+      // and leave the live one alone.
+      const stale = `${SKILLS_DIR}/.__platform__.staging-999-1` // ms=1 → ancient
+      const fresh = `${SKILLS_DIR}/.__platform__.staging-888-${Date.now()}` // now → live
+      for (const s of [stale, fresh]) {
+        fs.dirs.add(s)
+        fs.files.set(`${s}/SKILL.md`, 'x')
+      }
+      await mgr().installPlatformSkill({ 'SKILL.md': 'body' })
+      expect(fs.exists(stale)).toBe(false) // orphan reaped
+      expect(fs.exists(fresh)).toBe(true) // live sibling untouched
+      // The reap restored write on the readonly orphan first.
+      expect(
+        shell.calls.some((c) => c.cmd === 'chmod' && c.args.includes('u+w') && c.args.includes(stale)),
+      ).toBe(true)
     })
   })
 

--- a/internal/agent-skills/src/index.ts
+++ b/internal/agent-skills/src/index.ts
@@ -110,6 +110,12 @@ const LOCK_FILE = '.editing'
  */
 export const RESERVED_SKILL_NAMES: ReadonlySet<string> = new Set(['__platform__'])
 
+/** Hidden prefix of a `__platform__` publish staging dir: `<prefix><pid>-<ms>`. */
+const PLATFORM_STAGING_PREFIX = '.__platform__.staging-'
+/** A staging dir older than this is orphaned (no install runs that long), so a
+ * sweep may remove it without racing a sibling replica's live install. */
+const STAGING_STALE_MS = 5 * 60_000
+
 function assertNotReserved(name: string): void {
   if (RESERVED_SKILL_NAMES.has(name)) {
     throw new Error(`Skill name "${name}" is reserved for platform use`)
@@ -839,6 +845,44 @@ export class SkillManager {
   }
 
   /**
+   * Remove a tree that may have been locked readonly. The publish path chmods
+   * staging to 0444/0555 before renaming, so a plain rm of a staging that DIDN'T
+   * get renamed (the loser of a race, or a crash mid-install) fails EPERM —
+   * removing a file needs write on its parent dir. Restore write first, then rm.
+   */
+  private async forceRm(path: string): Promise<void> {
+    if (!this.fs.exists(path)) return
+    await this.shell.exec('chmod', ['-R', 'u+w', path]).catch(() => {})
+    await this.fs.rm(path).catch(() => {})
+  }
+
+  /**
+   * Sweep orphaned `__platform__` staging dirs off the shared volume. The loser
+   * of a publish race (or a crash between chmod-readonly and rename) leaves a
+   * readonly staging that nothing else clears. Only stagings older than
+   * STAGING_STALE_MS are removed: a sibling replica mid-install in this same
+   * cold-start wave has a fresh timestamp, so its live staging is never touched.
+   * The timestamp is the Date.now() embedded in the name at creation.
+   */
+  private async sweepStaleStaging(): Promise<void> {
+    let entries: string[]
+    try {
+      entries = await this.fs.readdir(this.skillsDir)
+    } catch {
+      return // no skillsDir yet — nothing to sweep
+    }
+    const cutoff = Date.now() - STAGING_STALE_MS
+    await Promise.all(
+      entries.map(async (e) => {
+        if (!e.startsWith(PLATFORM_STAGING_PREFIX)) return
+        const ts = Number(e.slice(e.lastIndexOf('-') + 1))
+        if (Number.isFinite(ts) && ts > cutoff) return // fresh → a live sibling
+        await this.forceRm(`${this.skillsDir}/${e}`)
+      }),
+    )
+  }
+
+  /**
    * Stamp the platform-managed `__platform__` skill onto disk. Caller passes a
    * map of relative paths → content; SkillManager owns the lifecycle.
    *
@@ -865,6 +909,11 @@ export class SkillManager {
     const version = SkillManager.platformVersion(files)
     const verPath = this.platformVersionPath()
 
+    // 0. Clear orphaned staging dirs from earlier races/crashes (readonly, so
+    // nothing else can). Skips fresh ones, so a sibling installing right now is
+    // never disturbed. Runs before the skip below so even a warm boot tidies up.
+    await this.sweepStaleStaging()
+
     // 1. Idempotent skip: this exact version is already installed (by us on a
     // prior boot, or by a sibling replica in this cold-start wave).
     if (this.fs.exists(dest)) {
@@ -878,8 +927,8 @@ export class SkillManager {
     }
 
     // 2. Stage the full tree on the same filesystem as dest.
-    const staging = `${this.skillsDir}/.__platform__.staging-${process.pid}-${Date.now()}`
-    await this.fs.rm(staging) // clear a leaked staging from a crashed prior boot
+    const staging = `${this.skillsDir}/${PLATFORM_STAGING_PREFIX}${process.pid}-${Date.now()}`
+    await this.forceRm(staging) // clear a same-name leftover (readonly-safe)
     await this.fs.mkdir(staging)
     const sorted = Object.entries(files).sort(
       ([a], [b]) => a.split('/').length - b.split('/').length,
@@ -908,7 +957,9 @@ export class SkillManager {
       }
       await this.fs.rename(staging, dest)
     } catch {
-      await this.fs.rm(staging).catch(() => {})
+      // Lost the race (or dest reappeared): our staging was chmod'd readonly
+      // above, so a plain rm would EPERM and leak it — restore write first.
+      await this.forceRm(staging)
     }
 
     // 4. Record the version last (best-effort: a missing marker only costs a


### PR DESCRIPTION
## Problem

`installPlatformSkill` stages the platform skill tree, chmods it readonly (0444 files / 0555 dirs) so the publish is atomic, then `rename`s it into place. On the loser of a publish race — two auto-scaling replicas installing into the **same shared** `skillsDir` — or a crash between the chmod and the rename, the code hit the catch and did `fs.rm(staging)`.

But removing files under a `0555` dir is **EPERM** (unlink needs write on the *parent* dir), so the rm failed, the `.catch(() => {})` swallowed it, and an **undeletable** staging dir was left on the shared RWX volume. Every racy install — an initial parallel cold-start, or a platform-version-change reload — could leak one, and nothing could ever clear them (readonly + hidden).

Found while dogfooding a **codex** auto-scaling workspace (min 2 replicas): both replicas showed `.__platform__.staging-1-<ts>` left behind, and `rm -rf` on it returns `Permission denied` / exit 1. The install itself was otherwise correct — `.__platform__.version` + `__platform__` present on both replicas, no crash.

**Core-agnostic.** Every core's `skillsDir` (`.claude` / `.codex` / `.agents`) lives on the same shared `/workspace` NFS volume (verified: `.claude` and `.home` are the same PVC mount, not a per-pod tmpfs), so claude-code and goose are equally susceptible — codex just happened to hit the race window in this run. The fix lives in the shared `internal/agent-skills`, so it covers all cores.

## Trigger conditions (all must hold)

1. Auto-scaling ws (≥2 replicas) — static/single-replica never races.
2. A real install, not the idempotent skip: `dest` absent (initial cold-start on the empty volume) or the platform-skill content version changed (reload). A warm boot with an unchanged version skips, so no staging, no leak.
3. The two replicas' publish steps interleave in the narrow window where one sees `dest` absent at its check but finds it present at its `rename` (the other won in between) → `ENOTEMPTY` → that replica is the readonly-staging loser.

At most one leak per such event. `podManagementPolicy: Parallel` makes the initial cold-start hit it readily.

## Fix

- `forceRm(path)` — chmod `-R u+w` then `rm`, mirroring the readonly-safe clear the dest path already does. Used on the loser's staging in the catch.
- `sweepStaleStaging()` at the start of install — reaps orphaned `.__platform__.staging-*` dirs from earlier races/crashes. It only removes stagings whose embedded timestamp is older than 5min, so a **sibling replica mid-install in the same cold-start wave is never disturbed**. Runs before the idempotent-skip so even a warm boot tidies up accumulated junk.

## Test

45 passing (`vitest`). The racer test now asserts a `chmod u+w <staging>` precedes the removal (the actual fix — the in-memory fs can't model EPERM). New test: a stale orphan staging is swept while a fresh sibling staging is preserved.