### PR TITLE
test(e2e): cover sandboxes across the control plane and the sandbox service

### DIFF
--- a/control-plane/e2e/README.md
+++ b/control-plane/e2e/README.md
@@ -64,8 +64,27 @@ Turning one off skips the specs that need it rather than failing them:
 | Capability   | Gates                                              |
 | ------------ | -------------------------------------------------- |
 | `kubernetes` | workspace lifecycle, and everything needing a live agent (sessions, shares, jobs) |
-| `sandbox`    | reserved for sandbox coverage                      |
+| `sandbox`    | sandbox specs (also needs `kubernetes`, since the pods have to schedule) |
 | `browser`    | reserved for browser coverage                      |
+
+## Sandboxes talk to two services
+
+The control plane proxies four sandbox operations — create, list, endpoint,
+delete — so the file and command surface has no route through it. The sandbox
+specs are split to match: one group drives the proxied routes and proves a
+workspace can own a sandbox, the other calls the sandbox service directly for
+everything else. Each group creates and deletes its own sandbox rather than
+sharing one, so neither depends on the other's principal resolving the same way.
+
+Point `sandboxServiceUrl` at the deployed service (or `E2E_SANDBOX_SERVICE_URL`)
+to enable the second group; leaving it out skips it, the same as turning the
+capability off. `sandboxImage` picks what those sandboxes run — it needs a shell
+and has to be pullable from the target's nodes, so override it when the
+deployment mirrors its registry.
+
+The run's own service token authenticates to both. The sandbox service resolves
+bearer tokens through the control plane, and ownership scoping means a run only
+ever sees the sandboxes it created — no service key, no shared principal.
 
 ## Agent core matrix
 

