### PR TITLE
fix(k8s-provider): ensure a workspace Service on every converge path

### DIFF
--- a/control-plane/src/services/env-runner-reconcile.test.ts
+++ b/control-plane/src/services/env-runner-reconcile.test.ts
@@ -163,7 +163,7 @@ describe('reconcileOnce decision table', () => {
     const result = await reconcileOnce(provider, transport)
 
     expect(provider.count('stop')).toBe(1)
-    expect(transport.writes()).toEqual([{ phase: 'stopped', endpoint: undefined }])
+    expect(transport.writes()).toEqual([{ phase: 'stopped', endpoint: undefined, message: null }])
     expect(result).toMatchObject({ acted: 1, failed: 0 })
   })
 
@@ -207,7 +207,9 @@ describe('reconcileOnce decision table', () => {
     const applies = provider.calls.filter((c) => c.method === 'apply')
     expect(applies).toHaveLength(1)
     expect(applies[0].args[1]).toBe(spec)
-    expect(transport.writes()).toEqual([{ phase: 'running', endpoint: undefined, version: 2 }])
+    expect(transport.writes()).toEqual([
+      { phase: 'running', endpoint: undefined, version: 2, message: null },
+    ])
     expect(result).toMatchObject({ acted: 1 })
   })
 
@@ -221,7 +223,9 @@ describe('reconcileOnce decision table', () => {
     const result = await reconcileOnce(provider, transport)
 
     expect(provider.count('apply')).toBe(1)
-    expect(transport.writes()).toEqual([{ phase: 'starting', endpoint: undefined, version: 1 }])
+    expect(transport.writes()).toEqual([
+      { phase: 'starting', endpoint: undefined, version: 1, message: null },
+    ])
     expect(result).toMatchObject({ acted: 1 })
   })
 
@@ -241,7 +245,7 @@ describe('reconcileOnce decision table', () => {
 
     expect(provider.count('start')).toBe(1)
     expect(provider.count('apply')).toBe(0)
-    expect(transport.writes()).toEqual([{ phase: 'running', endpoint: undefined }])
+    expect(transport.writes()).toEqual([{ phase: 'running', endpoint: undefined, message: null }])
     expect(result).toMatchObject({ acted: 1 })
   })
 
@@ -261,7 +265,7 @@ describe('reconcileOnce decision table', () => {
     expect(provider.count('apply')).toBe(0)
     expect(provider.count('start')).toBe(0)
     expect(provider.count('stop')).toBe(0)
-    expect(transport.writes()).toEqual([{ phase: 'starting', endpoint: undefined }])
+    expect(transport.writes()).toEqual([{ phase: 'starting', endpoint: undefined, message: null }])
     expect(result).toMatchObject({ noop: 1 })
   })
 

--- a/control-plane/src/services/k8s-provider-service.test.ts
+++ b/control-plane/src/services/k8s-provider-service.test.ts
@@ -139,6 +139,13 @@ function makeApis(opts: {
       services.push(svc)
       return { body: svc }
     },
+    deleteNamespacedService: async (name: string) => {
+      record('deleteNamespacedService', name)
+      const i = services.findIndex((s) => s.metadata?.name === name)
+      if (i < 0) throw apiError(404)
+      services.splice(i, 1)
+      return { body: {} }
+    },
     createNamespacedPersistentVolumeClaim: async (
       _ns: string,
       pvc: k8s.V1PersistentVolumeClaim,
@@ -210,6 +217,33 @@ describe('observation reflects Service presence', () => {
     const stopped = makeApis({ deployments: [deployment('ws1', 0, 0)], services: [] })
     await stopped.provider.observe('ws1')
     expect(stopped.methods()).not.toContain('readNamespacedService')
+  })
+})
+
+describe('stop releases the ClusterIP', () => {
+  it('stop: deletes the Service, and start puts it back', async () => {
+    const { provider, services } = makeApis({
+      deployments: [deployment('ws1', 1, 1)],
+      services: [service('ws1')],
+    })
+    await provider.stop('ws1')
+    expect(services).toHaveLength(0)
+
+    await provider.start('ws1')
+    expect(services.map((s) => s.metadata?.name)).toEqual(['nap-ws1'])
+  })
+
+  it('stop: tolerates a Service that is already gone', async () => {
+    const { provider } = makeApis({ deployments: [deployment('ws1', 1, 1)], services: [] })
+    await expect(provider.stop('ws1')).resolves.toBeUndefined()
+  })
+
+  it('stop: leaves the auto-scaling shape to its own teardown', async () => {
+    // No Deployment → stopInstance 404s → the StatefulSet path takes over; its
+    // headless Service holds no ClusterIP, so there is nothing to release.
+    const { provider, methods } = makeApis({ deployments: [], services: [] })
+    await provider.stop('ws1')
+    expect(methods()).not.toContain('deleteNamespacedService')
   })
 })
 

