### PR TITLE
feat: extend sandbox file and command capabilities across the service and MCP tools

### DIFF
--- a/control-plane/src/mcp/tools/sandbox.ts
+++ b/control-plane/src/mcp/tools/sandbox.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { getPlatformToken } from '../../services/db/shares'
 import { getWorkspace } from '../../services/db/workspaces'
 import * as sandbox from '../../services/sandbox'
-import { textResult } from './shared'
+import { errorResult, jsonResult, textResult } from './shared'
 
 const SANDBOX_PUBLIC_URL = process.env.SANDBOX_PUBLIC_URL || ''
 
@@ -39,6 +39,15 @@ For coding tasks (e.g. git clone, npm install, dev server), use a longer timeout
           })
           .optional()
           .describe('Resource limits for the sandbox'),
+        resource_requests: z
+          .object({
+            cpu: z.string().optional().describe('CPU request, e.g. "100m"'),
+            memory: z.string().optional().describe('Memory request, e.g. "128Mi"'),
+          })
+          .optional()
+          .describe(
+            'Resource requests, reserved against node capacity. Defaults to the same values as `resource` (limits). Set them lower for a sandbox that idles between bursts, so it stops holding its full limit. Ignored by older sandbox runtimes, in which case requests stay equal to limits.',
+          ),
         timeout_seconds: z
           .number()
           .optional()
@@ -56,7 +65,7 @@ For coding tasks (e.g. git clone, npm install, dev server), use a longer timeout
           .describe('Environment variables to inject into the sandbox'),
       }),
     },
-    async ({ image, resource, timeout_seconds, env }) => {
+    async ({ image, resource, resource_requests, timeout_seconds, env }) => {
       try {
         const token = await getToken()
         const envRecord = env ? Object.fromEntries(env.map((e) => [e.name, e.value])) : undefined
@@ -64,20 +73,43 @@ For coding tasks (e.g. git clone, npm install, dev server), use a longer timeout
           image,
           timeoutSeconds: timeout_seconds,
           resource: resource as Record<string, string> | undefined,
+          resourceRequests: resource_requests as Record<string, string> | undefined,
           env: envRecord,
           metadata: { workspace_id: workspaceId },
         })
-        return textResult(
-          JSON.stringify({
-            sandbox_id: info.id,
-            status: info.status,
-            image,
-            expires_at: info.expiresAt,
-            created_at: info.createdAt,
-          }),
-        )
+        return jsonResult({
+          sandbox_id: info.id,
+          status: info.status,
+          image,
+          expires_at: info.expiresAt,
+          created_at: info.createdAt,
+        })
       } catch (e: any) {
-        return textResult(`Error creating sandbox: ${e.message}`)
+        return errorResult(`Error creating sandbox: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_renew',
+    {
+      title: 'Renew Sandbox',
+      description:
+        'Extend a sandbox expiry. Use this instead of creating a replacement when a task runs longer than the original timeout.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        timeout_seconds: z
+          .number()
+          .describe('New lifetime in seconds, counted from now (e.g. 3600 for one more hour)'),
+      }),
+    },
+    async ({ sandbox_id, timeout_seconds }) => {
+      try {
+        const token = await getToken()
+        const result = await sandbox.renewSandbox(token, sandbox_id, timeout_seconds)
+        return jsonResult({ sandbox_id, expires_at: result.expiresAt })
+      } catch (e: any) {
+        return errorResult(`Error renewing sandbox: ${e.message}`)
       }
     },
   )
@@ -95,9 +127,9 @@ For coding tasks (e.g. git clone, npm install, dev server), use a longer timeout
         const result = await sandbox.listSandboxes(token, {
           metadata: { workspace_id: workspaceId },
         })
-        return textResult(JSON.stringify(result))
+        return jsonResult(result)
       } catch (e: any) {
-        return textResult(`Error listing sandboxes: ${e.message}`)
+        return errorResult(`Error listing sandboxes: ${e.message}`)
       }
     },
   )
@@ -108,7 +140,7 @@ For coding tasks (e.g. git clone, npm install, dev server), use a longer timeout
       title: 'Run Command in Sandbox',
       description: `Execute a shell command inside a sandbox.
 Returns stdout, stderr, exit_code, and execution_time_ms.
-IMPORTANT: This command blocks until completion. For long-running processes like dev servers, run in background: "nohup npm run dev > /tmp/dev.log 2>&1 & echo $!" then use sandbox_get_preview_url to get the URL.`,
+By default this blocks until the command exits. For anything long-running (dev servers, builds, watchers) pass background: true — it returns a command_id immediately, which you follow with sandbox_get_command_logs / sandbox_get_command_status and can stop with sandbox_interrupt_command. Then use sandbox_get_preview_url to reach a server you started.`,
       inputSchema: z.object({
         sandbox_id: z.string().describe('ID of the target sandbox'),
         command: z
@@ -125,9 +157,15 @@ IMPORTANT: This command blocks until completion. For long-running processes like
           )
           .optional()
           .describe('Additional environment variables for this command'),
+        background: z
+          .boolean()
+          .optional()
+          .describe(
+            'Return as soon as the command starts instead of waiting for it to exit. stdout/stderr come back empty; poll with the returned command_id.',
+          ),
       }),
     },