--- a/control-plane/e2e/config.ts
+++ b/control-plane/e2e/config.ts
@@ -56,6 +56,23 @@ export interface E2eProfile {
   llm: E2eLlmConfig
   capabilities: E2eCapabilities
   /**
+   * Base URL of the deployed sandbox service, e.g. http://10.0.0.5:30306.
+   *
+   * The control plane only proxies create/list/endpoint/delete, so the file and
+   * command surface has no route through it — those specs talk to the component
+   * directly. The run's own service token authenticates there too: the sandbox
+   * service resolves bearer tokens through the control plane, and ownership
+   * scoping means a run still only sees the sandboxes it created.
+   *
+   * Unset skips the specs that need it, the same as turning the capability off.
+   */
+  sandboxServiceUrl?: string
+  /**
+   * Image the sandbox specs run in. Needs a shell and to be pullable from the
+   * target's nodes — override it when the deployment mirrors its registry.
+   */
+  sandboxImage: string
+  /**
    * Explicit acknowledgement that the suite creates and deletes real data on
    * the target. Must be true — there is no default that lets an unconfigured
    * run mutate a cluster.
@@ -126,6 +143,8 @@ function envOverride(profile: Record<string, unknown>) {
   set('llm.apiKey', process.env.E2E_LLM_API_KEY)
   set('llm.model', process.env.E2E_LLM_MODEL)
   setList('llm.agentTypes', process.env.E2E_LLM_AGENT_TYPES)
+  set('sandboxServiceUrl', process.env.E2E_SANDBOX_SERVICE_URL)
+  set('sandboxImage', process.env.E2E_SANDBOX_IMAGE)
 }
 
 let cached: E2eProfile | undefined
@@ -182,6 +201,10 @@ export function loadProfile(): E2eProfile {
       sandbox: capabilities.sandbox ?? true,
       browser: capabilities.browser ?? true,
     },
+    sandboxServiceUrl: raw.sandboxServiceUrl
+      ? String(raw.sandboxServiceUrl).replace(/\/$/, '')
+      : undefined,
+    sandboxImage: String(raw.sandboxImage ?? 'python:3.12-slim'),
     confirmMutatesTarget: raw.confirmMutatesTarget === true,
     allowNonPristineTarget: raw.allowNonPristineTarget === true,
     artifactsDir: String(raw.artifactsDir ?? './e2e-artifacts'),

--- a/control-plane/e2e/profile.example.json
+++ b/control-plane/e2e/profile.example.json
@@ -30,6 +30,15 @@
     "browser": true
   },
 
+  "$sandboxComment": [
+    "The control plane proxies only create/list/endpoint/delete, so the sandbox",
+    "file and command specs call the sandbox service directly. Leave the URL out",
+    "to skip those, the same as turning the capability off. The image needs a",
+    "shell and to be pullable from the target's nodes."
+  ],
+  "sandboxServiceUrl": "http://127.0.0.1:30306",
+  "sandboxImage": "python:3.12-slim",
+
   "confirmMutatesTarget": false,
   "allowNonPristineTarget": false,
 

--- a/control-plane/e2e/sandbox-client.ts
+++ b/control-plane/e2e/sandbox-client.ts
@@ -1,0 +1,209 @@
+import { profile } from './setup'
+
+// Minimal client for the deployed sandbox service.
+//
+// The control plane proxies only create/list/endpoint/delete, so the file and
+// command surface has no route through it and these specs call the component
+// directly. Deliberately hand-rolled and narrow: this covers what the specs
+// assert, and a shared SDK would let a passing suite depend on a client that
+// the deployed service does not actually agree with.
+
+interface FileEntry {
+  path: string
+  type?: string
+  size?: number
+}
+
+interface CommandResult {
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  executionTimeMs?: number
+  commandId?: string
+  background?: boolean
+}
+
+interface CommandStatus {
+  id: string
+  running: boolean
+  exitCode: number | null
+  error?: string
+}
+
+interface CommandLogs {
+  content?: string
+  cursor?: number
+}
+
+class SandboxServiceError extends Error {
+  constructor(
+    readonly status: number,
+    readonly method: string,
+    readonly path: string,
+    body: string,
+  ) {
+    super(`sandbox-service ${method} ${path} → ${status}: ${body}`)
+  }
+}
+
+function baseUrl(): string {
+  const url = profile.sandboxServiceUrl
+  if (!url) throw new Error('sandboxServiceUrl is not configured for this run')
+  return url
+}
+
+async function requestTo<T>(
+  origin: string,
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const res = await fetch(`${origin}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: body != null ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(120_000),
+  })
+  if (!res.ok) {
+    throw new SandboxServiceError(res.status, method, path, await res.text().catch(() => ''))
+  }
+  const ct = res.headers.get('content-type') ?? ''
+  return (ct.includes('application/json') ? await res.json() : undefined) as T
+}
+
+const request = <T>(token: string, method: string, path: string, body?: unknown) =>
+  requestTo<T>(baseUrl(), token, method, path, body)
+
+/**
+ * The four sandbox operations the control plane proxies, scoped to a workspace.
+ * Separate from the component's own surface below because they prove a
+ * different thing: that a workspace can own a sandbox at all.
+ */
+export function workspaceSandboxes(token: string, workspaceId: string) {
+  const cp = <T>(method: string, path: string, body?: unknown) =>
+    requestTo<T>(profile.baseUrl, token, method, path, body)
+
+  return {
+    create: (body: {
+      image: string
+      resource?: Record<string, string>
+      timeout_seconds?: number
+    }) => cp<{ id: string }>('POST', `/api/workspaces/${workspaceId}/sandboxes`, body),
+    list: () => cp<{ sandboxes?: unknown[] }>('GET', `/api/workspaces/${workspaceId}/sandboxes`),
+    endpoint: (sandboxId: string, port: number) =>
+      cp<{ url: string }>(
+        'GET',
+        `/api/workspaces/${workspaceId}/sandboxes/${sandboxId}/endpoint/${port}`,
+      ),
+    delete: (sandboxId: string) =>
+      cp<void>('DELETE', `/api/workspaces/${workspaceId}/sandboxes/${sandboxId}`),
+  }
+}
+
+export function sandboxService(token: string) {
+  const q = (params: Record<string, string | number | undefined>) => {
+    const sp = new URLSearchParams()
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined) sp.set(k, String(v))
+    }
+    const s = sp.toString()
+    return s ? `?${s}` : ''
+  }
+
+  return {
+    create: (body: {
+      image: string
+      timeoutSeconds?: number
+      resource?: Record<string, string>
+      resourceRequests?: Record<string, string>
+      metadata?: Record<string, string>
+    }) => request<{ id: string }>(token, 'POST', '/api/sandboxes', body),
+
+    kill: (id: string) => request<void>(token, 'DELETE', `/api/sandboxes/${id}`),
+
+    exec: (
+      id: string,
+      command: string,
+      opts?: { cwd?: string; timeoutSeconds?: number; background?: boolean },
+    ) => request<CommandResult>(token, 'POST', `/api/sandboxes/${id}/exec`, { command, ...opts }),
+
+    commandStatus: (id: string, commandId: string) =>
+      request<CommandStatus>(token, 'GET', `/api/sandboxes/${id}/commands/${commandId}`),
+
+    commandLogs: (id: string, commandId: string, cursor?: number) =>
+      request<CommandLogs>(
+        token,
+        'GET',
+        `/api/sandboxes/${id}/commands/${commandId}/logs${q({ cursor })}`,
+      ),
+
+    interruptCommand: (id: string, commandId: string) =>
+      request<{ success: true }>(
+        token,
+        'POST',
+        `/api/sandboxes/${id}/commands/${commandId}/interrupt`,
+      ),
+
+    writeFiles: (id: string, files: Array<{ path: string; content: string }>) =>
+      request<{ success: true; count: number }>(token, 'POST', `/api/sandboxes/${id}/files`, {
+        files,
+      }),
+
+    readFile: (id: string, path: string, opts?: { offset?: number; limit?: number }) =>
+      request<{ content: string }>(
+        token,
+        'GET',
+        `/api/sandboxes/${id}/files${q({ path, ...opts })}`,
+      ),
+
+    listDirectory: (id: string, path: string, depth?: number) =>
+      request<{ files: FileEntry[] }>(
+        token,
+        'GET',
+        `/api/sandboxes/${id}/files/dir${q({ path, depth })}`,
+      ),
+
+    searchFiles: (id: string, path: string, pattern?: string) =>
+      request<{ files: FileEntry[] }>(
+        token,
+        'GET',
+        `/api/sandboxes/${id}/files/list${q({ path, pattern })}`,
+      ),
+
+    replaceContents: (
+      id: string,
+      entries: Array<{ path: string; oldContent: string; newContent: string }>,
+    ) =>
+      request<{
+        results: Array<{ path: string; replacedCount: number }>
+        detailAvailable: boolean
+      }>(token, 'POST', `/api/sandboxes/${id}/files/replace`, { entries }),
+
+    moveFiles: (id: string, entries: Array<{ src: string; dest: string }>) =>
+      request<{ success: true; count: number }>(token, 'POST', `/api/sandboxes/${id}/files/move`, {
+        entries,
+      }),
+
+    deleteFiles: (id: string, paths: string[]) =>
+      request<{ success: true; count: number }>(token, 'DELETE', `/api/sandboxes/${id}/files`, {
+        paths,
+      }),
+
+    createDirectories: (id: string, entries: Array<{ path: string }>) =>
+      request<{ success: true; count: number }>(token, 'POST', `/api/sandboxes/${id}/directories`, {
+        entries,
+      }),
+
+    deleteDirectories: (id: string, paths: string[]) =>
+      request<{ success: true; count: number }>(
+        token,
+        'DELETE',
+        `/api/sandboxes/${id}/directories`,
+        { paths },
+      ),
+  }
+}