--- a/control-plane/src/services/k8s-provider-service.test.ts
+++ b/control-plane/src/services/k8s-provider-service.test.ts
@@ -1,0 +1,264 @@
+import type * as k8s from '@kubernetes/client-node'
+import { describe, expect, it } from 'vitest'
+import { KubernetesProvider } from '../../../internal/k8s-provider'
+import type { K8sConfig } from '../../../internal/k8s-provider'
+
+// A workspace's ClusterIP Service is the one resource whose creation can fail
+// for a cluster-wide reason (ClusterIP range exhausted), so a healthy pod can
+// outlive its Service and become reachable by nothing. These tests pin the two
+// halves of the answer: every converge path recreates a missing Service, and an
+// observation reports 'error' instead of a 'running' that every HTTP hop turns
+// into a 502.
+
+const cfg: K8sConfig = {
+  namespace: 'nap',
+  namePrefix: 'nap',
+  agentImagePrefix: 'nap-agent',
+  agentImageTag: 'latest',
+  storageClass: 'nfs-csi',
+  imagePullSecret: '',
+  nodeSelector: undefined,
+  workspaceStorageSize: '10Gi',
+  cpServiceUrl: 'http://nap-cp:3000',
+  memoryFuseImage: '',
+  multiReplica: false,
+  afs: {
+    enabled: false,
+    image: '',
+    controllerAddr: 'afs-controller.nap.svc:9100',
+    fuseServerAddr: '127.0.0.1:9101',
+    storagePvc: 'afs-shared-storage',
+    configMap: 'afs-fuse-config',
+  },
+}
+
+/** A k8s API error shaped the way the client-node library reports one. */
+function apiError(statusCode: number, message = 'boom'): Error & { response: unknown } {
+  return Object.assign(new Error(message), { response: { statusCode } })
+}
+
+function deployment(wsId: string, replicas: number, readyReplicas: number): k8s.V1Deployment {
+  return {
+    metadata: { name: `nap-${wsId}`, labels: { 'workspace-id': wsId } },
+    spec: { replicas },
+    status: { readyReplicas },
+  } as unknown as k8s.V1Deployment
+}
+
+function service(wsId: string, clusterIP = '10.96.0.1', name = `nap-${wsId}`): k8s.V1Service {
+  return {
+    metadata: { name, labels: { 'workspace-id': wsId } },
+    spec: { clusterIP },
+  } as unknown as k8s.V1Service
+}
+
+type Call = { method: string; args: unknown[] }
+
+/**
+ * Fake apps/core API pair recording every call. `services` is the cluster's
+ * current Service set; tests seed it and assert on what the provider added.
+ */
+function makeApis(opts: {
+  deployments?: k8s.V1Deployment[]
+  services?: k8s.V1Service[]
+  serviceCreateFails?: boolean
+}) {
+  const calls: Call[] = []
+  const services = [...(opts.services ?? [])]
+  const deployments = [...(opts.deployments ?? [])]
+  const record = (method: string, ...args: unknown[]) => calls.push({ method, args })
+
+  const appsApi = {
+    listNamespacedDeployment: async () => {
+      record('listNamespacedDeployment')
+      return { body: { items: deployments, metadata: { resourceVersion: '1' } } }
+    },
+    readNamespacedDeployment: async (name: string) => {
+      record('readNamespacedDeployment', name)
+      const dep = deployments.find((d) => d.metadata?.name === name)
+      if (!dep) throw apiError(404)
+      return { body: dep }
+    },
+    createNamespacedDeployment: async (_ns: string, dep: k8s.V1Deployment) => {
+      record('createNamespacedDeployment', dep.metadata?.name)
+      deployments.push(dep)
+      return { body: dep }
+    },
+    patchNamespacedDeployment: async (name: string) => {
+      record('patchNamespacedDeployment', name)
+      const dep = deployments.find((d) => d.metadata?.name === name)
+      if (!dep) throw apiError(404)
+      return { body: dep }
+    },
+    patchNamespacedDeploymentScale: async (
+      name: string,
+      _ns: string,
+      body: { spec: { replicas: number } },
+    ) => {
+      record('patchNamespacedDeploymentScale', name)
+      const dep = deployments.find((d) => d.metadata?.name === name)
+      if (!dep) throw apiError(404)
+      dep.spec = { ...dep.spec, replicas: body.spec.replicas } as k8s.V1DeploymentSpec
+      return { body: dep }
+    },
+    deleteNamespacedDeployment: async (name: string) => {
+      record('deleteNamespacedDeployment', name)
+      const i = deployments.findIndex((d) => d.metadata?.name === name)
+      if (i < 0) throw apiError(404)
+      deployments.splice(i, 1)
+      return { body: {} }
+    },
+    readNamespacedStatefulSet: async () => {
+      throw apiError(404)
+    },
+    patchNamespacedStatefulSetScale: async (name: string) => {
+      record('patchNamespacedStatefulSetScale', name)
+      throw apiError(404)
+    },
+  } as unknown as k8s.AppsV1Api
+
+  const coreApi = {
+    listNamespacedService: async () => {
+      record('listNamespacedService')
+      return { body: { items: services } }
+    },
+    readNamespacedService: async (name: string) => {
+      record('readNamespacedService', name)
+      const svc = services.find((s) => s.metadata?.name === name)
+      if (!svc) throw apiError(404)
+      return { body: svc }
+    },
+    createNamespacedService: async (_ns: string, svc: k8s.V1Service) => {
+      record('createNamespacedService', svc.metadata?.name)
+      if (opts.serviceCreateFails) {
+        throw apiError(
+          500,
+          'Internal error occurred: failed to allocate a serviceIP: range is full',
+        )
+      }
+      services.push(svc)
+      return { body: svc }
+    },
+    createNamespacedPersistentVolumeClaim: async (
+      _ns: string,
+      pvc: k8s.V1PersistentVolumeClaim,
+    ) => {
+      record('createNamespacedPersistentVolumeClaim', pvc.metadata?.name)
+      return { body: pvc }
+    },
+    listNamespacedStatefulSet: async () => ({ body: { items: [] } }),
+    listNamespacedPod: async () => ({ body: { items: [] } }),
+  } as unknown as k8s.CoreV1Api
+
+  const provider = new KubernetesProvider(appsApi, coreApi, {} as k8s.KubeConfig, cfg)
+  return {
+    provider,
+    calls,
+    services,
+    deployments,
+    methods: () => calls.map((c) => c.method),
+  }
+}
+
+describe('observation reflects Service presence', () => {
+  it('observeAll: running Deployment with no Service reports error, not running', async () => {
+    const { provider } = makeApis({ deployments: [deployment('ws1', 1, 1)], services: [] })
+    const observed = await provider.observeAll()
+    expect(observed.get('ws1')).toMatchObject({
+      phase: 'error',
+      message: expect.stringContaining('Service missing'),
+    })
+  })
+
+  it('observeAll: running Deployment with its Service reports running, no message', async () => {
+    const { provider } = makeApis({
+      deployments: [deployment('ws1', 1, 1)],
+      services: [service('ws1')],
+    })
+    const observed = await provider.observeAll()
+    expect(observed.get('ws1')?.phase).toBe('running')
+    expect(observed.get('ws1')?.message).toBeUndefined()
+  })
+
+  it('observeAll: a stopped workspace with no Service stays stopped, not error', async () => {
+    // Reclaiming a stopped workspace's Service is legitimate — start() puts it
+    // back — so it must not show up as a failure in the meantime.
+    const { provider } = makeApis({ deployments: [deployment('ws1', 0, 0)], services: [] })
+    expect((await provider.observeAll()).get('ws1')?.phase).toBe('stopped')
+  })
+
+  it('observeAll: the auto-scaling headless Service does not count as the ClusterIP one', async () => {
+    const { provider } = makeApis({
+      deployments: [deployment('ws1', 1, 1)],
+      services: [service('ws1', 'None', 'nap-ws1-hl')],
+    })
+    expect((await provider.observeAll()).get('ws1')?.phase).toBe('error')
+  })
+
+  it('observe: same verdict for a single workspace', async () => {
+    const missing = makeApis({ deployments: [deployment('ws1', 1, 1)], services: [] })
+    expect((await missing.provider.observe('ws1')).phase).toBe('error')
+
+    const present = makeApis({
+      deployments: [deployment('ws1', 1, 1)],
+      services: [service('ws1')],
+    })
+    expect((await present.provider.observe('ws1')).phase).toBe('running')
+  })
+
+  it('observe: skips the Service read when the phase cannot be running', async () => {
+    const stopped = makeApis({ deployments: [deployment('ws1', 0, 0)], services: [] })
+    await stopped.provider.observe('ws1')
+    expect(stopped.methods()).not.toContain('readNamespacedService')
+  })
+})
+
+describe('converge paths repair a missing Service', () => {
+  it('start: recreates the Service of a stopped workspace whose Service was reclaimed', async () => {
+    const { provider, services, methods } = makeApis({
+      deployments: [deployment('ws1', 0, 0)],
+      services: [],
+    })
+    await provider.start('ws1')
+    expect(methods()).toContain('createNamespacedService')
+    expect(services.map((s) => s.metadata?.name)).toEqual(['nap-ws1'])
+  })
+
+  it('start: does not create a ClusterIP Service for the auto-scaling shape', async () => {
+    // No Deployment → startInstance 404s → the StatefulSet path takes over, and
+    // a ClusterIP Service there would just burn an IP it never routes with.
+    const { provider, methods } = makeApis({ deployments: [], services: [] })
+    await provider.start('ws1')
+    expect(methods()).not.toContain('createNamespacedService')
+  })
+
+  it('apply: recreates the Service of an existing workspace before rebuilding', async () => {
+    const { provider, methods } = makeApis({
+      deployments: [deployment('ws1', 1, 1)],
+      services: [],
+    })
+    await provider.apply('ws1', { agentType: 'claude-code', resources: {}, version: 1 })
+    expect(methods()).toContain('createNamespacedService')
+  })
+})
+
+describe('createInstance orders the Service before the Deployment', () => {
+  it('creates the Service first', async () => {
+    const { provider, methods } = makeApis({})
+    await provider.createInstance('ws1')
+    const order = methods()
+    expect(order.indexOf('createNamespacedService')).toBeLessThan(
+      order.indexOf('createNamespacedDeployment'),
+    )
+  })
+
+  it('a full ClusterIP range leaves no Deployment behind', async () => {
+    // The failure that started this: the Service could not be allocated. With
+    // the Service first, no Deployment exists, so observe() says 'unknown' and
+    // reconcile keeps retrying — instead of a running-but-unreachable workspace
+    // that no drift trigger ever revisits.
+    const { provider, deployments } = makeApis({ serviceCreateFails: true })
+    await expect(provider.createInstance('ws1')).rejects.toThrow('range is full')
+    expect(deployments).toHaveLength(0)
+  })
+})

