### PR TITLE
fix(proxy): bound how long a wedged agent pod can stall a request

### DIFF
--- a/control-plane/src/routes/proxy.test.ts
+++ b/control-plane/src/routes/proxy.test.ts
@@ -72,6 +72,36 @@ describe('agent proxy headers deadline', () => {
     expect((await res.json()).error).toMatch(/did not respond/i)
   })
 
+  it('gives non-session paths a budget the session deadline would have cut short', async () => {
+    vi.useFakeTimers()
+    // `skills/:name/pack` tars a directory over NFS in a throttled pod, and
+    // a JSON/tarball handler flushes headers only once it has bytes to send —
+    // so the deadline covers the whole job. Holding every path to the session
+    // budget would turn a slow pack into a 504.
+    let respond!: () => void
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((resolve, reject) => {
+            respond = () => resolve(new Response('{}'))
+            init.signal?.addEventListener('abort', () =>
+              reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+            )
+          }),
+      ),
+    )
+
+    const pending = buildApp().request('/_proxy/agent/ws1/skills/big-skill/pack', {
+      method: 'POST',
+    })
+    await vi.advanceTimersByTimeAsync(30_000)
+    respond()
+    const res = await pending
+
+    expect(res.status).toBe(200)
+  })
+
   it('lets an SSE body outlive the deadline once headers have landed', async () => {
     vi.useFakeTimers()
     // Headers arrive immediately; the body stays open far longer than the

--- a/control-plane/src/routes/proxy.test.ts
+++ b/control-plane/src/routes/proxy.test.ts
@@ -2,9 +2,9 @@
  * Agent passthrough deadline.
  *
  * A workspace pod that has exhausted its memory still completes the TCP
- * handshake while its event loop is wedged, so the proxy's fetch never
- * settles and the browser request behind it hangs forever. That hang is what
- * froze the chat panel's session switch — and with it the new-session button.
+ * handshake while its event loop is wedged. Nothing but undici's 300s default
+ * ended such a request, and five minutes of a frozen session switch — and
+ * with it a dead new-session button — reads as broken.
  *
  * The deadline that fixes it must cover the response headers ONLY: SSE turns
  * flow through this same fetch, and a timer that stayed armed would sever

--- a/control-plane/src/routes/proxy.test.ts
+++ b/control-plane/src/routes/proxy.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Agent passthrough deadline.
+ *
+ * A workspace pod that has exhausted its memory still completes the TCP
+ * handshake while its event loop is wedged, so the proxy's fetch never
+ * settles and the browser request behind it hangs forever. That hang is what
+ * froze the chat panel's session switch — and with it the new-session button.
+ *
+ * The deadline that fixes it must cover the response headers ONLY: SSE turns
+ * flow through this same fetch, and a timer that stayed armed would sever
+ * every live stream once it expired. Both halves are pinned here.
+ */
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppEnv } from '../lib/types'
+
+const getWorkspace = vi.hoisted(() => vi.fn())
+
+vi.mock('../services/db/workspaces', () => ({ getWorkspace }))
+vi.mock('../lib/workspace-address', () => ({
+  resolveAgentAddress: () => 'http://agent-pod:8080',
+}))
+vi.mock('../lib/sse', () => ({
+  createInterceptedSSEResponse: vi.fn(),
+  createReconnectSSEResponse: vi.fn(),
+}))
+vi.mock('../services/db/sessions', () => ({ transitionSessionStatus: vi.fn() }))
+
+const { createProxyRoutes } = await import('./proxy')
+
+const WORKSPACE = { id: 'ws1', user_id: 'u1', status: 'running', is_system: false }
+
+/** Mount the proxy behind a stub auth middleware, as index.ts does. */
+function buildApp() {
+  const app = new Hono<AppEnv>()
+  app.use('*', async (c, next) => {
+    c.set('user', { sub: 'u1', role: 'user', username: 'u1', name: 'u1', exp: 0 })
+    await next()
+  })
+  app.route('/_proxy', createProxyRoutes())
+  return app
+}
+
+describe('agent proxy headers deadline', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    getWorkspace.mockReset()
+    getWorkspace.mockResolvedValue(WORKSPACE)
+  })
+
+  it('answers 504 when the pod never produces headers', async () => {
+    vi.useFakeTimers()
+    // A wedged pod: connection accepted, response never begins. Only an
+    // abort ends this promise.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () =>
+              reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+            )
+          }),
+      ),
+    )
+
+    const pending = buildApp().request('/_proxy/agent/ws1/sessions/s1/pending-question')
+    await vi.advanceTimersByTimeAsync(10_000)
+    const res = await pending
+
+    expect(res.status).toBe(504)
+    expect((await res.json()).error).toMatch(/did not respond/i)
+  })
+
+  it('lets an SSE body outlive the deadline once headers have landed', async () => {
+    vi.useFakeTimers()
+    // Headers arrive immediately; the body stays open far longer than the
+    // deadline, which is exactly what a live turn looks like.
+    let push!: (chunk: string) => void
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        push = (chunk) => controller.enqueue(new TextEncoder().encode(chunk))
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { headers: { 'Content-Type': 'text/event-stream' } })),
+    )
+
+    const res = await buildApp().request('/_proxy/agent/ws1/sessions/s1/stream')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+
+    // Well past the deadline — had the timer stayed armed, this abort would
+    // have destroyed the stream mid-turn.
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    push('data: still-alive\n\n')
+    const reader = res.body!.getReader()
+    const { value } = await reader.read()
+    expect(new TextDecoder().decode(value)).toContain('still-alive')
+  })
+})

