### PR TITLE
fix(self-host): grant cp RBAC to delete StatefulSets

### DIFF
--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -14,7 +14,9 @@ rules:
     resources: ["pods", "services", "secrets", "configmaps", "events", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["apps"]
-    resources: ["deployments", "deployments/scale"]
+    # statefulsets: auto-scaling workspaces are StatefulSet-backed; cp deletes
+    # them on workspace delete (get to detect the shape, delete to tear down).
+    resources: ["deployments", "deployments/scale", "statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Follow-up to the shape-aware workspace teardown (cp now calls `provider.destroy` which deletes an auto-scaling workspace's StatefulSet). The control-plane Role only granted `apps/deployments`, so `deleteNamespacedStatefulSet` returned **403 Forbidden** and the delete API 500'd — an auto-scaling workspace could not be deleted at all (its StatefulSet, pods, and headless Service would also leak). Adds `statefulsets` to the apps rule (get to detect the shape, delete to tear it down).