--- a/internal/env-runner-core/reconcile.ts
+++ b/internal/env-runner-core/reconcile.ts
@@ -39,6 +39,9 @@ async function recordIfChanged(
     await transport.writeObserved(p.workspace_id, {
       phase: current.phase,
       endpoint: current.endpoint,
+      // Explicit null, not omitted: a phase that recovered has to clear the
+      // message the failing phase left behind.
+      message: current.message ?? null,
     })
   }
 }
@@ -71,6 +74,7 @@ async function reconcilePlacement(
       await transport.writeObserved(p.workspace_id, {
         phase: after.phase,
         endpoint: after.endpoint,
+        message: after.message ?? null,
       })
       return 'stop'
     }
@@ -88,6 +92,7 @@ async function reconcilePlacement(
       phase: after.phase,
       endpoint: after.endpoint,
       version: p.spec_version,
+      message: after.message ?? null,
     })
     return 'apply'
   }
@@ -102,6 +107,7 @@ async function reconcilePlacement(
         phase: after.phase,
         endpoint: after.endpoint,
         version: p.spec_version,
+        message: after.message ?? null,
       })
       return 'apply'
     }
@@ -111,6 +117,7 @@ async function reconcilePlacement(
       await transport.writeObserved(p.workspace_id, {
         phase: after.phase,
         endpoint: after.endpoint,
+        message: after.message ?? null,
       })
       return 'start'
     }

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -3,6 +3,7 @@ import type { ComputeResources } from '../types/api'
 import type {
   Capabilities,
   EnvironmentProvider,
+  ObservedPhase,
   ObservedState,
   WorkspaceSpec,
 } from '../types/environments'
