### PR TITLE
fix(autoscaling): tear down by shape on delete, don't leak the StatefulSet

### DIFF
--- a/control-plane/src/services/k8s.ts
+++ b/control-plane/src/services/k8s.ts
@@ -67,3 +67,14 @@ export function watchDeployments(
 export function deleteInstance(workspaceId: string) {
   return defaultProvider.deleteInstance(workspaceId)
 }
+
+/**
+ * Tear down a workspace's instance by whatever shape actually exists: a static
+ * Deployment (+ ClusterIP Service) or an auto-scaling StatefulSet (+ headless
+ * Service). Both share the PVC name. Prefer this over {@link deleteInstance},
+ * which only knows the Deployment shape and would leak an auto-scaling
+ * workspace's StatefulSet, pods, and headless Service.
+ */
+export function destroy(workspaceId: string) {
+  return defaultProvider.destroy(workspaceId)
+}

--- a/control-plane/src/services/workspace-lifecycle.test.ts
+++ b/control-plane/src/services/workspace-lifecycle.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Workspace } from './db/types'
+
+// destroyWorkspace must tear a built-in workspace down by the shape that exists
+// (Deployment OR StatefulSet) via k8s.destroy — NOT the Deployment-only
+// deleteInstance, which leaks an auto-scaling workspace's StatefulSet, pods, and
+// headless Service. Remote environments invert control (mark desired=deleted and
+// let the runner reap), so cp must not try to delete their k8s directly.
+
+vi.mock('../routes/workspaces/_shared', () => ({ interruptAllSessions: vi.fn() }))
+vi.mock('./db/schedules', () => ({ listSchedulesByWorkspace: vi.fn().mockResolvedValue([]) }))
+vi.mock('../lib/service-hooks', () => ({ fireDeleteHooks: vi.fn() }))
+vi.mock('../lib/jobs', () => ({ cancelScheduleTimer: vi.fn() }))
+vi.mock('./db/environments', () => ({ getWorkspacePlacementEnv: vi.fn() }))
+vi.mock('./db/sessions', () => ({ resetAllSessionsIdle: vi.fn() }))
+vi.mock('./db/workspaces', () => ({ deleteWorkspace: vi.fn(), updateWorkspace: vi.fn() }))
+vi.mock('./placement', () => ({ setDesiredPhase: vi.fn() }))
+vi.mock('./k8s', () => ({ destroy: vi.fn(), deleteInstance: vi.fn() }))
+
+import { getWorkspacePlacementEnv } from './db/environments'
+import { deleteWorkspace, updateWorkspace } from './db/workspaces'
+import * as k8s from './k8s'
+import { setDesiredPhase } from './placement'
+import { destroyWorkspace } from './workspace-lifecycle'
+
+const ws = { id: 'ws1' } as Workspace
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('destroyWorkspace', () => {
+  it('tears a built-in workspace down by shape (k8s.destroy), never the Deployment-only deleteInstance', async () => {
+    vi.mocked(getWorkspacePlacementEnv).mockResolvedValue({ isBuiltin: true } as never)
+
+    await destroyWorkspace(ws)
+
+    expect(k8s.destroy).toHaveBeenCalledWith('ws1')
+    // The leak-prone path: deleteInstance only deletes the Deployment shape.
+    expect(k8s.deleteInstance).not.toHaveBeenCalled()
+    expect(deleteWorkspace).toHaveBeenCalledWith('ws1')
+    expect(setDesiredPhase).not.toHaveBeenCalled()
+  })
+
+  it('treats a null placement env as built-in (synchronous teardown)', async () => {
+    vi.mocked(getWorkspacePlacementEnv).mockResolvedValue(null as never)
+
+    await destroyWorkspace(ws)
+
+    expect(k8s.destroy).toHaveBeenCalledWith('ws1')
+    expect(deleteWorkspace).toHaveBeenCalledWith('ws1')
+  })
+
+  it('inverts control for a remote workspace: mark desired=deleted, no direct k8s teardown', async () => {
+    vi.mocked(getWorkspacePlacementEnv).mockResolvedValue({ isBuiltin: false } as never)
+
+    await destroyWorkspace(ws)
+
+    expect(setDesiredPhase).toHaveBeenCalledWith('ws1', 'deleted')
+    expect(updateWorkspace).toHaveBeenCalledWith('ws1', { status: 'deleting' })
+    expect(k8s.destroy).not.toHaveBeenCalled()
+    expect(k8s.deleteInstance).not.toHaveBeenCalled()
+    expect(deleteWorkspace).not.toHaveBeenCalled()
+  })
+})

--- a/control-plane/src/services/workspace-lifecycle.ts
+++ b/control-plane/src/services/workspace-lifecycle.ts
@@ -55,6 +55,10 @@ export async function destroyWorkspace(workspace: Workspace): Promise<void> {
     return
   }
 
-  await k8s.deleteInstance(workspace.id)
+  // Tear down by the shape that exists (Deployment or StatefulSet). deleteInstance
+  // knows only the Deployment shape, so an auto-scaling workspace's StatefulSet,
+  // pods, and headless Service would leak — and since the row (and its placement)
+  // is deleted next, the runner's reconcile never sees it to clean up.
+  await k8s.destroy(workspace.id)
   await deleteWorkspace(workspace.id)
 }


### PR DESCRIPTION
## Problem

Deleting a built-in workspace runs `destroyWorkspace`, which tore the k8s objects down via `k8s.deleteInstance`. That path only knows the **static Deployment** shape — it deletes the Deployment, the ClusterIP Service, and the PVC.

For an **auto-scaling** workspace the Deployment and ClusterIP Service don't exist (404), the shared-named PVC **is** deleted, but the **StatefulSet, its pods, and the headless Service are never targeted** — they leak. Worse, `destroyWorkspace` deletes the workspace row (and its placement, via CASCADE) immediately after, so the runner's reconcile never sees a `desired=deleted` placement to clean them up. **The pods run forever.**

Reproduced: deleting an auto-scaling ws returned `{success:true}` and removed the DB rows, but `kubectl` showed the StatefulSet still `2/2`, both pods `Running` (no `deletionTimestamp`), and the headless Service still present — only the PVC was `Terminating`.

## Fix

The provider already has a shape-aware `destroy()` — StatefulSet (+ headless Service) if one exists, else the Deployment path — and the runner's own `desired=deleted` reconcile uses it. cp's delete route just wasn't. Route `destroyWorkspace` through a new `k8s.destroy()` wrapper instead of `k8s.deleteInstance()`.

## Test

New `workspace-lifecycle` suite (340 passing total): a built-in workspace tears down via `k8s.destroy` and never the Deployment-only `deleteInstance`; a null placement env is treated as built-in; a remote environment inverts control (`desired=deleted`, no direct k8s teardown). `tsc --noEmit` clean.