-    async ({ sandbox_id, command, cwd, timeout_seconds, env }) => {
+    async ({ sandbox_id, command, cwd, timeout_seconds, env, background }) => {
       try {
         const token = await getToken()
         const envRecord = env ? Object.fromEntries(env.map((e) => [e.name, e.value])) : undefined
@@ -135,10 +173,79 @@ IMPORTANT: This command blocks until completion. For long-running processes like
           cwd: cwd ?? undefined,
           timeoutSeconds: timeout_seconds,
           env: envRecord,
+          background,
         })
-        return textResult(JSON.stringify(result))
+        return jsonResult(result)
       } catch (e: any) {
-        return textResult(`Error running command: ${e.message}`)
+        return errorResult(`Error running command: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_get_command_status',
+    {
+      title: 'Get Background Command Status',
+      description:
+        'Check whether a background command is still running. Returns running, exit_code, and timing.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        command_id: z.string().describe('command_id returned by sandbox_run_command'),
+      }),
+    },
+    async ({ sandbox_id, command_id }) => {
+      try {
+        const token = await getToken()
+        return jsonResult(await sandbox.getCommandStatus(token, sandbox_id, command_id))
+      } catch (e: any) {
+        return errorResult(`Error getting command status: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_get_command_logs',
+    {
+      title: 'Get Background Command Logs',
+      description: `Fetch output from a background command.
+Returns { content, cursor }. Pass the cursor back on the next call to get only what was written since — polling from cursor 0 every time re-reads the whole log and will eventually blow past the tool output limit.`,
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        command_id: z.string().describe('command_id returned by sandbox_run_command'),
+        cursor: z
+          .number()
+          .optional()
+          .describe('Cursor from the previous call. Omit or use 0 to read from the start.'),
+      }),
+    },
+    async ({ sandbox_id, command_id, cursor }) => {
+      try {
+        const token = await getToken()
+        return jsonResult(await sandbox.getCommandLogs(token, sandbox_id, command_id, cursor))
+      } catch (e: any) {
+        return errorResult(`Error getting command logs: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_interrupt_command',
+    {
+      title: 'Interrupt Command',
+      description:
+        'Stop a running background command. The command ends with a non-zero exit code and a "signal: terminated" error.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        command_id: z.string().describe('command_id returned by sandbox_run_command'),
+      }),
+    },
+    async ({ sandbox_id, command_id }) => {
+      try {
+        const token = await getToken()
+        await sandbox.interruptCommand(token, sandbox_id, command_id)
+        return jsonResult({ success: true, command_id })
+      } catch (e: any) {
+        return errorResult(`Error interrupting command: ${e.message}`)
       }
     },
   )
@@ -147,19 +254,69 @@ IMPORTANT: This command blocks until completion. For long-running processes like
     'sandbox_read_file',
     {
       title: 'Read File from Sandbox',
-      description: 'Read the contents of a file inside a sandbox.',
+      description: `Read the contents of a file inside a sandbox.
+Reads the whole file by default. For a large file, page through it with offset/limit instead — an oversized read gets truncated on the way back to you, and you will not be told where it was cut.`,
       inputSchema: z.object({
         sandbox_id: z.string().describe('ID of the target sandbox'),
         path: z.string().describe('Absolute file path inside the sandbox'),
+        offset: z.number().optional().describe('Starting line number, 1-based'),
+        limit: z.number().optional().describe('Number of lines to read from offset'),
       }),
     },
-    async ({ sandbox_id, path }) => {
+    async ({ sandbox_id, path, offset, limit }) => {
       try {
         const token = await getToken()
-        const content = await sandbox.readFile(token, sandbox_id, path)
+        const content = await sandbox.readFile(token, sandbox_id, path, { offset, limit })
         return textResult(content)
       } catch (e: any) {
-        return textResult(`Error reading file: ${e.message}`)
+        return errorResult(`Error reading file: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_list_directory',
+    {
+      title: 'List Sandbox Directory',
+      description: `List a directory inside a sandbox. Each entry carries a type (file / directory / symlink).
+Use depth to walk subdirectories. To find a file by name rather than list a directory, use sandbox_search_files.`,
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        path: z.string().describe('Absolute directory path inside the sandbox'),
+        depth: z
+          .number()
+          .optional()
+          .describe('Traversal depth; defaults to 1 (immediate children only)'),
+      }),
+    },
+    async ({ sandbox_id, path, depth }) => {
+      try {
+        const token = await getToken()
+        return jsonResult({ files: await sandbox.listDirectory(token, sandbox_id, path, depth) })
+      } catch (e: any) {
+        return errorResult(`Error listing directory: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_search_files',
+    {
+      title: 'Search Files in Sandbox',
+      description:
+        'Find files under a directory by glob pattern (e.g. "*.py"). Returns a flat list.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        path: z.string().describe('Base directory to search from'),
+        pattern: z.string().optional().describe('Glob pattern, e.g. "*.log"'),
+      }),
+    },
+    async ({ sandbox_id, path, pattern }) => {
+      try {
+        const token = await getToken()
+        return jsonResult({ files: await sandbox.searchFiles(token, sandbox_id, path, pattern) })
+      } catch (e: any) {
+        return errorResult(`Error searching files: ${e.message}`)
       }
     },
   )
@@ -192,7 +349,145 @@ IMPORTANT: This command blocks until completion. For long-running processes like
         )
         return textResult(`Successfully wrote ${files.length} file(s)`)
       } catch (e: any) {
-        return textResult(`Error writing files: ${e.message}`)
+        return errorResult(`Error writing files: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_delete_files',
+    {
+      title: 'Delete Files from Sandbox',
+      description: 'Delete one or more files. For directories use sandbox_delete_directories.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        paths: z.array(z.string()).describe('Absolute file paths to delete'),
+      }),
+    },
+    async ({ sandbox_id, paths }) => {
+      try {
+        const token = await getToken()
+        await sandbox.deleteFiles(token, sandbox_id, paths)
+        return jsonResult({ success: true, count: paths.length })
+      } catch (e: any) {
+        return errorResult(`Error deleting files: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_move_files',
+    {
+      title: 'Move or Rename Files in Sandbox',
+      description: 'Move or rename files and directories inside a sandbox.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        entries: z
+          .array(
+            z.object({
+              src: z.string().describe('Current absolute path'),
+              dest: z.string().describe('New absolute path'),
+            }),
+          )
+          .describe('Move operations to apply'),
+      }),
+    },
+    async ({ sandbox_id, entries }) => {
+      try {
+        const token = await getToken()
+        await sandbox.moveFiles(token, sandbox_id, entries)
+        return jsonResult({ success: true, count: entries.length })
+      } catch (e: any) {
+        return errorResult(`Error moving files: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_create_directories',
+    {
+      title: 'Create Directories in Sandbox',
+      description:
+        'Create directories. Not needed before sandbox_write_files, which creates parents on its own.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        paths: z.array(z.string()).describe('Absolute directory paths to create'),
+      }),
+    },
+    async ({ sandbox_id, paths }) => {
+      try {
+        const token = await getToken()
+        await sandbox.createDirectories(
+          token,
+          sandbox_id,
+          paths.map((p) => ({ path: p })),
+        )
+        return jsonResult({ success: true, count: paths.length })
+      } catch (e: any) {
+        return errorResult(`Error creating directories: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_delete_directories',
+    {
+      title: 'Delete Directories from Sandbox',
+      description: 'Delete directories and everything inside them.',
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        paths: z.array(z.string()).describe('Absolute directory paths to delete'),
+      }),
+    },
+    async ({ sandbox_id, paths }) => {
+      try {
+        const token = await getToken()
+        await sandbox.deleteDirectories(token, sandbox_id, paths)
+        return jsonResult({ success: true, count: paths.length })
+      } catch (e: any) {
+        return errorResult(`Error deleting directories: ${e.message}`)
+      }
+    },
+  )
+
+  server.registerTool(
+    'sandbox_replace_contents',
+    {
+      title: 'Replace Text in Sandbox Files',
+      description: `Replace text inside files, editing in place instead of rewriting the whole file.
+Returns a replaced_count per file — 0 means the old text was not found, so check it rather than assuming the edit landed.
+If detail_available is false the sandbox runtime is too old to report counts: the replacement still happened, but you have to read the file back to confirm what changed.`,
+      inputSchema: z.object({
+        sandbox_id: z.string().describe('ID of the target sandbox'),
+        entries: z
+          .array(
+            z.object({
+              path: z.string().describe('Absolute file path'),
+              old_content: z.string().describe('Text to find'),
+              new_content: z.string().describe('Text to replace it with'),
+            }),
+          )
+          .describe('Replacements to apply'),
+      }),
+    },
+    async ({ sandbox_id, entries }) => {
+      try {
+        const token = await getToken()
+        const { results, detailAvailable } = await sandbox.replaceContents(
+          token,
+          sandbox_id,
+          entries.map((e) => ({
+            path: e.path,
+            oldContent: e.old_content,
+            newContent: e.new_content,
+          })),
+        )
+        return jsonResult({
+          results: results.map((r) => ({ path: r.path, replaced_count: r.replacedCount })),
+          detail_available: detailAvailable,
+        })
+      } catch (e: any) {
+        return errorResult(`Error replacing contents: ${e.message}`)
       }
     },
   )
@@ -215,7 +510,7 @@ Use this after starting a dev server (e.g. on port 3000, 5173, 8080). The URL is
     },
     async ({ sandbox_id, port }) => {
       if (!SANDBOX_PUBLIC_URL) {
-        return textResult(
+        return errorResult(
           'Error getting preview URL: SANDBOX_PUBLIC_URL env var is not set on the control plane',
         )
       }
@@ -224,7 +519,7 @@ Use this after starting a dev server (e.g. on port 3000, 5173, 8080). The URL is
         const url = `${base.protocol}//${sandbox_id}-${port}.${base.host}/`
         return textResult(JSON.stringify({ sandbox_id, port, url }))
       } catch (e: any) {
-        return textResult(`Error getting preview URL: ${e.message}`)
+        return errorResult(`Error getting preview URL: ${e.message}`)
       }
     },
   )
@@ -244,7 +539,7 @@ Use this after starting a dev server (e.g. on port 3000, 5173, 8080). The URL is
         await sandbox.deleteSandbox(token, sandbox_id)
         return textResult(`Sandbox ${sandbox_id} killed`)
       } catch (e: any) {
-        return textResult(`Error killing sandbox: ${e.message}`)
+        return errorResult(`Error killing sandbox: ${e.message}`)
       }
     },
   )