--- a/control-plane/src/routes/proxy.test.ts
+++ b/control-plane/src/routes/proxy.test.ts
@@ -65,7 +65,7 @@ describe('agent proxy headers deadline', () => {
     )
 
     const pending = buildApp().request('/_proxy/agent/ws1/sessions/s1/pending-question')
-    await vi.advanceTimersByTimeAsync(10_000)
+    await vi.advanceTimersByTimeAsync(30_000)
     const res = await pending
 
     expect(res.status).toBe(504)
@@ -95,7 +95,7 @@ describe('agent proxy headers deadline', () => {
     const pending = buildApp().request('/_proxy/agent/ws1/skills/big-skill/pack', {
       method: 'POST',
     })
-    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(60_000)
     respond()
     const res = await pending
 

--- a/control-plane/src/routes/proxy.ts
+++ b/control-plane/src/routes/proxy.ts
@@ -11,16 +11,29 @@ function canAccessProxy(workspace: Workspace, user: { sub: string; role: string 
 }
 
 /**
- * How long the agent pod gets to produce response *headers*. A container that
- * has exhausted its memory keeps accepting connections while its event loop
- * is wedged, so without a deadline the fetch below — and the browser request
+ * How long the agent pod gets to start responding. A container that has
+ * exhausted its memory keeps accepting connections while its event loop is
+ * wedged, so without a deadline the fetch below — and the browser request
  * waiting on it — stays pending indefinitely.
  *
- * The deadline covers the headers only, never the body: SSE streams flow
- * through this same fetch, and aborting on a timer would sever every live
- * turn after 10s. See the clearTimeout in the handler.
+ * The deadline is disarmed as soon as `fetch` resolves, so it never touches a
+ * response body: SSE streams flow through this same fetch, and a timer left
+ * armed would sever every live turn when it expired.
+ *
+ * It does, however, cover the handler's whole runtime, not just connection
+ * setup — a JSON handler flushes headers only once it has a body to write. So
+ * the budget is per-path rather than global:
+ *
+ *   - `/sessions/*` (pending-question, respond, reconnect) are trivial reads,
+ *     and they are the ones the chat panel awaits while its session-switch
+ *     lock is held. A tight bound is what gets the UI unstuck quickly.
+ *   - Everything else can legitimately take a while — `skills/:name/pack`
+ *     tars a directory, and skill trees are many small files on NFS inside a
+ *     CPU-throttled pod. Bounding infinity is the goal here, not policing
+ *     latency, so this one is deliberately loose.
  */
-const AGENT_HEADERS_TIMEOUT_MS = 10_000
+const AGENT_SESSION_TIMEOUT_MS = 10_000
+const AGENT_DEFAULT_TIMEOUT_MS = 60_000
 
 export function createProxyRoutes() {
   const proxy = new Hono<AppEnv>()
@@ -83,15 +96,15 @@ export function createProxyRoutes() {
     if (destination) headers.set('Destination', destination)
 
     const clientSignal = c.req.raw.signal
-    // Arm the headers deadline against our own controller (chained to the
-    // client's signal so a disconnect still cancels), then disarm it the
-    // moment `fetch` resolves. Once disarmed the controller can no longer
-    // fire, so a streaming body — SSE included — is free to run as long as
-    // it likes.
+    // Arm the deadline against our own controller (chained to the client's
+    // signal so a disconnect still cancels), then disarm it the moment
+    // `fetch` resolves. Once disarmed the controller can no longer fire, so a
+    // streaming body — SSE included — is free to run as long as it likes.
+    const timeoutMs = sessionMatch ? AGENT_SESSION_TIMEOUT_MS : AGENT_DEFAULT_TIMEOUT_MS
     const ac = new AbortController()
     const onClientAbort = () => ac.abort()
     clientSignal.addEventListener('abort', onClientAbort, { once: true })
-    const headersDeadline = setTimeout(() => ac.abort(), AGENT_HEADERS_TIMEOUT_MS)
+    const responseDeadline = setTimeout(() => ac.abort(), timeoutMs)
     let response: Response
     try {
       response = await fetch(targetUrl, {
@@ -104,7 +117,7 @@ export function createProxyRoutes() {
       if (clientSignal.aborted) return new Response(null, { status: 499 })
       if (ac.signal.aborted) {
         console.error(
-          `[proxy] Agent did not respond within ${AGENT_HEADERS_TIMEOUT_MS}ms workspace=${workspaceId} path=${agentPath}`,
+          `[proxy] Agent did not respond within ${timeoutMs}ms workspace=${workspaceId} path=${agentPath}`,
         )
         return c.json({ error: 'Agent did not respond in time' }, 504)
       }
@@ -115,7 +128,7 @@ export function createProxyRoutes() {
       // wired for the whole request: a browser that disconnects mid-stream
       // must still cancel the upstream fetch, or the agent keeps producing
       // into a body nobody reads.
-      clearTimeout(headersDeadline)
+      clearTimeout(responseDeadline)
     }
 
     // SSE response: intercept for ASQ-answer reconnect, passthrough otherwise.

--- a/control-plane/src/routes/proxy.ts
+++ b/control-plane/src/routes/proxy.ts
@@ -13,8 +13,11 @@ function canAccessProxy(workspace: Workspace, user: { sub: string; role: string 
 /**
  * How long the agent pod gets to start responding. A container that has
  * exhausted its memory keeps accepting connections while its event loop is
- * wedged, so without a deadline the fetch below — and the browser request
- * waiting on it — stays pending indefinitely.
+ * wedged, and the only thing that ended such a request before was undici's
+ * default `headersTimeout` — 300s. Nothing upstream shortens it either: the
+ * ingress route for this service disables its response timeout, and a browser
+ * `fetch` has no deadline of its own. Five minutes of a frozen panel is
+ * indistinguishable from broken, hence an explicit budget.
  *
  * The deadline is disarmed as soon as `fetch` resolves, so it never touches a
  * response body: SSE streams flow through this same fetch, and a timer left

--- a/control-plane/src/routes/proxy.ts
+++ b/control-plane/src/routes/proxy.ts
@@ -10,6 +10,18 @@ function canAccessProxy(workspace: Workspace, user: { sub: string; role: string 
   return workspace.user_id === user.sub || (workspace.is_system && user.role === 'admin')
 }
 
+/**
+ * How long the agent pod gets to produce response *headers*. A container that
+ * has exhausted its memory keeps accepting connections while its event loop
+ * is wedged, so without a deadline the fetch below — and the browser request
+ * waiting on it — stays pending indefinitely.
+ *
+ * The deadline covers the headers only, never the body: SSE streams flow
+ * through this same fetch, and aborting on a timer would sever every live
+ * turn after 10s. See the clearTimeout in the handler.
+ */
+const AGENT_HEADERS_TIMEOUT_MS = 10_000
+
 export function createProxyRoutes() {
   const proxy = new Hono<AppEnv>()
 
@@ -71,18 +83,39 @@ export function createProxyRoutes() {
     if (destination) headers.set('Destination', destination)
 
     const clientSignal = c.req.raw.signal
+    // Arm the headers deadline against our own controller (chained to the
+    // client's signal so a disconnect still cancels), then disarm it the
+    // moment `fetch` resolves. Once disarmed the controller can no longer
+    // fire, so a streaming body — SSE included — is free to run as long as
+    // it likes.
+    const ac = new AbortController()
+    const onClientAbort = () => ac.abort()
+    clientSignal.addEventListener('abort', onClientAbort, { once: true })
+    const headersDeadline = setTimeout(() => ac.abort(), AGENT_HEADERS_TIMEOUT_MS)
     let response: Response
     try {
       response = await fetch(targetUrl, {
         method: c.req.method,
         headers,
         body,
-        signal: clientSignal,
+        signal: ac.signal,
       })
     } catch (e: any) {
       if (clientSignal.aborted) return new Response(null, { status: 499 })
+      if (ac.signal.aborted) {
+        console.error(
+          `[proxy] Agent did not respond within ${AGENT_HEADERS_TIMEOUT_MS}ms workspace=${workspaceId} path=${agentPath}`,
+        )
+        return c.json({ error: 'Agent did not respond in time' }, 504)
+      }
       console.error(`[proxy] Fetch failed workspace=${workspaceId} path=${agentPath}:`, e.message)
       return c.json({ error: 'Agent unavailable' }, 502)
+    } finally {
+      // Only the timer is disarmed here. The client-abort forwarding stays
+      // wired for the whole request: a browser that disconnects mid-stream
+      // must still cancel the upstream fetch, or the agent keeps producing
+      // into a body nobody reads.
+      clearTimeout(headersDeadline)
     }
 
     // SSE response: intercept for ASQ-answer reconnect, passthrough otherwise.

--- a/control-plane/src/routes/proxy.ts
+++ b/control-plane/src/routes/proxy.ts
@@ -32,11 +32,16 @@ function canAccessProxy(workspace: Workspace, user: { sub: string; role: string 
  *     lock is held. A tight bound is what gets the UI unstuck quickly.
  *   - Everything else can legitimately take a while — `skills/:name/pack`
  *     tars a directory, and skill trees are many small files on NFS inside a
- *     CPU-throttled pod. Bounding infinity is the goal here, not policing
- *     latency, so this one is deliberately loose.
+ *     CPU-throttled pod. Beating the 300s default is the goal here, not
+ *     policing latency, so this one is deliberately loose.
+ *
+ * Both tiers are set well above the slowest healthy call we know of. They can
+ * be tightened once production tells us what the real distribution looks
+ * like; starting loose means the first rollout cannot turn a slow-but-working
+ * request into a 504.
  */
-const AGENT_SESSION_TIMEOUT_MS = 10_000
-const AGENT_DEFAULT_TIMEOUT_MS = 60_000
+const AGENT_SESSION_TIMEOUT_MS = 30_000
+const AGENT_DEFAULT_TIMEOUT_MS = 180_000
 
 export function createProxyRoutes() {
   const proxy = new Hono<AppEnv>()

--- a/web/src/hooks/useSkillsBasePath.ts
+++ b/web/src/hooks/useSkillsBasePath.ts
@@ -1,3 +1,4 @@
+import { agentProxyFetch } from '@/lib/api/client'
 import { DEFAULT_SKILLS_BASE_PATH } from '@/lib/workspace-file-link'
 import { useQuery } from '@tanstack/react-query'
 
@@ -19,8 +20,8 @@ export function useSkillsBasePath(workspaceId: string | undefined, enabled: bool
     queryKey: skillsBasePathQueryKey(workspaceId ?? ''),
     queryFn: async () => {
       // Canonical agent skills endpoint (same as the skill browser uses).
-      const resp = await fetch(`/_proxy/agent/${workspaceId}/skills`, { credentials: 'include' })
-      if (!resp.ok) throw new Error(`fetch skills failed: ${resp.status}`)
+      const resp = await agentProxyFetch(`/_proxy/agent/${workspaceId}/skills`)
+      if (!resp?.ok) throw new Error(`fetch skills failed: ${resp?.status ?? 'unreachable'}`)
       const json = (await resp.json()) as { filesBrowsePath?: string }
       return json.filesBrowsePath ?? DEFAULT_SKILLS_BASE_PATH
     },

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -107,8 +107,8 @@ import type {
  * over NFS inside a throttled pod). These bound a hang; they do not police
  * latency, so the slow lane is deliberately loose.
  */
-const AGENT_SESSION_TIMEOUT_MS = 15_000
-const AGENT_PROXY_TIMEOUT_MS = 65_000
+const AGENT_SESSION_TIMEOUT_MS = 45_000
+const AGENT_PROXY_TIMEOUT_MS = 195_000
 
 /**
  * Read/write against a workspace's agent pod, via the control plane's

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -98,15 +98,20 @@ import type {
 } from './types'
 
 /**
- * Deadline for short reads proxied to a workspace's agent pod. Deliberately
- * generous versus the sub-second these endpoints normally take — it exists to
- * bound a wedged container, not to police latency. Kept above the control
- * plane's own proxy deadline so cp's 504 is what surfaces when it fires.
+ * Deadlines for calls proxied to a workspace's agent pod. Both sit just above
+ * the control plane's matching budget so its 504 is what surfaces when a pod
+ * is wedged, rather than a bare client-side abort.
+ *
+ * Split for the same reason cp splits: `/sessions/*` handlers are trivial
+ * reads, while the rest can legitimately grind (packing a skill directory
+ * over NFS inside a throttled pod). These bound a hang; they do not police
+ * latency, so the slow lane is deliberately loose.
  */
-const AGENT_PROXY_TIMEOUT_MS = 15_000
+const AGENT_SESSION_TIMEOUT_MS = 15_000
+const AGENT_PROXY_TIMEOUT_MS = 65_000
 
 /**
- * Short read/write against a workspace's agent pod, via the control plane's
+ * Read/write against a workspace's agent pod, via the control plane's
  * `/_proxy/agent` passthrough. These bypass `request()` because each caller
  * wants its own take on failure (null vs throw), but they share the part
  * that matters: a bounded wait.
@@ -119,12 +124,16 @@ const AGENT_PROXY_TIMEOUT_MS = 15_000
  * Transport failure and a tripped deadline both resolve to `null`, which
  * every caller already handles as part of its non-ok branch.
  */
-export async function agentProxyFetch(url: string, init?: RequestInit): Promise<Response | null> {
+export async function agentProxyFetch(
+  url: string,
+  init?: RequestInit & { timeoutMs?: number },
+): Promise<Response | null> {
+  const { timeoutMs = AGENT_PROXY_TIMEOUT_MS, ...rest } = init ?? {}
   try {
     return await fetch(url, {
       credentials: 'include',
-      ...init,
-      signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
+      ...rest,
+      signal: AbortSignal.timeout(timeoutMs),
     })
   } catch {
     return null
@@ -474,6 +483,7 @@ class ApiClient {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ requestId, answers }),
+      timeoutMs: AGENT_SESSION_TIMEOUT_MS,
     })
     if (!response?.ok) {
       throw new Error(i18n.t('session.errors.respondQuestionFailed'))
@@ -487,7 +497,7 @@ class ApiClient {
     // the panel usable — `switchSession` awaits this alongside the history
     // load, so a hang here is what froze the whole session switch. The
     // question re-appears on the next poll once the pod recovers.
-    const response = await agentProxyFetch(url)
+    const response = await agentProxyFetch(url, { timeoutMs: AGENT_SESSION_TIMEOUT_MS })
     if (!response?.ok) return null
     return (await response.json()) ?? null
   }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -98,6 +98,40 @@ import type {
 } from './types'
 
 /**
+ * Deadline for short reads proxied to a workspace's agent pod. Deliberately
+ * generous versus the sub-second these endpoints normally take — it exists to
+ * bound a wedged container, not to police latency. Kept above the control
+ * plane's own proxy deadline so cp's 504 is what surfaces when it fires.
+ */
+const AGENT_PROXY_TIMEOUT_MS = 15_000
+
+/**
+ * Short read/write against a workspace's agent pod, via the control plane's
+ * `/_proxy/agent` passthrough. These bypass `request()` because each caller
+ * wants its own take on failure (null vs throw), but they share the part
+ * that matters: a bounded wait.
+ *
+ * A container that has exhausted its memory still completes the TCP
+ * handshake while its event loop is wedged, so an unbounded fetch here never
+ * settles — and an unsettled promise is what left the chat panel stuck in
+ * its switching lock, silently disabling the new-session button.
+ *
+ * Transport failure and a tripped deadline both resolve to `null`, which
+ * every caller already handles as part of its non-ok branch.
+ */
+export async function agentProxyFetch(url: string, init?: RequestInit): Promise<Response | null> {
+  try {
+    return await fetch(url, {
+      credentials: 'include',
+      ...init,
+      signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
+    })
+  } catch {
+    return null
+  }
+}
+
+/**
  * Error subclass that preserves the parsed JSON body of a 4xx/5xx response,
  * so callers can read structured fields (e.g. template link-acl `missing[]`)
  * instead of having to string-parse the English message.
@@ -436,13 +470,12 @@ class ApiClient {
     answers: Record<string, string>,
   ): Promise<{ success: boolean }> {
     const url = `/_proxy/agent/${workspaceId}/sessions/${encodeURIComponent(sessionId)}/respond`
-    const response = await fetch(url, {
+    const response = await agentProxyFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ requestId, answers }),
-      credentials: 'include',
     })
-    if (!response.ok) {
+    if (!response?.ok) {
       throw new Error(i18n.t('session.errors.respondQuestionFailed'))
     }
     return response.json()
@@ -450,8 +483,12 @@ class ApiClient {
 
   async getPendingQuestion(workspaceId: string, sessionId: string): Promise<AskUserRequest | null> {
     const url = `/_proxy/agent/${workspaceId}/sessions/${encodeURIComponent(sessionId)}/pending-question`
-    const response = await fetch(url, { credentials: 'include' })
-    if (!response.ok) return null
+    // Degrading to "no pending question" when the pod is unreachable keeps
+    // the panel usable — `switchSession` awaits this alongside the history
+    // load, so a hang here is what froze the whole session switch. The
+    // question re-appears on the next poll once the pod recovers.
+    const response = await agentProxyFetch(url)
+    if (!response?.ok) return null
     return (await response.json()) ?? null
   }
 
@@ -1857,8 +1894,8 @@ class ApiClient {
   // Agent info
   async getAgentInfo(workspaceId: string): Promise<AgentInfo | null> {
     const url = `/_proxy/agent/${workspaceId}/info`
-    const response = await fetch(url, { credentials: 'include' })
-    if (!response.ok) return null
+    const response = await agentProxyFetch(url)
+    if (!response?.ok) return null
     return response.json()
   }
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -117,9 +117,11 @@ const AGENT_PROXY_TIMEOUT_MS = 65_000
  * that matters: a bounded wait.
  *
  * A container that has exhausted its memory still completes the TCP
- * handshake while its event loop is wedged, so an unbounded fetch here never
- * settles — and an unsettled promise is what left the chat panel stuck in
- * its switching lock, silently disabling the new-session button.
+ * handshake while its event loop is wedged. A browser `fetch` has no deadline
+ * of its own, so these calls used to hang until the control plane gave up on
+ * its side — five minutes, on undici's default. That is long enough to leave
+ * the chat panel stuck in its switching lock, silently disabling the
+ * new-session button, for as long as anyone would keep looking at it.
  *
  * Transport failure and a tripped deadline both resolve to `null`, which
  * every caller already handles as part of its non-ok branch.


### PR DESCRIPTION
## Root cause

A workspace container that exhausts its memory keeps completing the TCP handshake while its event loop is dead. Requests to such a pod were bounded only by undici's default `headersTimeout` — 300s — and nothing upstream shortened that: the ingress route for this service disables its response timeout, and the browser calls below set no deadline of their own.

`switchSession` awaits `Promise.allSettled([getWorkspaceMessages, getPendingQuestion, getSession])`, and `getPendingQuestion` is the one that proxies to the pod. So a single wedged container held that promise for five minutes, keeping the chat panel in its `isSwitching` lock and `isSessionLocked` true throughout. The new-session button is both `disabled` and guarded by an early return in its click handler, which explains the two reported symptoms together: the button does nothing, and devtools shows no request at all.

Five minutes is not permanent, but it is indistinguishable from broken — and restarting the workspace does not help, because it replaces the container, not the pending promise in the open tab. Only a page refresh did.

## Changes

**Control plane.** The proxy arms its own `AbortController` before the fetch and disarms it the moment the fetch resolves; a tripped deadline answers 504.

Disarming is the load-bearing part: SSE turns flow through this same fetch (the reconnect path streams `text/event-stream` straight through), so a timer left armed would sever every live stream once it expired. Client-abort forwarding stays wired for the whole request, so a browser that disconnects mid-stream still cancels upstream instead of leaving the agent producing into a body nobody reads.

The budget is per-path, because the deadline covers the handler's whole runtime rather than connection setup — a JSON or tarball handler flushes headers only once it has bytes to write:

- `/sessions/*` (pending-question, respond, reconnect) — 30s. Trivial reads, and the ones the chat panel awaits while holding its switch lock, so a quick unstick is worth more than patience.
- everything else — 180s. `skills/:name/pack` tars a directory of many small files over NFS inside a CPU-throttled pod and can legitimately take a while. The goal is beating the 300s default, not policing latency.

Both tiers are deliberately loose for a first rollout: the win is the distance from 300s, not how tight the bound is, and a cluster whose real latency distribution we have not measured should not have slow-but-healthy requests turned into 504s. Tighten later from production evidence.

**Web.** The three agent-proxy calls that bypassed the shared `request()` helper (`getPendingQuestion`, `respondToQuestion`, `getAgentInfo`) now go through one `agentProxyFetch` that mirrors the split — 45s for the session calls, 195s otherwise, each tier above its control-plane counterpart so the 504 surfaces rather than a bare client abort. Transport failure folds into the non-ok branch each caller already had. `useSkillsBasePath` was doing the same raw fetch and joins them.

Once a deadline trips, the fetch rejects, `allSettled` settles, and the existing tail of `switchSession` clears `isSwitching` — the UI unlocks on its own. A timed-out `getPendingQuestion` costs at most one poll's worth of pending-question display.

## Verification

`control-plane/src/routes/proxy.test.ts` is new and pins the three properties a future refactor is most likely to break:

- a wedged pod yields 504
- an SSE body keeps streaming past the deadline (a chunk pushed after advancing fake timers 60s still arrives) — catches re-arming the timer for the whole request
- a non-session path survives well past the session budget — catches collapsing the two tiers back into one

control-plane: 357 tests pass. `tsc --noEmit` clean in control-plane and web; biome clean.

## Known coverage gap

"Client disconnect yields 499" is not covered by a test: Hono's `app.request()` does not propagate a caller-supplied signal to `c.req.raw.signal`, so it cannot be exercised at that level. Rather than ship a test that pretends to check it, the behavior is left to code review.