@@ -80,6 +81,35 @@ export class KubernetesProvider implements EnvironmentProvider {
     return workspaceLabels(this.cfg, workspaceId)
   }
 
+  /**
+   * Create the workspace's ClusterIP Service if it isn't there (agents are
+   * reached via cluster DNS at `<prefix>-<wsId>.<ns>.svc:3001`; afs-fuse via
+   * :9101). Idempotent — a 409 means it already exists.
+   *
+   * Called from every converge path, not just create: the Service is the one
+   * workspace resource whose creation can fail for a *cluster-wide* reason
+   * (ClusterIP range exhausted) rather than a per-workspace one, so a
+   * workspace can outlive its Service. Without a repair on start()/apply(),
+   * such a workspace stays unreachable forever — its Deployment is healthy, so
+   * nothing in reconcile ever fires.
+   */
+  private async ensureService(workspaceId: string): Promise<void> {
+    const name = this.getResourceName(workspaceId)
+    const labels = this.getLabels(workspaceId)
+    await createOrAdopt(() =>
+      this.coreApi.createNamespacedService(this.cfg.namespace, {
+        apiVersion: 'v1',
+        kind: 'Service',
+        metadata: { name, labels },
+        spec: {
+          selector: labels,
+          ports: WORKSPACE_SERVICE_PORTS,
+          type: 'ClusterIP',
+        },
+      }),
+    )
+  }
+
   /** Create K8s resources for a workspace */
   async createInstance(
     workspaceId: string,
@@ -105,6 +135,13 @@ export class KubernetesProvider implements EnvironmentProvider {
       }),
     )
 