--- a/control-plane/src/mcp/tools/shared.ts
+++ b/control-plane/src/mcp/tools/shared.ts
@@ -3,6 +3,20 @@ export function textResult(text: string) {
 }
 
 /**
+ * Failure result. Sets `isError` so the caller can tell a failure from a
+ * successful call that merely returned text starting with "Error" — without it
+ * the model has to string-match to know whether the tool worked.
+ */
+export function errorResult(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], isError: true as const }
+}
+
+/** Success result carrying a JSON payload. */
+export function jsonResult(value: unknown) {
+  return textResult(JSON.stringify(value))
+}
+
+/**
  * Poll `fn` until it returns a truthy value or the timeout expires.
  * Returns the first truthy result, or `null` on timeout.
  */

--- a/control-plane/src/services/sandbox.ts
+++ b/control-plane/src/services/sandbox.ts
@@ -43,6 +43,15 @@ interface CommandResult {
   stderr: string
   exit_code: number | null
   execution_time_ms?: number
+  command_id?: string
+  background?: boolean
+}
+
+interface FileEntry {
+  path: string
+  type?: string
+  size?: number
+  modifiedAt?: string
 }
 
 // ---- Lifecycle ----
@@ -53,6 +62,7 @@ export async function createSandbox(
     image: string
     timeoutSeconds?: number
     resource?: Record<string, string>
+    resourceRequests?: Record<string, string>
     entrypoint?: string[]
     env?: Record<string, string>
     metadata?: Record<string, string>
@@ -62,9 +72,20 @@ export async function createSandbox(
     image: opts.image,
     timeoutSeconds: opts.timeoutSeconds ?? 3600,
     resource: opts.resource ?? { cpu: '500m', memory: '512Mi' },
+    resourceRequests: opts.resourceRequests,
     entrypoint: opts.entrypoint,
     env: opts.env,
     metadata: opts.metadata,
+  })
+}
+
+export async function renewSandbox(
+  token: string,
+  sandboxId: string,
+  timeoutSeconds: number,
+): Promise<{ expiresAt: string }> {
+  return request<{ expiresAt: string }>(token, 'POST', `/api/sandboxes/${sandboxId}/renew`, {
+    timeoutSeconds,
   })
 }
 