--- a/control-plane/e2e/sandbox.test.ts
+++ b/control-plane/e2e/sandbox.test.ts
@@ -1,0 +1,280 @@
+import { afterAll, beforeAll, expect, test } from 'vitest'
+import { sandboxService, workspaceSandboxes } from './sandbox-client'
+import {
+  client,
+  describeIfSandbox,
+  describeIfSandboxService,
+  profile,
+  runToken,
+  scoped,
+} from './setup'
+
+// Sandboxes are covered in two halves, each owning its own sandbox.
+//
+// The control plane proxies four operations, so the file and command surface
+// has no route through it. Rather than have one group depend on the other's
+// sandbox — and on a control-plane token and a service token resolving to the
+// same principal — each half creates and deletes its own.
+
+const WAIT_STEP_MS = 500
+
+async function until<T>(
+  what: string,
+  fn: () => Promise<T | null | undefined | false>,
+  timeoutMs = 30_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  let lastErr: unknown
+  while (Date.now() < deadline) {
+    try {
+      const result = await fn()
+      if (result) return result
+    } catch (e) {
+      lastErr = e
+    }
+    await new Promise((r) => setTimeout(r, WAIT_STEP_MS))
+  }
+  const detail = lastErr ? `; last error: ${(lastErr as Error).message}` : ''
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}${detail}`)
+}
+
+// ---------------------------------------------------------------------------
+
+describeIfSandbox('sandboxes through the workspace API', () => {
+  let wsId: string
+  let sandboxId: string | undefined
+
+  beforeAll(async () => {
+    // A bare workspace is enough: the route authorises against the workspace
+    // record and mints the owner's token. It never has to be running.
+    const ws = await client.workspaces.create({ name: scoped('sbx-ws') })
+    wsId = ws.id
+  })
+
+  afterAll(async () => {
+    try {
+      if (sandboxId)
+        await workspaceSandboxes(runToken, wsId)
+          .delete(sandboxId)
+          .catch(() => {})
+    } catch {}
+    try {
+      if (wsId) await client.workspaces.delete(wsId)
+    } catch {}
+  })
+
+  test('create a sandbox owned by the workspace', { timeout: 180_000 }, async () => {
+    const created = await workspaceSandboxes(runToken, wsId).create({
+      image: profile.sandboxImage,
+      resource: { cpu: '500m', memory: '512Mi' },
+      timeout_seconds: 900,
+    })
+    expect(created.id).toBeTruthy()
+    sandboxId = created.id
+  })
+
+  test('list is scoped to the workspace', async () => {
+    const result = await workspaceSandboxes(runToken, wsId).list()
+    const ids = (result.sandboxes ?? []).map((s) => (s as { id: string }).id)
+    expect(ids).toContain(sandboxId)
+  })
+
+  test('resolve an endpoint for a port', async () => {
+    const { url } = await workspaceSandboxes(runToken, wsId).endpoint(sandboxId as string, 8080)
+    expect(url).toMatch(/^https?:\/\//)
+  })
+
+  test('delete releases the sandbox', { timeout: 60_000 }, async () => {
+    await workspaceSandboxes(runToken, wsId).delete(sandboxId as string)
+    const gone = await until('the sandbox to leave the workspace listing', async () => {
+      const result = await workspaceSandboxes(runToken, wsId).list()
+      const ids = (result.sandboxes ?? []).map((s) => (s as { id: string }).id)
+      return !ids.includes(sandboxId as string)
+    })
+    expect(gone).toBe(true)
+    sandboxId = undefined
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describeIfSandboxService('sandbox files and commands', () => {
+  let sbx: ReturnType<typeof sandboxService>
+  let id: string
+
+  beforeAll(async () => {
+    sbx = sandboxService(runToken)
+    const created = await sbx.create({
+      image: profile.sandboxImage,
+      timeoutSeconds: 1800,
+      resource: { cpu: '500m', memory: '512Mi' },
+      metadata: { e2e: scoped('files') },
+    })
+    id = created.id
+  }, 180_000)
+
+  afterAll(async () => {
+    try {
+      if (id) await sbx.kill(id)
+    } catch {}
+  })
+
+  test('run a command and report its exit code', { timeout: 60_000 }, async () => {
+    const ok = await sbx.exec(id, 'echo out; echo err >&2')
+    expect(ok.stdout).toContain('out')
+    expect(ok.stderr).toContain('err')
+    expect(ok.exitCode).toBe(0)
+
+    const failed = await sbx.exec(id, 'exit 3')
+    expect(failed.exitCode).toBe(3)
+  })
+
+  test('honour the working directory', { timeout: 60_000 }, async () => {
+    const result = await sbx.exec(id, 'pwd', { cwd: '/tmp' })
+    expect(result.stdout.trim()).toBe('/tmp')
+  })
+
+  test(
+    'follow a background command by cursor, then interrupt one',
+    { timeout: 120_000 },
+    async () => {
+      const started = await sbx.exec(id, 'for i in 1 2 3; do echo tick-$i; sleep 1; done', {
+        background: true,
+      })
+      expect(started.commandId).toBeTruthy()
+      // Detached: output arrives through the log endpoint, not this response.
+      expect(started.stdout).toBe('')
+      expect(started.exitCode).toBeNull()
+      const commandId = started.commandId as string
+
+      const running = await sbx.commandStatus(id, commandId)
+      expect(running.running).toBe(true)
+
+      const first = await sbx.commandLogs(id, commandId, 0)
+      expect(typeof first.cursor).toBe('number')
+
+      const done = await until(
+        'the background command to finish',
+        async () => {
+          const status = await sbx.commandStatus(id, commandId)
+          return status.running === false ? status : null
+        },
+        60_000,
+      )
+      expect(done.exitCode).toBe(0)
+
+      // The cursor is an offset, so resuming from it returns only what came after.
+      const all = await sbx.commandLogs(id, commandId, 0)
+      expect(all.content).toContain('tick-3')
+      expect(all.cursor as number).toBeGreaterThan(first.cursor as number)
+      const tail = await sbx.commandLogs(id, commandId, all.cursor)
+      expect(tail.content ?? '').toBe('')
+
+      const long = await sbx.exec(id, 'sleep 120', { background: true })
+      await sbx.interruptCommand(id, long.commandId as string)
+      const stopped = await until(
+        'the interrupted command to stop running',
+        async () => {
+          const status = await sbx.commandStatus(id, long.commandId as string)
+          return status.running === false ? status : null
+        },
+        30_000,
+      )
+      expect(stopped.exitCode).not.toBe(0)
+    },
+  )
+
+  test('write a file and read a line range back', { timeout: 60_000 }, async () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `L${i + 1}`)
+    await sbx.writeFiles(id, [
+      { path: '/workspace/e2e/lines.txt', content: `${lines.join('\n')}\n` },
+    ])
+
+    const whole = await sbx.readFile(id, '/workspace/e2e/lines.txt')
+    expect(whole.content).toBe(`${lines.join('\n')}\n`)
+
+    // offset is 1-based. Worth asserting exactly: an older sandbox runtime
+    // ignores the range and hands back the whole file, which the service
+    // normalises rather than passing on.
+    const middle = await sbx.readFile(id, '/workspace/e2e/lines.txt', { offset: 3, limit: 2 })
+    expect(middle.content).toBe('L3\nL4')
+
+    const pastEnd = await sbx.readFile(id, '/workspace/e2e/lines.txt', { offset: 9, limit: 5 })
+    expect(pastEnd.content).toBe('L9\nL10')
+  })
+
+  test('list a directory with entry types', { timeout: 60_000 }, async () => {
+    await sbx.writeFiles(id, [{ path: '/workspace/e2e/nested/inner.txt', content: 'inner' }])
+
+    const shallow = await sbx.listDirectory(id, '/workspace/e2e')
+    const shallowPaths = shallow.files.map((f) => f.path)
+    expect(shallowPaths).toContain('/workspace/e2e/lines.txt')
+    expect(shallowPaths).toContain('/workspace/e2e/nested')
+    // Default depth is 1, so the nested file is not reached yet.
+    expect(shallowPaths).not.toContain('/workspace/e2e/nested/inner.txt')
+
+    const byPath = new Map(shallow.files.map((f) => [f.path, f.type]))
+    expect(byPath.get('/workspace/e2e/lines.txt')).toBe('file')
+    expect(byPath.get('/workspace/e2e/nested')).toBe('directory')
+
+    const deep = await sbx.listDirectory(id, '/workspace/e2e', 3)
+    expect(deep.files.map((f) => f.path)).toContain('/workspace/e2e/nested/inner.txt')
+  })
+
+  test('search by glob', { timeout: 60_000 }, async () => {
+    const found = await sbx.searchFiles(id, '/workspace/e2e', '*.txt')
+    expect(found.files.map((f) => f.path)).toContain('/workspace/e2e/lines.txt')
+
+    const none = await sbx.searchFiles(id, '/workspace/e2e', '*.nomatch')
+    expect(none.files).toHaveLength(0)
+  })
+
+  test('replace reports a per-file count', { timeout: 60_000 }, async () => {
+    await sbx.writeFiles(id, [{ path: '/workspace/e2e/replace.txt', content: 'a a a' }])
+
+    const hit = await sbx.replaceContents(id, [
+      { path: '/workspace/e2e/replace.txt', oldContent: 'a', newContent: 'b' },
+    ])
+    const after = await sbx.readFile(id, '/workspace/e2e/replace.txt')
+    expect(after.content).toBe('b b b')
+
+    // An older sandbox runtime performs the replacement without reporting
+    // counts, and says so rather than returning an empty list that reads like
+    // "nothing matched".
+    if (hit.detailAvailable) {
+      expect(hit.results).toEqual([{ path: '/workspace/e2e/replace.txt', replacedCount: 3 }])
+
+      const miss = await sbx.replaceContents(id, [
+        { path: '/workspace/e2e/replace.txt', oldContent: 'zzz', newContent: 'x' },
+      ])
+      expect(miss.results[0].replacedCount).toBe(0)
+    } else {
+      expect(hit.results).toHaveLength(0)
+    }
+  })
+
+  test('move, delete, and manage directories', { timeout: 60_000 }, async () => {
+    await sbx.createDirectories(id, [{ path: '/workspace/e2e/mk' }])
+    await sbx.writeFiles(id, [{ path: '/workspace/e2e/mk/one.txt', content: 'one' }])
+
+    await sbx.moveFiles(id, [
+      { src: '/workspace/e2e/mk/one.txt', dest: '/workspace/e2e/mk/two.txt' },
+    ])
+    const moved = await sbx.listDirectory(id, '/workspace/e2e/mk')
+    expect(moved.files.map((f) => f.path)).toEqual(['/workspace/e2e/mk/two.txt'])
+
+    await sbx.deleteFiles(id, ['/workspace/e2e/mk/two.txt'])
+    const emptied = await sbx.listDirectory(id, '/workspace/e2e/mk')
+    expect(emptied.files).toHaveLength(0)
+
+    await sbx.deleteDirectories(id, ['/workspace/e2e/mk'])
+    const parent = await sbx.listDirectory(id, '/workspace/e2e')
+    expect(parent.files.map((f) => f.path)).not.toContain('/workspace/e2e/mk')
+  })
+
+  test('another run cannot reach this sandbox', { timeout: 60_000 }, async () => {
+    // Ownership is enforced on every route, not just the listing.
+    const stranger = sandboxService('not-a-real-token')
+    await expect(stranger.exec(id, 'echo hello')).rejects.toThrow()
+  })
+})

--- a/control-plane/e2e/setup.ts
+++ b/control-plane/e2e/setup.ts
@@ -20,6 +20,12 @@ if (!baseUrl || !serviceToken) {
 /** Authenticated as the throwaway user this run provisioned. */
 export const client = new NapClient({ baseUrl, serviceToken })
 
+/**
+ * The same token as a bare string, for the few surfaces NapClient does not
+ * cover — the sandbox specs call the sandbox service directly.
+ */
+export const runToken = serviceToken
+
 export const profile = loadProfile()
 
 /** Identifier shared by every resource this run creates. */
@@ -41,6 +47,20 @@ export function scoped(name: string): string {
 
 /** Workspaces can reach `running` — needs a real Kubernetes-backed target. */
 export const describeIfK8s = profile.capabilities.kubernetes ? describe : describe.skip
+
+/**
+ * Sandboxes can actually be created. Needs the component installed and a
+ * cluster to schedule the pods on; specs that reach past the control plane's
+ * four proxied routes also need the service's own URL.
+ */
+export const describeIfSandbox =
+  profile.capabilities.sandbox && profile.capabilities.kubernetes ? describe : describe.skip
+
+/** As above, plus a reachable sandbox service for the file and command surface. */
+export const describeIfSandboxService =
+  profile.capabilities.sandbox && profile.capabilities.kubernetes && profile.sandboxServiceUrl
+    ? describe
+    : describe.skip
 
 /** Agent cores this run exercises, from the profile. */
 export const agentCores = profile.llm.agentTypes


### PR DESCRIPTION
## What

The e2e suite reserved a `sandbox` capability but had nothing behind it. This fills it in, covering the sandbox surface added in #200.

Two groups, each owning its own sandbox:

| Group | Drives | Proves |
|---|---|---|
| `sandboxes through the workspace API` | the control plane's four proxied routes | a workspace can own a sandbox |
| `sandbox files and commands` | the sandbox service directly | the file and command surface |

The control plane proxies only create / list / endpoint / delete, so the rest has no route through it. Sharing one sandbox between the groups would have made the suite depend on a control-plane-minted owner token and the run's service token resolving to the same principal — separate sandboxes cost one extra create and drop the assumption.

The run's own service token authenticates to both: the sandbox service resolves bearer tokens through the control plane, and ownership scoping means a run only sees the sandboxes it created. No service key, no shared principal.

## Covered

The four proxied routes · foreground exit codes and working directory · a background command followed by cursor and another interrupted · line-range reads · directory listing with entry types and depth · glob search · replace counts · move, delete and directory management · a rejected stranger token.

Two assertions are deliberately exact rather than loose, because they are the regression line for the compatibility handling in #200:

- **Line ranges** are normalised in the service, since an older sandbox runtime ignores `offset`/`limit` and returns the whole file. The spec pins the exact slice (`L3\nL4`, and a limit running past EOF) rather than a prefix, so a regression to pass-through fails rather than silently returning more.
- **Replace counts** branch on `detailAvailable`. An older runtime performs the replacement without reporting counts, so the spec asserts it *said so*, instead of reading an empty list as "nothing matched". Passes on both runtimes without hiding the difference.

## Profile

Two new fields, both with `E2E_*` overrides:

- `sandboxServiceUrl` — gates the second group; leaving it out skips it, same as turning the capability off
- `sandboxImage` — what the sandboxes run; needs a shell and to be pullable from the target's nodes, so a deployment mirroring its registry has to override it

## Not yet run

**This has not been executed against a live target.** There was no non-production deployment to point it at, and validating unproven test code against production is the wrong way round — a failure there would most likely be a bug in this spec, diagnosed on a live cluster.

Typecheck, lint and knip pass. The suite refuses to collect without a target by design, so that is as far as static checking goes.
