### PR TITLE
fix(skills): stop git sync from silently dropping unimportable skills

### DIFF
--- a/control-plane/src/routes/skills.ts
+++ b/control-plane/src/routes/skills.ts
@@ -853,6 +853,7 @@ skills.openapi(syncSourceRoute, async (c) => {
     {
       source: sourceToApi(value.source),
       results: value.results,
+      skipped: value.skipped,
       commit_sha: value.commit_sha,
     },
     200,

--- a/control-plane/src/services/skills-content.ts
+++ b/control-plane/src/services/skills-content.ts
@@ -199,9 +199,18 @@ interface SyncResultRow {
   changed: boolean
 }
 
+/** A skill the sync could not import — reported instead of silently dropped. */
+interface SyncSkipRow {
+  skill_id: string
+  name: string
+  subpath: string
+  reason: 'subpath_not_found' | 'too_large'
+}
+
 export interface SyncResult {
   source: SkillSource
   results: SyncResultRow[]
+  skipped: SyncSkipRow[]
   commit_sha: string | null
 }
 

--- a/control-plane/src/services/skills-service.test.ts
+++ b/control-plane/src/services/skills-service.test.ts
@@ -819,6 +819,7 @@ describe('SkillsService.syncSource', () => {
       ok({
         source,
         commit_sha: 'newsha',
+        skipped: [],
         results: [
           { skill_id: s1.id, version_id: 'v-new', content_hash: 'h1', changed: true },
           { skill_id: s2.id, version_id: 'v-old', content_hash: 'h2', changed: false },

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -692,6 +692,18 @@ export const SkillSyncResponseSchema = z.object({
       changed: z.boolean(),
     }),
   ),
+  // Skills the sync could not import (subpath no longer resolves after an
+  // upstream restructure, or the packed skill outgrew the size limit). Non-
+  // empty means the source's stored commit SHA was cleared, so the next sync
+  // re-walks the repo instead of short-circuiting on an unchanged HEAD.
+  skipped: z.array(
+    z.object({
+      skill_id: z.string(),
+      name: z.string(),
+      subpath: z.string(),
+      reason: z.enum(['subpath_not_found', 'too_large']),
+    }),
+  ),
   commit_sha: z.string().nullable(),
 })
 

--- a/skills-content-service/src/from-git.test.ts
+++ b/skills-content-service/src/from-git.test.ts
@@ -23,7 +23,8 @@ const mocks = vi.hoisted(() => {
   const listSkillsBySource = vi.fn()
   const markSourceSynced = vi.fn()
   const setActiveVersion = vi.fn()
-  const withTx = vi.fn(async (fn: (client: unknown) => unknown) => fn({}))
+  const query = vi.fn(async () => ({ rowCount: 1, rows: [] }))
+  const withTx = vi.fn(async (fn: (client: unknown) => unknown) => fn({ query }))
   return {
     fetchTarball,
     fetchCommitSha,
@@ -38,6 +39,7 @@ const mocks = vi.hoisted(() => {
     insertVersion,
     listSkillsBySource,
     markSourceSynced,
+    query,
     setActiveVersion,
     withTx,
   }
@@ -78,7 +80,8 @@ beforeEach(() => {
       ;(k as { mockReset: () => void }).mockReset()
     }
   }
-  mocks.withTx.mockImplementation(async (fn) => fn({}))
+  mocks.query.mockImplementation(async () => ({ rowCount: 1, rows: [] }))
+  mocks.withTx.mockImplementation(async (fn) => fn({ query: mocks.query }))
 })
 
 // Tarball with a single root-level skill, wrapped under the github-style
@@ -398,5 +401,71 @@ describe('syncSource', () => {
     if (!r.ok) return
     expect(r.data.results[0].changed).toBe(false)
     expect(mocks.setActiveVersion).not.toHaveBeenCalled()
+    // Clean run — the SHA is recorded, so the next sync can short-circuit.
+    expect(mocks.markSourceSynced).toHaveBeenCalledWith(expect.anything(), 'src1', 'deadbeef')
+  })
+
+  it('reports a skill whose subpath no longer resolves, and withholds the SHA', async () => {
+    mocks.getSourceById.mockResolvedValueOnce({
+      id: 'src1',
+      kind: 'git',
+      git_url: 'https://github.com/owner/repo',
+      git_type: 'github',
+      git_ref: null,
+      last_commit_sha: 'cafe1234',
+    })
+    mocks.fetchTarball.mockResolvedValueOnce(await singleSkillTarball())
+    mocks.fetchCommitSha.mockResolvedValueOnce('deadbeef')
+    // The repo moved SKILL.md to the root; the skill still tracks old/dir.
+    mocks.listSkillsBySource.mockResolvedValueOnce([
+      { id: 'sk1', source_id: 'src1', subpath: 'old/dir', name: 'myskill' },
+    ])
+    mocks.markSourceSynced.mockResolvedValueOnce({ id: 'src1', kind: 'git' })
+
+    const r = await syncSource({ sourceId: 'src1', publishedBy: 'u1' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.data.results).toHaveLength(0)
+    expect(r.data.skipped).toEqual([
+      { skill_id: 'sk1', name: 'myskill', subpath: 'old/dir', reason: 'subpath_not_found' },
+    ])
+    expect(mocks.insertVersion).not.toHaveBeenCalled()
+    // The SHA must be cleared, not advanced: recording 'deadbeef' here would
+    // make every later sync short-circuit on the pre-check and never retry
+    // this skill.
+    expect(mocks.query).toHaveBeenCalledWith(
+      'UPDATE skill_sources SET last_commit_sha = NULL WHERE id = $1',
+      ['src1'],
+    )
+    expect(mocks.markSourceSynced).toHaveBeenCalledWith(expect.anything(), 'src1', null)
+  })
+
+  it('still syncs the healthy skills alongside a skipped one', async () => {
+    mocks.getSourceById.mockResolvedValueOnce({
+      id: 'src1',
+      kind: 'git',
+      git_url: 'https://github.com/owner/repo',
+      git_type: 'github',
+      git_ref: null,
+    })
+    mocks.fetchTarball.mockResolvedValueOnce(await singleSkillTarball())
+    mocks.fetchCommitSha.mockResolvedValueOnce('deadbeef')
+    mocks.listSkillsBySource.mockResolvedValueOnce([
+      { id: 'sk1', source_id: 'src1', subpath: '', name: 'myskill' },
+      { id: 'sk2', source_id: 'src1', subpath: 'gone', name: 'stale' },
+    ])
+    mocks.getActiveVersionHash.mockResolvedValueOnce({ content_hash: 'OLDHASH' })
+    mocks.insertVersion.mockResolvedValueOnce({
+      version: { id: 'v2', skill_id: 'sk1', source_id: 'src1', content_hash: 'NEWHASH' },
+      created: true,
+    })
+    mocks.setActiveVersion.mockResolvedValueOnce({})
+    mocks.markSourceSynced.mockResolvedValueOnce({ id: 'src1', kind: 'git' })
+
+    const r = await syncSource({ sourceId: 'src1', publishedBy: 'u1' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.data.results.map((x) => x.skill_id)).toEqual(['sk1'])
+    expect(r.data.skipped.map((x) => x.skill_id)).toEqual(['sk2'])
   })
 })

--- a/skills-content-service/src/from-git.ts
+++ b/skills-content-service/src/from-git.ts
@@ -479,9 +479,17 @@ interface SyncRow {
   changed: boolean
 }
 
+interface SyncSkip {
+  skill_id: string
+  name: string
+  subpath: string
+  reason: 'subpath_not_found' | 'too_large'
+}
+
 interface SyncSourceResult {
   source: SkillSource
   results: SyncRow[]
+  skipped: SyncSkip[]
   commit_sha: string | null
 }
 
@@ -491,6 +499,11 @@ interface SyncSourceResult {
  * current active version, append a new version and flip active. Same hash
  * means no-op (we still report it with changed=false so callers can show
  * "unchanged" rows in their sync summary).
+ *
+ * A skill we could not import at all (its subpath no longer resolves after an
+ * upstream restructure, or it outgrew the size limit) is reported in
+ * `skipped` rather than dropped, and suppresses the `last_commit_sha`
+ * advance — see the mark-synced call at the end for why that matters.
  *
  * Source-kind guarding (must be 'git') lives in the route handler; this
  * helper assumes the caller already checked.
@@ -542,7 +555,7 @@ export async function syncSource(
     )
     return {
       ok: true,
-      data: { source: updatedSource ?? source, results: [], commit_sha: commitSha },
+      data: { source: updatedSource ?? source, results: [], skipped: [], commit_sha: commitSha },
     }
   }
 
@@ -565,18 +578,23 @@ export async function syncSource(
   // has — typically <10 for monorepos.
   const tImport = Date.now()
   const rows = await Promise.all(
-    skills.map(async (skill): Promise<SyncRow | null> => {
+    skills.map(async (skill): Promise<SyncRow | SyncSkip | null> => {
       const scoped = filterSubpath(entries, skill.subpath || null)
       if (scoped.length === 0) {
         console.warn(
           `[skills-content] sync: subpath "${skill.subpath}" empty for skill ${skill.id}`,
         )
-        return null
+        return {
+          skill_id: skill.id,
+          name: skill.name,
+          subpath: skill.subpath,
+          reason: 'subpath_not_found',
+        }
       }
       const repacked = await repack(scoped)
       if (repacked.byteLength > maxSkillPackageBytes()) {
         console.warn(`[skills-content] sync: skill ${skill.id} exceeds size limit; skipping`)
-        return null
+        return { skill_id: skill.id, name: skill.name, subpath: skill.subpath, reason: 'too_large' }
       }
       const currentHash = (await getActiveVersionHash(skill.id))?.content_hash ?? null
       return withTx(async (client) => {
@@ -599,19 +617,34 @@ export async function syncSource(
       })
     }),
   )
-  const results = rows.filter((r): r is SyncRow => r !== null)
+  const results = rows.filter((r): r is SyncRow => r !== null && 'version_id' in r)
+  const skipped = rows.filter((r): r is SyncSkip => r !== null && 'reason' in r)
   mark('per_skill_import', tImport)
 
+  // Only record the SHA when every skill actually imported. Recording it
+  // after a partial run poisons the source permanently: the pre-check above
+  // would match on the next sync and short-circuit, so the skipped skill
+  // stays stale and every later sync reports "already up to date" without
+  // ever retrying it. Clearing the SHA instead forces the next sync to do
+  // the full walk, which both re-reports the skip and lets a corrected
+  // subpath take effect. `markSourceSynced` COALESCEs a null argument onto
+  // the stored value, so the clear needs its own statement.
   const tMark = Date.now()
-  const updatedSource = await withTx((client) => markSourceSynced(client, args.sourceId, commitSha))
+  const updatedSource = await withTx(async (client) => {
+    if (skipped.length === 0) return markSourceSynced(client, args.sourceId, commitSha)
+    await client.query('UPDATE skill_sources SET last_commit_sha = NULL WHERE id = $1', [
+      args.sourceId,
+    ])
+    return markSourceSynced(client, args.sourceId, null)
+  })
   mark('mark_synced', tMark)
 
   console.log(
-    `[skills-content] sync: source=${args.sourceId} skills=${skills.length} changed=${results.filter((r) => r.changed).length} sha=${commitSha?.slice(0, 7) ?? 'none'} total=${Date.now() - t0}ms ${phases.join(' ')}`,
+    `[skills-content] sync: source=${args.sourceId} skills=${skills.length} changed=${results.filter((r) => r.changed).length} skipped=${skipped.length} sha=${commitSha?.slice(0, 7) ?? 'none'} total=${Date.now() - t0}ms ${phases.join(' ')}`,
   )
 
   return {
     ok: true,
-    data: { source: updatedSource ?? source, results, commit_sha: commitSha },
+    data: { source: updatedSource ?? source, results, skipped, commit_sha: commitSha },
   }
 }

--- a/skills-content-service/src/index.ts
+++ b/skills-content-service/src/index.ts
@@ -464,6 +464,13 @@ const SyncResultRow = z.object({
   changed: z.boolean(),
 })
 
+const SyncSkipRow = z.object({
+  skill_id: z.string(),
+  name: z.string(),
+  subpath: z.string(),
+  reason: z.enum(['subpath_not_found', 'too_large']),
+})
+
 const syncRoute = createRoute({
   method: 'post',
   path: '/sources/{id}/sync',
@@ -478,6 +485,7 @@ const syncRoute = createRoute({
           schema: z.object({
             source: SourceSchema,
             results: z.array(SyncResultRow),
+            skipped: z.array(SyncSkipRow),
             commit_sha: z.string().nullable(),
           }),
         },

--- a/web/src/components/library/SkillsSection.tsx
+++ b/web/src/components/library/SkillsSection.tsx
@@ -460,10 +460,26 @@ export function SkillsSection({ instanceId }: { instanceId: string }) {
   function handleSyncSource(sourceId: string) {
     syncSource.mutate(sourceId, {
       onSuccess: (result) => {
+        // Skips are the headline when present: those skills did NOT sync, and
+        // the fix is manual (re-point the subpath / shrink the skill). One
+        // toast per reason keeps the remedy specific. Reported alongside the
+        // success toast rather than instead of it — the other skills in the
+        // source did sync.
+        for (const reason of ['subpath_not_found', 'too_large'] as const) {
+          const hit = result.skipped.filter((s) => s.reason === reason)
+          if (hit.length === 0) continue
+          const key =
+            reason === 'subpath_not_found'
+              ? 'components.library.skills.toasts.syncSkippedSubpath'
+              : 'components.library.skills.toasts.syncSkippedTooLarge'
+          toast.warning(t(key, { count: hit.length, names: hit.map((s) => s.name).join(', ') }), {
+            duration: 10000,
+          })
+        }
         const changed = result.results.some((r) => r.changed)
         if (changed) {
           toast.success(t('components.library.skills.toasts.synced'))
-        } else {
+        } else if (result.skipped.length === 0) {
           toast.info(t('components.library.skills.toasts.alreadyUpToDate'))
         }
       },

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -975,6 +975,12 @@ class ApiClient {
       content_hash: string
       changed: boolean
     }>
+    skipped: Array<{
+      skill_id: string
+      name: string
+      subpath: string
+      reason: 'subpath_not_found' | 'too_large'
+    }>
     commit_sha: string | null
   }> {
     return this.request(`/skills/sources/${encodeURIComponent(sourceId)}/sync`, {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -940,6 +940,8 @@
           "uploaded": "Skill uploaded",
           "synced": "Skill synced",
           "alreadyUpToDate": "Already up to date",
+          "syncSkippedSubpath": "Not synced: {{names}} — the tracked directory no longer exists in the repo. Edit the skill and pick its new directory.",
+          "syncSkippedTooLarge": "Not synced: {{names}} — the packed skill exceeds the size limit.",
           "switchedToGit": "Skill switched to Git source",
           "deleted": "Skill deleted"
         },

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -970,6 +970,8 @@
           "uploaded": "Skill 已上传",
           "synced": "Skill 已同步",
           "alreadyUpToDate": "当前已是最新",
+          "syncSkippedSubpath": "未同步：{{names}} —— 记录的目录在仓库中已不存在。请编辑该 skill 重新选择目录。",
+          "syncSkippedTooLarge": "未同步：{{names}} —— 打包后超出体积上限。",
           "switchedToGit": "Skill 已切换到 Git 来源",
           "deleted": "Skill 已删除"
         },


### PR DESCRIPTION
## Problem

A source sync walks every skill under it and imports each one's subpath. Two cases produced no version at all — the subpath matched no files (the upstream restructured and moved the directory), and the repacked skill exceeded the size limit — and both were handled by logging a warning and dropping the row from the result set. The user saw a plain "synced" toast with no hint that one of their skills had not been touched.

Worse, the run still recorded the upstream SHA as `last_commit_sha`. The pre-check at the top of sync short-circuits whenever that matches the current HEAD, so a single partial run poisoned the source permanently: every later sync reported "already up to date" and never retried the stale skill, no matter how long the directory stayed wrong. Re-importing through the edit dialog was the only way out, since that path has no pre-check.

## Changes

- Both cases are reported as `skipped` entries carrying the skill, its subpath, and a reason, instead of being silently dropped
- Their presence withholds the SHA — the sync clears it instead, so the next run does the full walk, re-reports the problem, and picks up a corrected subpath immediately. (`markSourceSynced` COALESCEs a null argument onto the stored value, so the clear needs its own statement.)
- The web sync handler surfaces one warning toast per reason, naming the affected skills and how to fix them; healthy skills in the same source still report success

## Limitation

An already-poisoned source cannot be detected without fetching the repo, so it stays short-circuited until the upstream gets its next commit — at which point the SHA no longer matches, the full walk runs, and it self-heals through the path above.

## Verification

- skills-content-service: 75 tests pass, including 3 new ones — a dead subpath is reported and the SHA cleared, healthy and skipped skills coexist correctly, and a clean sync still records the SHA
- control-plane: skills-service 81 tests pass
- `tsc --noEmit` clean across the three touched workspaces; biome clean