@@ -96,6 +117,7 @@ export async function runCommand(
     cwd?: string
     timeoutSeconds?: number
     env?: Record<string, string>
+    background?: boolean
   },
 ): Promise<CommandResult> {
   const result = await request<{
@@ -103,18 +125,57 @@ export async function runCommand(
     stderr: string
     exitCode: number | null
     executionTimeMs?: number
+    commandId?: string
+    background?: boolean
   }>(token, 'POST', `/api/sandboxes/${sandboxId}/exec`, {
     command,
     cwd: opts?.cwd,
     timeoutSeconds: opts?.timeoutSeconds,
     env: opts?.env,
+    background: opts?.background,
   })
   return {
     stdout: result.stdout,
     stderr: result.stderr,
     exit_code: result.exitCode,
     execution_time_ms: result.executionTimeMs,
+    command_id: result.commandId,
+    background: result.background,
   }
+}
+
+export async function getCommandStatus(
+  token: string,
+  sandboxId: string,
+  commandId: string,
+): Promise<Record<string, unknown>> {
+  return request<Record<string, unknown>>(
+    token,
+    'GET',
+    `/api/sandboxes/${sandboxId}/commands/${commandId}`,
+  )
+}
+
+export async function getCommandLogs(
+  token: string,
+  sandboxId: string,
+  commandId: string,
+  cursor?: number,
+): Promise<{ content?: string; cursor?: number }> {
+  const qs = cursor != null ? `?cursor=${cursor}` : ''
+  return request<{ content?: string; cursor?: number }>(
+    token,
+    'GET',
+    `/api/sandboxes/${sandboxId}/commands/${commandId}/logs${qs}`,
+  )
+}
+
+export async function interruptCommand(
+  token: string,
+  sandboxId: string,
+  commandId: string,
+): Promise<void> {
+  await request<void>(token, 'POST', `/api/sandboxes/${sandboxId}/commands/${commandId}/interrupt`)
 }
 
 // ---- Endpoint ----
@@ -130,11 +191,19 @@ export async function getEndpoint(token: string, sandboxId: string, port: number
 
 // ---- File operations ----
 
-export async function readFile(token: string, sandboxId: string, path: string): Promise<string> {
+export async function readFile(
+  token: string,
+  sandboxId: string,
+  path: string,
+  opts?: { offset?: number; limit?: number },
+): Promise<string> {
+  const params = new URLSearchParams({ path })
+  if (opts?.offset != null) params.set('offset', String(opts.offset))
+  if (opts?.limit != null) params.set('limit', String(opts.limit))
   const result = await request<{ content: string }>(
     token,
     'GET',
-    `/api/sandboxes/${sandboxId}/files?path=${encodeURIComponent(path)}`,
+    `/api/sandboxes/${sandboxId}/files?${params.toString()}`,
   )
   return result.content
 }
@@ -147,4 +216,84 @@ export async function writeFiles(
   await request<void>(token, 'POST', `/api/sandboxes/${sandboxId}/files`, {
     files: files.map((f) => ({ path: f.path, content: f.data })),
   })
+}
+
+/** Glob search, flat result. See listDirectory for a real directory listing. */
+export async function searchFiles(
+  token: string,
+  sandboxId: string,
+  path: string,
+  pattern?: string,
+): Promise<FileEntry[]> {
+  const params = new URLSearchParams({ path })
+  if (pattern) params.set('pattern', pattern)
+  const result = await request<{ files: FileEntry[] }>(
+    token,
+    'GET',
+    `/api/sandboxes/${sandboxId}/files/list?${params.toString()}`,
+  )
+  return result.files
+}
+
+/** Directory listing; each entry carries a `type` (file / directory / symlink). */
+export async function listDirectory(
+  token: string,
+  sandboxId: string,
+  path: string,
+  depth?: number,
+): Promise<FileEntry[]> {
+  const params = new URLSearchParams({ path })
+  if (depth != null) params.set('depth', String(depth))
+  const result = await request<{ files: FileEntry[] }>(
+    token,
+    'GET',
+    `/api/sandboxes/${sandboxId}/files/dir?${params.toString()}`,
+  )
+  return result.files
+}
+
+export async function deleteFiles(
+  token: string,
+  sandboxId: string,
+  paths: string[],
+): Promise<void> {
+  await request<void>(token, 'DELETE', `/api/sandboxes/${sandboxId}/files`, { paths })
+}
+
+export async function moveFiles(
+  token: string,
+  sandboxId: string,
+  entries: Array<{ src: string; dest: string }>,
+): Promise<void> {
+  await request<void>(token, 'POST', `/api/sandboxes/${sandboxId}/files/move`, { entries })
+}
+
+export async function createDirectories(
+  token: string,
+  sandboxId: string,
+  entries: Array<{ path: string; mode?: number }>,
+): Promise<void> {
+  await request<void>(token, 'POST', `/api/sandboxes/${sandboxId}/directories`, { entries })
+}
+
+export async function deleteDirectories(
+  token: string,
+  sandboxId: string,
+  paths: string[],
+): Promise<void> {
+  await request<void>(token, 'DELETE', `/api/sandboxes/${sandboxId}/directories`, { paths })
+}
+
+export async function replaceContents(
+  token: string,
+  sandboxId: string,
+  entries: Array<{ path: string; oldContent: string; newContent: string }>,
+): Promise<{
+  results: Array<{ path: string; replacedCount: number }>
+  detailAvailable: boolean
+}> {
+  return request<{
+    results: Array<{ path: string; replacedCount: number }>
+    detailAvailable: boolean
+  }>(token, 'POST', `/api/sandboxes/${sandboxId}/files/replace`, { entries })
 }

--- a/sandbox-service/package-lock.json
+++ b/sandbox-service/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "tos-sandbox-service",
+  "name": "@neutree-ai/sandbox-service",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tos-sandbox-service",
+      "name": "@neutree-ai/sandbox-service",
       "version": "0.1.0",
       "dependencies": {
-        "@alibaba-group/opensandbox": "^0.1.5",
+        "@alibaba-group/opensandbox": "^0.1.11",
         "@hono/node-server": "^1.19.14",
         "@hono/zod-openapi": "^1.2.4",
         "@scalar/hono-api-reference": "^0.10.7",
@@ -28,13 +28,13 @@
       }
     },
     "node_modules/@alibaba-group/opensandbox": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@alibaba-group/opensandbox/-/opensandbox-0.1.6.tgz",
-      "integrity": "sha512-mZ2Q2qXNC0dgctoPIlcotnlPSJ1ODMG4DKQ3AA2lTO4ZoC/vWU3CzSL5pNEU7hakfMOotQiZVxunNItVGY4W8w==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@alibaba-group/opensandbox/-/opensandbox-0.1.11.tgz",
+      "integrity": "sha512-xDJzs+5yYAPrje+z3GKUmXezpVq3kO/NyP8BM9JwzCbfuSr5vQyHJI3/Pu4FBGdb/xQnxMcWFlsKqC4/80OeiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.14.1",
-        "undici": "^7.18.2"
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=20"
@@ -1564,9 +1564,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/sandbox-service/package.json
+++ b/sandbox-service/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
-    "@alibaba-group/opensandbox": "^0.1.5",
+    "@alibaba-group/opensandbox": "^0.1.11",
     "@hono/node-server": "^1.19.14",
     "@hono/zod-openapi": "^1.2.4",
     "@scalar/hono-api-reference": "^0.10.7",

--- a/sandbox-service/src/lib/sandbox.ts
+++ b/sandbox-service/src/lib/sandbox.ts
@@ -42,6 +42,11 @@ export async function createSandbox(opts: {
   image: string
   timeoutSeconds?: number
   resource?: Record<string, string>
+  // Kubernetes resource *requests*, set independently of `resource` (which maps
+  // to limits). Omitting this keeps the server's default of requests == limits.
+  // Lowering requests puts the pod in Burstable QoS so idle sandboxes stop
+  // reserving their full limit against node capacity. Requires server >= v0.2.1.
+  resourceRequests?: Record<string, string>
   entrypoint?: string[]
   env?: Record<string, string>
   metadata?: Record<string, string>
@@ -51,6 +56,7 @@ export async function createSandbox(opts: {
     image: opts.image,
     timeoutSeconds: opts.timeoutSeconds ?? 3600,
     resource: opts.resource ?? { cpu: '500m', memory: '512Mi' },
+    resourceRequests: opts.resourceRequests,
     entrypoint: opts.entrypoint,
     env: opts.env,
     metadata: opts.metadata,
@@ -102,6 +108,10 @@ interface CommandResult {
   stderr: string
   exitCode: number | null
   executionTimeMs?: number
+  // Present when the command was started with `background: true`. Feed it to
+  // getCommandStatus / getBackgroundCommandLogs to follow the run.
+  commandId?: string
+  background?: boolean
 }
 
 export async function runCommand(
@@ -111,6 +121,10 @@ export async function runCommand(
     cwd?: string
     timeoutSeconds?: number
     env?: Record<string, string>
+    // Detach instead of blocking until exit. stdout/stderr come back empty —
+    // the command is still starting — so callers poll with the returned
+    // commandId. Replaces the `nohup cmd &` workaround.
+    background?: boolean
   },
 ): Promise<CommandResult> {
   const sbx = await connectSandbox(sandboxId)
@@ -119,13 +133,65 @@ export async function runCommand(
       workingDirectory: opts?.cwd,
       timeoutSeconds: opts?.timeoutSeconds,
       envs: opts?.env,
+      background: opts?.background,
     })
     return {
       stdout: execution.logs.stdout.map((m) => m.text).join('\n'),
       stderr: execution.logs.stderr.map((m) => m.text).join('\n'),
       exitCode: execution.exitCode ?? null,
       executionTimeMs: execution.complete?.executionTimeMs,
+      commandId: execution.id,
+      background: opts?.background || undefined,
     }
+  } finally {
+    await sbx.close()
+  }
+}
+
+export async function getCommandStatus(
+  sandboxId: string,
+  commandId: string,
+): Promise<Record<string, unknown>> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    return (await sbx.commands.getCommandStatus(commandId)) as unknown as Record<string, unknown>
+  } finally {
+    await sbx.close()
+  }
+}
+
+/**
+ * Fetch a chunk of a background command's output. `cursor` is the byte offset
+ * returned by the previous call — pass it back to continue where you left off
+ * instead of re-reading the whole log.
+ */
+export async function getBackgroundCommandLogs(
+  sandboxId: string,
+  commandId: string,
+  cursor?: number,
+): Promise<Record<string, unknown>> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    return (await sbx.commands.getBackgroundCommandLogs(commandId, cursor)) as unknown as Record<
+      string,
+      unknown
+    >
+  } finally {
+    await sbx.close()
+  }
+}
+
+/**
+ * Terminate a running command.
+ *
+ * The SDK types name the argument `sessionId`, but execd accepts a background
+ * command id here too — verified against opensandbox-server v0.2.2, where the
+ * command lands on `running: false, exitCode: -1, error: "signal: terminate…"`.
+ */
+export async function interruptCommand(sandboxId: string, commandId: string): Promise<void> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    await sbx.commands.interrupt(commandId)
   } finally {
     await sbx.close()
   }