+    // Service before Deployment: it is the step that can fail on a cluster-wide
+    // resource (ClusterIP range full). Creating it first means such a failure
+    // leaves no Deployment behind — observe() reports 'unknown' and reconcile
+    // keeps retrying, instead of a running-but-unreachable workspace nothing
+    // ever re-converges.
+    await this.ensureService(workspaceId)
+
     // Create Deployment. A 409 here can only be a race with a concurrent
     // create building the same fresh spec (a pre-existing Deployment routes
     // apply() to rebuildInstance instead), so adopting is safe.
@@ -113,21 +150,6 @@ export class KubernetesProvider implements EnvironmentProvider {
         this.cfg.namespace,
         buildDeploymentSpec(name, labels, workspaceId, agentType, pvcName, resources, this.cfg),
       ),
-    )
-
-    // Create Service (ClusterIP — agents are reached via cluster DNS at
-    // <prefix>-<wsId>.<ns>.svc:3001; afs-fuse via :9101)
-    await createOrAdopt(() =>
-      this.coreApi.createNamespacedService(this.cfg.namespace, {
-        apiVersion: 'v1',
-        kind: 'Service',
-        metadata: { name, labels },
-        spec: {
-          selector: labels,
-          ports: WORKSPACE_SERVICE_PORTS,
-          type: 'ClusterIP',
-        },
-      }),
     )
 
     return {
@@ -527,6 +549,40 @@ export class KubernetesProvider implements EnvironmentProvider {
   }
 
   /**
+   * The workspace-ids that currently have a ClusterIP Service. Same label
+   * selector as {@link listWorkspaceDeployments}; only the ids are kept, since
+   * every caller asks "does this workspace have one" and nothing else.
+   */
+  async listWorkspaceServiceIds(timeoutMs = 30_000): Promise<Set<string>> {
+    const response = await Promise.race([
+      this.coreApi.listNamespacedService(
+        this.cfg.namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        `app=${this.cfg.namePrefix},component=workspace`,
+      ),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`listWorkspaceServiceIds timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        ),
+      ),
+    ])
+
+    const ids = new Set<string>()
+    for (const svc of response.body.items) {
+      // Skip the auto-scaling headless Service (`<name>-hl`), which carries the
+      // same labels but is not the ClusterIP one this check is about.
+      if (svc.spec?.clusterIP === 'None') continue
+      const wsId = svc.metadata?.labels?.['workspace-id']
+      if (wsId) ids.add(wsId)
+    }
+    return ids
+  }
+
+  /**
    * Full list of all workspace deployments. Returns deployments indexed by
    * workspace-id plus the response resourceVersion for starting a watch.
    */
@@ -640,6 +696,7 @@ export class KubernetesProvider implements EnvironmentProvider {
       // rebuild swaps the Deployment (new container resources/image) but
       // preserves the PVC, so grow storage separately when the spec asks for it
       // (expand only ever increases; same-size is a no-op).
+      await this.ensureService(workspaceId)
       await this.rebuildInstance(workspaceId, spec.agentType, spec.resources)
       if (spec.resources?.storage) {
         await this.expandInstanceStorage(workspaceId, spec.resources.storage)
@@ -655,7 +712,16 @@ export class KubernetesProvider implements EnvironmentProvider {
     // i.e. an auto-scaling workspace, whose StatefulSet we wake instead (also a
     // no-op if it has neither shape).
     const started = await this.startInstance(workspaceId)
-    if (!started) await this.autoScaling.start(workspaceId)
+    if (!started) {
+      await this.autoScaling.start(workspaceId)
+      return
+    }
+    // Static shape woke up — repair its Service on the way. A stopped workspace
+    // keeps its Service while scaled to 0, but that Service may have been
+    // reclaimed (or never created), and waking the pod alone would leave it
+    // unreachable. Only on this branch: the auto-scaling shape routes through
+    // its own headless Service and a ClusterIP one would just burn an IP.
+    await this.ensureService(workspaceId)
   }
 
   async stop(workspaceId: string): Promise<void> {
@@ -682,6 +748,23 @@ export class KubernetesProvider implements EnvironmentProvider {
   }
 
   /**
+   * A workspace whose pods are up but whose Service is gone is reachable by
+   * nothing: cp addresses agents by cluster DNS, which resolves through that
+   * Service. Reported as 'error' rather than 'running' so the placement row
+   * says what a caller would find, instead of a `running` that every HTTP hop
+   * turns into a 502.
+   *
+   * Only applied to 'running': a stopped workspace legitimately has no Service
+   * once one is reclaimed, and start() recreates it on the way up.
+   */
+  private withServiceCheck(phase: ObservedPhase, hasService: boolean): ObservedState['phase'] {
+    return phase === 'running' && !hasService ? 'error' : phase
+  }
+
+  private static readonly SERVICE_MISSING_MESSAGE =
+    'Service missing — workspace is running but unreachable via cluster DNS'
+
+  /**
    * Point-in-time observation via a single Deployment read. `version` is left
    * undefined: the spec-convergence version is a placement concept the runner
    * tracks itself (NOT the pod-template version stamped on the Deployment).
@@ -690,11 +773,26 @@ export class KubernetesProvider implements EnvironmentProvider {
     const name = this.getResourceName(workspaceId)
     try {
       const res = await this.appsApi.readNamespacedDeployment(name, this.cfg.namespace)
+      const deployPhase = resolveDeploymentStatus(res.body)
+      // Only pay for the Service read when its absence would change the answer.
+      const hasService =
+        deployPhase !== 'running' ||
+        (await this.coreApi
+          .readNamespacedService(name, this.cfg.namespace)
+          .then(() => true)
+          .catch((e: any) => {
+            if (e.response?.statusCode === 404) return false
+            throw e
+          }))
+      const phase = this.withServiceCheck(deployPhase, hasService)
       return {
-        phase: resolveDeploymentStatus(res.body),
+        phase,
         endpoint: {
           address: `${name}.${this.cfg.namespace}.svc.cluster.local:3001`,
         },
+        ...(phase === 'error' && deployPhase === 'running'
+          ? { message: KubernetesProvider.SERVICE_MISSING_MESSAGE }
+          : {}),
       }
     } catch (e: any) {
       if (e.response?.statusCode === 404) {
@@ -711,17 +809,29 @@ export class KubernetesProvider implements EnvironmentProvider {
    * (status + cluster-DNS endpoint); workspaces with no deployment are simply
    * absent from the map (the reconcile loop treats them as 'unknown', exactly
    * as observe()'s 404 path does).
+   *
+   * Two LISTs, not one: the Service set is fetched alongside the Deployments so
+   * the running-but-unreachable case {@link observe} catches per workspace is
+   * caught here too, still in O(1) round-trips per pass.
    */
   async observeAll(): Promise<Map<string, ObservedState>> {
-    const { deployments } = await this.listWorkspaceDeployments()
+    const [{ deployments }, services] = await Promise.all([
+      this.listWorkspaceDeployments(),
+      this.listWorkspaceServiceIds(),
+    ])
     const out = new Map<string, ObservedState>()
     for (const [wsId, dep] of deployments) {
       const name = this.getResourceName(wsId)
+      const deployPhase = resolveDeploymentStatus(dep)
+      const phase = this.withServiceCheck(deployPhase, services.has(wsId))
       out.set(wsId, {
-        phase: resolveDeploymentStatus(dep),
+        phase,
         endpoint: {
           address: `${name}.${this.cfg.namespace}.svc.cluster.local:3001`,
         },
+        ...(phase === 'error' && deployPhase === 'running'
+          ? { message: KubernetesProvider.SERVICE_MISSING_MESSAGE }
+          : {}),
       })
     }
     // Merge in auto-scaling (StatefulSet) workspaces. A workspace is only ever

--- a/internal/k8s-provider/provider.ts
+++ b/internal/k8s-provider/provider.ts
@@ -14,6 +14,7 @@ import {
   expandWorkspacePvc,
   isPodReady,
   resourceName,
+  swallow404,
   workspaceLabels,
   workspacePvcName,
 } from './support'
@@ -729,7 +730,19 @@ export class KubernetesProvider implements EnvironmentProvider {
     // workspace scales its Deployment; stopInstance returns false (404) when
     // there is none, i.e. an auto-scaling workspace, whose StatefulSet we scale.
     const scaled = await this.stopInstance(workspaceId)
-    if (!scaled) await this.autoScaling.stop(workspaceId)
+    if (!scaled) {
+      await this.autoScaling.stop(workspaceId)
+      return
+    }
+    // Release the ClusterIP while scaled to 0. A stopped workspace routes
+    // nothing, but its Service holds an address out of a range that is finite
+    // and cluster-wide (a /22 is 1022 of them) — with stopped workspaces
+    // typically outnumbering running ones, holding those is what exhausts the
+    // range and starves *new* workspaces. start() recreates it on the way up,
+    // which is what makes releasing it safe.
+    await this.coreApi
+      .deleteNamespacedService(this.getResourceName(workspaceId), this.cfg.namespace)
+      .catch(swallow404)
   }
 
   async destroy(workspaceId: string): Promise<void> {


### PR DESCRIPTION
A workspace's ClusterIP Service was created exactly once, in `createInstance`, and never again. When a cluster's ClusterIP range fills up, that create fails **after** the Deployment is already in — leaving a healthy pod with no Service, unreachable through cluster DNS, and reported as `running` by an `observe()` that only ever read the Deployment. Nothing in reconcile re-converges a workspace that is already `running`, so it stays broken indefinitely: every file listing and agent call 502s, while the reconcile loop reports `0 failed` every pass.

Three independent gaps made that possible; this fixes all three.

## Ensure the Service on every converge path, not just create

`ensureService()` — an idempotent create (409 = already there) — is now called from `createInstance`, `start()` and `apply()`. A Service that was reclaimed or lost for any reason comes back on the next start or spec change, instead of requiring a hand-written manifest.

`start()` only does this on the static (Deployment) branch. The auto-scaling shape routes through its own headless Service, so a ClusterIP one there would just burn an IP it never routes with.

## Create the Service before the Deployment

The Service is the one workspace resource whose creation can fail for a **cluster-wide** reason (`failed to allocate a serviceIP: range is full`) rather than a per-workspace one. Creating it first means such a failure leaves nothing half-built: `observe()` reports `unknown`, reconcile keeps retrying, and the workspace converges once capacity frees up — instead of a running-but-unreachable workspace no drift trigger ever revisits.

## Release the ClusterIP while a workspace is stopped

The other half of the capacity problem: a stopped workspace routes nothing but kept its Service, and stopped workspaces typically outnumber running ones — those held addresses are what exhausts the range in the first place. `stop()` now deletes the Service on the static branch. `start()` recreating it is exactly what makes this safe; the auto-scaling branch is untouched, its headless Service holding no ClusterIP to release.

## Say so when a running workspace has no Service

`observe()` / `observeAll()` now report `error` plus a message when a running Deployment has no Service, so this cannot silently rot again. Deliberately not applied to stopped workspaces — their Service may legitimately be absent (reclaimed while scaled to 0) and `start()` puts it back.

Cost: `observeAll()` pays one extra LIST per pass (still O(1) round-trips); `observe()` reads the Service only when the phase could be `running`.

`reconcile` also plumbs `ObservedState.message` into `writeObserved`. The transport interface and the placement row already carried the column — the value was simply being dropped, so no diagnostic ever reached the DB. Written as an explicit `null` when absent, so a recovered phase clears the message its failing predecessor left behind.

## Tests

14 new cases in `k8s-provider-service.test.ts`, driving `KubernetesProvider` against a fake apps/core API pair: the observation verdicts (missing / present / stopped / headless-only), the repair on `start()` and `apply()`, the stop→start release-and-restore round trip, both auto-scaling branches staying out of ClusterIP business, the create ordering, and a full-range failure leaving no Deployment behind.

Existing reconcile-decision-table expectations updated for the new `message` field.