@@ -161,15 +227,60 @@ export async function getEndpointDirect(sandboxId: string, port: number): Promis
 
 // ---- File operations ----
 
-export async function readFile(sandboxId: string, path: string): Promise<string> {
+/** Take lines [offset, offset+limit) from `text`; offset is 1-based. */
+function sliceLines(text: string, offset?: number, limit?: number): string {
+  const lines = text.split('\n')
+  // A trailing newline yields a final empty element that is not a line.
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  const start = Math.max(0, (offset ?? 1) - 1)
+  const end = limit != null ? start + limit : lines.length
+  return lines.slice(start, end).join('\n')
+}
+
+/**
+ * Read a text file. `offset`/`limit` select a line range (offset is 1-based) so
+ * callers can page through a large file instead of pulling all of it — a full
+ * read is easy to truncate downstream once it crosses a tool-output limit.
+ *
+ * Line ranges are an execd-side feature. Older execd (v1.0.16, what production
+ * currently runs) ignores the parameters and returns the whole file with no
+ * error, which would hand the caller far more than it asked for while looking
+ * like a successful paged read.
+ *
+ * So the range is always applied here, and the request to execd asks for the
+ * leading `offset + limit - 1` lines rather than the range itself. That prefix
+ * is the same shape whether execd honours it or returns everything, so slicing
+ * it locally lands on the right lines either way and needs no version check.
+ * The cost is pulling the lines before `offset` on a capable execd; bounded,
+ * and only noticeable when paging deep into a file.
+ */
+export async function readFile(
+  sandboxId: string,
+  path: string,
+  opts?: { offset?: number; limit?: number },
+): Promise<string> {
+  const ranged = opts?.offset !== undefined || opts?.limit !== undefined
   const sbx = await connectSandbox(sandboxId)
   try {
-    return await sbx.files.readFile(path)
+    if (!ranged) return await sbx.files.readFile(path)
+    const offset = opts?.offset ?? 1
+    const prefixLimit = opts?.limit != null ? offset + opts.limit - 1 : undefined
+    const content = await sbx.files.readFile(
+      path,
+      prefixLimit != null ? { offset: 1, limit: prefixLimit } : undefined,
+    )
+    return sliceLines(content, offset, opts?.limit)
   } finally {
     await sbx.close()
   }
 }
 
+/**
+ * Search for files by glob pattern. Returns a flat list.
+ *
+ * Kept separate from listDirectory: browser-service uses this to find a
+ * downloaded file by name under /downloads, which is a search, not a listing.
+ */
 export async function listFiles(
   sandboxId: string,
   path: string,
@@ -178,6 +289,102 @@ export async function listFiles(
   const sbx = await connectSandbox(sandboxId)
   try {
     return await sbx.files.search({ path, pattern })
+  } finally {
+    await sbx.close()
+  }
+}
+
+/**
+ * List a directory's entries, each carrying a `type` (file/directory/symlink).
+ * `depth` defaults to 1 (immediate children); symlinks are reported as
+ * symlinks and are not followed.
+ *
+ * Note: `type` is populated by the server, not the SDK — against an older
+ * opensandbox-server the field comes back empty.
+ */
+export async function listDirectory(
+  sandboxId: string,
+  path: string,
+  depth?: number,
+): Promise<FileInfo[]> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    return await sbx.files.listDirectory({ path, depth })
+  } catch (e: any) {
+    // execd v1.0.16 has no directory endpoint and fails with a bare
+    // "List directory failed". Say why, so this doesn't read as a bad path.
+    throw new Error(
+      `${e?.message ?? e} (directory listing needs execd >= v1.0.20; use the glob search endpoint on older sandboxes)`,
+    )
+  } finally {
+    await sbx.close()
+  }
+}
+
+export async function deleteFiles(sandboxId: string, paths: string[]): Promise<void> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    await sbx.files.deleteFiles(paths)
+  } finally {
+    await sbx.close()
+  }
+}
+
+export async function moveFiles(
+  sandboxId: string,
+  entries: Array<{ src: string; dest: string }>,
+): Promise<void> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    await sbx.files.moveFiles(entries)
+  } finally {
+    await sbx.close()
+  }
+}
+
+export async function createDirectories(
+  sandboxId: string,
+  entries: Array<{ path: string; mode?: number }>,
+): Promise<void> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    await sbx.files.createDirectories(entries)
+  } finally {
+    await sbx.close()
+  }
+}
+
+export async function deleteDirectories(sandboxId: string, paths: string[]): Promise<void> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    await sbx.files.deleteDirectories(paths)
+  } finally {
+    await sbx.close()
+  }
+}
+
+/**
+ * Replace text in files. Returns a per-file `replacedCount` so callers can tell
+ * "no match" (0) from "changed" — a plain replace call can't.
+ *
+ * The counts come from execd and older builds (v1.0.16) return an empty list
+ * while still performing the replacement. `detailAvailable: false` marks that
+ * case, so an empty `results` is not mistaken for "nothing was replaced".
+ */
+export async function replaceContents(
+  sandboxId: string,
+  entries: Array<{ path: string; oldContent: string; newContent: string }>,
+): Promise<{
+  results: Array<{ path: string; replacedCount: number }>
+  detailAvailable: boolean
+}> {
+  const sbx = await connectSandbox(sandboxId)
+  try {
+    const results = await sbx.files.replaceContentsDetailed(entries)
+    return {
+      results,
+      detailAvailable: !(entries.length > 0 && results.length === 0),
+    }
   } finally {
     await sbx.close()
   }

--- a/sandbox-service/src/lib/sandbox.ts
+++ b/sandbox-service/src/lib/sandbox.ts
@@ -36,6 +36,61 @@ async function connectSandbox(sandboxId: string): Promise<Sandbox> {
   })
 }
 
+// ---- Resource requests ----
+
+// Requests default to the limits, so an idle sandbox holds its full limit
+// against node capacity for as long as it lives. Measured over 7 days across
+// the running sandboxes, memory peaks at 7% of the limit at the median and 30%
+// at p95, while the sandbox nodes were sitting at 45-92% reserved.
+//
+// Memory only, for now. CPU requests also set the CFS weight, so cutting them
+// makes a busy sandbox lose ground under contention, and the CPU tail is real
+// (p95 peaks at 99% of its limit) — that one wants its own rollout.
+const MEMORY_REQUEST_RATIO = 0.4
+const MEMORY_REQUEST_FLOOR_MIB = 256
+
+const MEMORY_UNITS: Record<string, number> = {
+  Ki: 1 / 1024,
+  Mi: 1,
+  Gi: 1024,
+  Ti: 1024 * 1024,
+  K: 1000 / 1024 / 1024,
+  M: (1000 * 1000) / 1024 / 1024,
+  G: (1000 * 1000 * 1000) / 1024 / 1024,
+}
+
+/** Parse a Kubernetes memory quantity into MiB; null if it isn't one. */
+function parseMemoryMiB(value: string): number | null {
+  const m = /^(\d+(?:\.\d+)?)([KMGT]i?)?$/.exec(value.trim())
+  if (!m) return null
+  const amount = Number.parseFloat(m[1])
+  if (!Number.isFinite(amount)) return null
+  const unit = m[2]
+  if (!unit) return amount / 1024 / 1024 // plain bytes
+  const factor = MEMORY_UNITS[unit]
+  return factor === undefined ? null : amount * factor
+}
+
+/**
+ * Derive the resource requests for a sandbox whose caller did not specify any.
+ * Returns undefined when there is nothing to derive, which leaves the runtime
+ * on its own default of requests == limits.
+ */
+function deriveResourceRequests(
+  resource: Record<string, string>,
+): Record<string, string> | undefined {
+  const limit = resource.memory
+  if (!limit) return undefined
+  const limitMiB = parseMemoryMiB(limit)
+  if (limitMiB === null) return undefined
+  const requestMiB = Math.min(
+    limitMiB,
+    Math.max(MEMORY_REQUEST_FLOOR_MIB, Math.round(limitMiB * MEMORY_REQUEST_RATIO)),
+  )
+  // Omitting cpu leaves the CPU request defaulting to the CPU limit.
+  return { memory: `${Math.round(requestMiB)}Mi` }
+}
+
 // ---- Lifecycle ----
 
 export async function createSandbox(opts: {
@@ -43,20 +98,23 @@ export async function createSandbox(opts: {
   timeoutSeconds?: number
   resource?: Record<string, string>
   // Kubernetes resource *requests*, set independently of `resource` (which maps
-  // to limits). Omitting this keeps the server's default of requests == limits.
-  // Lowering requests puts the pod in Burstable QoS so idle sandboxes stop
-  // reserving their full limit against node capacity. Requires server >= v0.2.1.
+  // to limits). Left unset, a memory request is derived from the memory limit —
+  // see deriveResourceRequests. Pass a value to override that, including the
+  // limits themselves to opt back into Guaranteed QoS.
+  // Honoured by opensandbox-server >= v0.2.1; older servers ignore it and leave
+  // requests equal to limits.
   resourceRequests?: Record<string, string>
   entrypoint?: string[]
   env?: Record<string, string>
   metadata?: Record<string, string>
 }): Promise<SandboxInfo> {
+  const resource = opts.resource ?? { cpu: '500m', memory: '512Mi' }
   const sbx = await Sandbox.create({
     connectionConfig: getConnectionConfig(),
     image: opts.image,
     timeoutSeconds: opts.timeoutSeconds ?? 3600,
-    resource: opts.resource ?? { cpu: '500m', memory: '512Mi' },
-    resourceRequests: opts.resourceRequests,
+    resource,
+    resourceRequests: opts.resourceRequests ?? deriveResourceRequests(resource),
     entrypoint: opts.entrypoint,
     env: opts.env,
     metadata: opts.metadata,

--- a/sandbox-service/src/routes/sandboxes.ts
+++ b/sandbox-service/src/routes/sandboxes.ts
@@ -3,7 +3,11 @@ import type { AuthUser } from '../lib/auth'
 import * as launches from '../lib/launches'
 import * as sandbox from '../lib/sandbox'
 import {
+  CommandLogsResponseSchema,
+  CommandStatusResponseSchema,
+  CreateDirectoriesBodySchema,
   CreateSandboxBodySchema,
+  DeletePathsBodySchema,
   DeleteSandboxResponseSchema,
   EndpointResponseSchema,
   ErrorSchema,
@@ -12,9 +16,13 @@ import {
   ListFilesResponseSchema,
   ListLaunchesResponseSchema,
   ListSandboxesResponseSchema,
+  MoveFilesBodySchema,
+  MutationSuccessResponseSchema,
   ReadFileResponseSchema,
   RenewSandboxBodySchema,
   RenewSandboxResponseSchema,
+  ReplaceContentsBodySchema,
+  ReplaceContentsResponseSchema,
   SandboxInfoSchema,
   WriteFilesBodySchema,
   WriteFilesResponseSchema,
@@ -157,6 +165,7 @@ sandboxes.openapi(
       const info = await sandbox.createSandbox({
         image: body.image,
         resource,
+        resourceRequests: body.resourceRequests as Record<string, string> | undefined,
         timeoutSeconds: body.timeoutSeconds,
         entrypoint: body.entrypoint,
         env: body.env,
@@ -418,8 +427,122 @@ sandboxes.openapi(
         cwd: body.cwd,
         timeoutSeconds: body.timeoutSeconds,
         env: body.env,
+        background: body.background,
       })
       return c.json(result, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+const IdCommandParam = z.object({
+  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+  commandId: z.string().openapi({ param: { name: 'commandId', in: 'path' } }),
+})
+
+// Background command status
+sandboxes.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{id}/commands/{commandId}',
+    tags: tag,
+    security,
+    summary: 'Get the status of a command started with background: true',
+    request: { params: IdCommandParam },
+    responses: {
+      200: {
+        description: 'Command status',
+        content: { 'application/json': { schema: CommandStatusResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const status = await sandbox.getCommandStatus(c.req.param('id'), c.req.param('commandId'))
+      return c.json(status, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Interrupt a running command
+sandboxes.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{id}/commands/{commandId}/interrupt',
+    tags: tag,
+    security,
+    summary: 'Terminate a running command',
+    responses: {
+      200: {
+        description: 'Interrupted',
+        content: { 'application/json': { schema: DeleteSandboxResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+    request: { params: IdCommandParam },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      await sandbox.interruptCommand(c.req.param('id'), c.req.param('commandId'))
+      return c.json({ success: true as const }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Background command logs
+sandboxes.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{id}/commands/{commandId}/logs',
+    tags: tag,
+    security,
+    summary: 'Fetch a chunk of a background command output',
+    request: {
+      params: IdCommandParam,
+      query: z.object({
+        cursor: z.coerce
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .openapi({
+            param: { name: 'cursor', in: 'query' },
+            description: 'Offset returned by the previous call; resumes from there.',
+          }),
+      }),
+    },
+    responses: {
+      200: {
+        description: 'Log chunk',
+        content: { 'application/json': { schema: CommandLogsResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const { cursor } = c.req.valid('query')
+      const logs = await sandbox.getBackgroundCommandLogs(
+        c.req.param('id'),
+        c.req.param('commandId'),
+        cursor,
+      )
+      return c.json(logs, 200)
     } catch (e: any) {
       return c.json({ error: e.message }, 500)
     }
@@ -564,10 +687,30 @@ sandboxes.openapi(
     tags: tag,
     security,
     summary: 'Read a file from the sandbox',
+    description:
+      'Returns the whole file by default. Pass offset/limit to read a line range instead — useful for large files that would otherwise be truncated by a downstream output limit.',
     request: {
       params: IdParam,
       query: z.object({
         path: z.string().openapi({ param: { name: 'path', in: 'query' }, example: '/tmp/foo.txt' }),
+        offset: z.coerce
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .openapi({
+            param: { name: 'offset', in: 'query' },
+            description: 'Starting line number, 1-based.',
+          }),
+        limit: z.coerce
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .openapi({
+            param: { name: 'limit', in: 'query' },
+            description: 'Number of lines to read.',
+          }),
       }),
     },
     responses: {
@@ -584,8 +727,8 @@ sandboxes.openapi(
     try {
       const info = await withOwnership(c, c.req.param('id'))
       if (!info) return c.json({ error: 'Sandbox not found' }, 404)
-      const { path } = c.req.valid('query')
-      const content = await sandbox.readFile(c.req.param('id'), path)
+      const { path, offset, limit } = c.req.valid('query')
+      const content = await sandbox.readFile(c.req.param('id'), path, { offset, limit })
       return c.json({ content }, 200)
     } catch (e: any) {
       return c.json({ error: e.message }, 500)
@@ -624,6 +767,231 @@ sandboxes.openapi(
         body.files.map((f) => ({ path: f.path, data: f.content })),
       )
       return c.json({ success: true as const, count: body.files.length }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Directory listing.
+// Distinct from /files/list, which is a glob *search* returning a flat list —
+// this walks the directory and reports an entry type for each item.
+sandboxes.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{id}/files/dir',
+    tags: tag,
+    security,
+    summary: 'List a directory, with entry types',
+    description:
+      'Each entry carries a `type` (file / directory / symlink). Symlinks are reported as symlinks and are not followed. Note: `type` is filled in by opensandbox-server — against an older server the field comes back empty.',
+    request: {
+      params: IdParam,
+      query: z.object({
+        path: z.string().openapi({ param: { name: 'path', in: 'query' }, example: '/workspace' }),
+        depth: z.coerce
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .openapi({
+            param: { name: 'depth', in: 'query' },
+            description: 'Traversal depth; defaults to 1 (immediate children).',
+          }),
+      }),
+    },
+    responses: {
+      200: {
+        description: 'OK',
+        content: { 'application/json': { schema: ListFilesResponseSchema } },
+      },
+      400: errorResponses[400],
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const { path, depth } = c.req.valid('query')
+      const files = await sandbox.listDirectory(c.req.param('id'), path, depth)
+      return c.json({ files: files as any[] }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Delete files
+sandboxes.openapi(
+  createRoute({
+    method: 'delete',
+    path: '/{id}/files',
+    tags: tag,
+    security,
+    summary: 'Delete one or more files from the sandbox',
+    request: {
+      params: IdParam,
+      body: { content: { 'application/json': { schema: DeletePathsBodySchema } } },
+    },
+    responses: {
+      200: {
+        description: 'Deleted',
+        content: { 'application/json': { schema: MutationSuccessResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const body = c.req.valid('json')
+      await sandbox.deleteFiles(c.req.param('id'), body.paths)
+      return c.json({ success: true as const, count: body.paths.length }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Move / rename files
+sandboxes.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{id}/files/move',
+    tags: tag,
+    security,
+    summary: 'Move or rename files inside the sandbox',
+    request: {
+      params: IdParam,
+      body: { content: { 'application/json': { schema: MoveFilesBodySchema } } },
+    },
+    responses: {
+      200: {
+        description: 'Moved',
+        content: { 'application/json': { schema: MutationSuccessResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const body = c.req.valid('json')
+      await sandbox.moveFiles(c.req.param('id'), body.entries)
+      return c.json({ success: true as const, count: body.entries.length }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Create directories
+sandboxes.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{id}/directories',
+    tags: tag,
+    security,
+    summary: 'Create directories inside the sandbox',
+    request: {
+      params: IdParam,
+      body: { content: { 'application/json': { schema: CreateDirectoriesBodySchema } } },
+    },
+    responses: {
+      200: {
+        description: 'Created',
+        content: { 'application/json': { schema: MutationSuccessResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const body = c.req.valid('json')
+      await sandbox.createDirectories(c.req.param('id'), body.entries)
+      return c.json({ success: true as const, count: body.entries.length }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Delete directories
+sandboxes.openapi(
+  createRoute({
+    method: 'delete',
+    path: '/{id}/directories',
+    tags: tag,
+    security,
+    summary: 'Delete directories from the sandbox',
+    request: {
+      params: IdParam,
+      body: { content: { 'application/json': { schema: DeletePathsBodySchema } } },
+    },
+    responses: {
+      200: {
+        description: 'Deleted',
+        content: { 'application/json': { schema: MutationSuccessResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const body = c.req.valid('json')
+      await sandbox.deleteDirectories(c.req.param('id'), body.paths)
+      return c.json({ success: true as const, count: body.paths.length }, 200)
+    } catch (e: any) {
+      return c.json({ error: e.message }, 500)
+    }
+  },
+)
+
+// Replace file contents
+sandboxes.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{id}/files/replace',
+    tags: tag,
+    security,
+    summary: 'Replace text inside files',
+    description:
+      'Returns a per-file replacedCount so callers can tell "no match" (0) from "changed".',
+    request: {
+      params: IdParam,
+      body: { content: { 'application/json': { schema: ReplaceContentsBodySchema } } },
+    },
+    responses: {
+      200: {
+        description: 'Replacement results',
+        content: { 'application/json': { schema: ReplaceContentsResponseSchema } },
+      },
+      404: errorResponses[404],
+      500: errorResponses[500],
+    },
+  }),
+  async (c) => {
+    try {
+      const info = await withOwnership(c, c.req.param('id'))
+      if (!info) return c.json({ error: 'Sandbox not found' }, 404)
+      const body = c.req.valid('json')
+      const { results, detailAvailable } = await sandbox.replaceContents(
+        c.req.param('id'),
+        body.entries,
+      )
+      return c.json({ results, detailAvailable }, 200)
     } catch (e: any) {
       return c.json({ error: e.message }, 500)
     }

--- a/sandbox-service/src/schemas.ts
+++ b/sandbox-service/src/schemas.ts
@@ -31,7 +31,7 @@ export const CreateSandboxBodySchema = z
       .optional()
       .openapi({
         description:
-          'Kubernetes resource requests, set independently of `resource` (limits). Omit to keep requests == limits. Lowering requests puts the sandbox in Burstable QoS so it stops reserving its full limit against node capacity.',
+          'Kubernetes resource requests, set independently of `resource` (limits). Omit and a memory request is derived from the memory limit, so an idle sandbox stops reserving its full limit against node capacity; the CPU request stays at the CPU limit. Pass the limits here to opt back into requests == limits.',
       }),
     timeoutSeconds: z.number().int().positive().optional(),
     entrypoint: z.array(z.string()).optional(),

--- a/sandbox-service/src/schemas.ts
+++ b/sandbox-service/src/schemas.ts
@@ -26,6 +26,13 @@ export const CreateSandboxBodySchema = z
   .object({
     image: z.string().openapi({ example: 'ubuntu:22.04' }),
     resource: z.object({ cpu: z.string().optional(), memory: z.string().optional() }).optional(),
+    resourceRequests: z
+      .object({ cpu: z.string().optional(), memory: z.string().optional() })
+      .optional()
+      .openapi({
+        description:
+          'Kubernetes resource requests, set independently of `resource` (limits). Omit to keep requests == limits. Lowering requests puts the sandbox in Burstable QoS so it stops reserving its full limit against node capacity.',
+      }),
     timeoutSeconds: z.number().int().positive().optional(),
     entrypoint: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
@@ -55,6 +62,10 @@ export const ExecBodySchema = z
     cwd: z.string().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     env: z.record(z.string(), z.string()).optional(),
+    background: z.boolean().optional().openapi({
+      description:
+        'Detach instead of blocking until the command exits. stdout/stderr come back empty; poll the returned commandId via /commands/{commandId} and /commands/{commandId}/logs.',
+    }),
   })
   .openapi('ExecBody')
 
@@ -64,8 +75,20 @@ export const ExecResponseSchema = z
     stderr: z.string(),
     exitCode: z.number().int().nullable(),
     executionTimeMs: z.number().optional(),
+    commandId: z.string().optional(),
+    background: z.boolean().optional(),
   })
   .openapi('ExecResponse')
+
+export const CommandStatusResponseSchema = z
+  .object({})
+  .loose()
+  .openapi('CommandStatusResponse', { description: 'Command status (execd-defined shape)' })
+
+export const CommandLogsResponseSchema = z.object({}).loose().openapi('CommandLogsResponse', {
+  description:
+    'Background command log chunk (execd-defined shape). Carries a tail cursor to resume from.',
+})
 
 export const ReadFileResponseSchema = z
   .object({
@@ -109,6 +132,67 @@ export const WriteFilesResponseSchema = z
     count: z.number().int(),
   })
   .openapi('WriteFilesResponse')
+
+export const DeletePathsBodySchema = z
+  .object({
+    paths: z
+      .array(z.string())
+      .min(1)
+      .openapi({ example: ['/tmp/foo.txt'] }),
+  })
+  .openapi('DeletePathsBody')
+
+export const MoveFilesBodySchema = z
+  .object({
+    entries: z
+      .array(z.object({ src: z.string(), dest: z.string() }))
+      .min(1)
+      .openapi({ example: [{ src: '/tmp/a.txt', dest: '/tmp/b.txt' }] }),
+  })
+  .openapi('MoveFilesBody')
+
+export const CreateDirectoriesBodySchema = z
+  .object({
+    entries: z
+      .array(
+        z.object({
+          path: z.string(),
+          mode: z
+            .number()
+            .int()
+            .optional()
+            .openapi({ description: 'Unix permissions, e.g. 493 (0o755)' }),
+        }),
+      )
+      .min(1)
+      .openapi({ example: [{ path: '/tmp/newdir' }] }),
+  })
+  .openapi('CreateDirectoriesBody')
+
+export const ReplaceContentsBodySchema = z
+  .object({
+    entries: z
+      .array(z.object({ path: z.string(), oldContent: z.string(), newContent: z.string() }))
+      .min(1),
+  })
+  .openapi('ReplaceContentsBody')
+
+export const ReplaceContentsResponseSchema = z
+  .object({
+    results: z.array(z.object({ path: z.string(), replacedCount: z.number().int() })),
+    detailAvailable: z.boolean().openapi({
+      description:
+        'False when the sandbox runtime is too old to report per-file counts. The replacement still happened — an empty `results` in that case does not mean nothing matched.',
+    }),
+  })
+  .openapi('ReplaceContentsResponse')
+
+export const MutationSuccessResponseSchema = z
+  .object({
+    success: z.literal(true),
+    count: z.number().int(),
+  })
+  .openapi('MutationSuccessResponse')
 
 export const DeleteSandboxResponseSchema = z
   .object({


### PR DESCRIPTION
## What

Bumps the opensandbox SDK to 0.1.11 and surfaces the capabilities it unlocks through sandbox-service and the control-plane MCP tools.

Agents could create a sandbox, run a blocking command, and read or write a file. Everything else — deleting, renaming, searching, listing a directory — had to be shelled out through `sandbox_run_command`, and a long-running process had to be hand-rolled as `nohup cmd &`.

### sandbox-service

New endpoints:

| | |
|---|---|
| `GET /{id}/files/dir` | directory listing, each entry with a type |
| `DELETE /{id}/files` | delete files |
| `POST /{id}/files/move` | move / rename |
| `POST /{id}/files/replace` | in-place replace, with a per-file count |
| `POST` \| `DELETE /{id}/directories` | create / delete directories |
| `GET /{id}/commands/{commandId}` | background command status |
| `GET /{id}/commands/{commandId}/logs` | output chunk, resumable by cursor |
| `POST /{id}/commands/{commandId}/interrupt` | terminate a command |

Extended: `GET /{id}/files` takes `offset`/`limit` for a line range, `POST /{id}/exec` takes `background`, `POST /` takes `resourceRequests`.

`GET /{id}/files/list` keeps its glob-search behaviour — browser-service uses it to locate a downloaded file by name, which is a search rather than a listing.

### MCP tools

7 tools become 18. New: `sandbox_renew`, `sandbox_list_directory`, `sandbox_search_files`, `sandbox_delete_files`, `sandbox_move_files`, `sandbox_create_directories`, `sandbox_delete_directories`, `sandbox_replace_contents`, `sandbox_get_command_status`, `sandbox_get_command_logs`, `sandbox_interrupt_command`.

Failures now return `isError` rather than text starting with `"Error"`, which the model previously had to string-match to tell a failure from a successful call that happened to return that text. Scoped to the sandbox tools; the other tool files have the same problem and are left for a separate change.

`sandbox_get_preview_url` and the per-workspace metadata scoping are unchanged.

## Compatibility

Three of these degrade *silently* against an older sandbox runtime, which is worse than failing, so they are normalised in the service layer:

- **Line ranges** are an execd feature. Older execd ignores `offset`/`limit` and returns the whole file, so a caller that thinks it is paging gets everything and is then truncated downstream with no marker. The request now asks for the leading `offset + limit - 1` lines and the range is applied locally. That prefix has the same shape whether execd honours it or returns everything, so no version check is needed.
- **Replace counts** are absent on older execd, which still performs the replacement. `detailAvailable` distinguishes that from "nothing matched".
- **Directory listing** fails on older execd with a bare `List directory failed`; the error now names the version it needs and the alternative.

`resourceRequests` is ignored by older runtimes, leaving requests equal to limits — no behaviour change, so it is only documented.

## Verification

Exercised against a live opensandbox on both runtimes — server `v0.1.14` + execd `v1.0.16`, and server `v0.2.2` + execd `v1.0.21`:

- Every new file and command operation, plus a regression pass over the existing paths (foreground exec, glob search, both endpoint resolutions).
- Background commands work on **both** runtimes: `run(background)` → `getCommandStatus` (`running: true` → `running: false, exitCode: 0`) → `getBackgroundCommandLogs` with the cursor advancing → `interrupt`.
- The line-range fallback returns identical results on both across 6 cases, including a limit running past EOF and offset- or limit-only reads. Passing the range straight through returns the whole file on the older runtime and the correct slice on the newer one, which is the difference being normalised.
- `resourceRequests` produces `requests={cpu:100m,memory:128Mi}` against `limits={cpu:1,memory:1Gi}` (Burstable) on the newer runtime, and is ignored on the older one.

Typecheck, build and lint pass in both packages.
