### PR TITLE
feat(wecom): add /cancel to interrupt the running turn

### DIFF
--- a/channel-gateway/src/connectors/wecom.ts
+++ b/channel-gateway/src/connectors/wecom.ts
@@ -452,6 +452,25 @@ async function handleMessage(
     console.log(`[WeCom] ${connector.name}: no route for chat=${chatId}, ignoring`)
     return
   }
+  const activeRoute = route
+
+  // Act as the route owner (route.user_id), not the connector owner. Every
+  // call below targets route.workspace_id; with a shared connector whose route
+  // points at another user's workspace, calling cp as the connector owner gets
+  // scoped out → 404 "Workspace not found". Reuse the connector client when
+  // owners match to avoid an extra token lookup per message. Null means the
+  // route owner has no platform token — already logged, caller should bail.
+  const resolveRouteClient = async (): Promise<NapClient | null> => {
+    if (activeRoute.user_id === connector.user_id) return napClient
+    const routeToken = await db.getPlatformToken(activeRoute.user_id)
+    if (!routeToken) {
+      console.error(
+        `[WeCom] ${connector.name}: no platform token for route owner=${activeRoute.user_id}`,
+      )
+      return null
+    }
+    return new NapClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
+  }
 
   // Voice transcription failure → reply error and abort. Do this only when a
   // voice segment was actually present; otherwise voiceError stays null.
@@ -503,6 +522,57 @@ async function handleMessage(
     return
   }
 
+  // Intercept /cancel the same way. Interrupting has to bypass the job queue
+  // to be worth anything: inbound messages are serialized behind the running
+  // turn, so a queued interrupt would only arrive after the thing it meant to
+  // stop had finished. Going straight to cp reaches the turn that is actually
+  // in flight.
+  //
+  // The user's follow-up then resumes the same session normally, keeping the
+  // history — which is the point: cancel exists so a wrong IP or a missing
+  // detail can be corrected without starting over. Whatever the interrupted
+  // turn had produced so far is discarded, which is the desired outcome here.
+  if (cleanText === '/cancel') {
+    const sessionId = await db.getThreadSessionId(route.id, chatId)
+    let ack = 'No active session.'
+    if (sessionId) {
+      const client = await resolveRouteClient()
+      if (!client) return
+      try {
+        await client.sessions.interrupt(route.workspace_id, sessionId)
+        ack = 'Cancelled. Send your correction and I will continue from here.'
+      } catch (e) {
+        // A turn that already finished is the common case, not a failure —
+        // the user pressed cancel a moment too late. Say so plainly instead
+        // of surfacing an API error.
+        console.warn(`[WeCom] ${connector.name}: /cancel failed session=${sessionId}:`, e)
+        ack = 'Nothing to cancel — the current turn already finished.'
+      }
+    }
+    console.log(
+      `[WeCom] ${connector.name}: /cancel from=${from} chat=${chatId} session=${sessionId ?? 'none'}`,
+    )
+    try {
+      await wecomSend(connector, route, ack, { chat_id: chatId, req_id: reqId })
+    } catch (e) {
+      console.warn(`[WeCom] ${connector.name}: failed to ack /cancel:`, e)
+    }
+    await db.logEvent({
+      route_id: route.id,
+      connector_id: connector.id,
+      event_type: 'mention',
+      payload: {
+        user: from,
+        chat_id: chatId,
+        text: content,
+        command: '/cancel',
+        session_id: sessionId,
+      },
+      status: 'success',
+    })
+    return
+  }
+
   const promptTemplate = (route.config as Record<string, unknown>)?.prompt as string | undefined
   // Expose sender / chat metadata to the agent. The aibot WS callback only
   // ships `from.userid` (no name/email), so {user} is the most specific
@@ -537,20 +607,8 @@ async function handleMessage(
     )
   }
 
-  // Create the job as the route owner (route.user_id), not the connector owner.
-  // The job targets route.workspace_id; with a shared connector whose route
-  // points at another user's workspace, calling cp as the connector owner gets
-  // scoped out → 404 "Workspace not found". Reuse the connector client when
-  // owners match to avoid an extra token lookup per message.
-  let jobClient = napClient
-  if (route.user_id !== connector.user_id) {
-    const routeToken = await db.getPlatformToken(route.user_id)
-    if (!routeToken) {
-      console.error(`[WeCom] ${connector.name}: no platform token for route owner=${route.user_id}`)
-      return
-    }
-    jobClient = new NapClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
-  }
+  const jobClient = await resolveRouteClient()
+  if (!jobClient) return
 
   try {
     const result = await jobClient.jobs.create(route.workspace_id, {

--- a/channel-gateway/src/services/db.ts
+++ b/channel-gateway/src/services/db.ts
@@ -528,6 +528,24 @@ export async function getThreadSessionCursor(
   return rows[0]?.cursor_ts ?? null
 }
 
+/** Resolve the agent session a chat thread is currently bound to, if any.
+ *
+ *  Interrupting needs the session, not just the workspace: a workspace can be
+ *  the target of several routes and chats at once, and `workspaces.interrupt`
+ *  would stop whichever turns happen to be running — including other people's.
+ */
+export async function getThreadSessionId(
+  routeId: string,
+  threadId: string,
+): Promise<string | null> {
+  const { rows } = await pool.query(
+    `SELECT session_id FROM channel.thread_sessions
+     WHERE route_id = $1 AND external_thread_id = $2`,
+    [routeId, threadId],
+  )
+  return rows[0]?.session_id ?? null
+}
+
 /** Delete the thread_sessions row so the next message starts a fresh session.
  *  Returns true if a row was deleted. */
 export async function deleteThreadSession(routeId: string, threadId: string): Promise<boolean> {


### PR DESCRIPTION
## Why

A user watching an agent work in chat has no way to stop it. Inbound messages are serialized behind the turn already in flight, so noticing a wrong parameter halfway through does not help — the correction is only picked up after the run it was meant to correct has finished. In practice that means waiting out a long wrong answer, then starting the exchange again.

The platform has had interrupt support all along (all three agent cores and the control plane implement it); only the web client ever called it.

## What

`/cancel` joins `/new` as a connector-level intercept. That placement is what makes it work: commands are handled before the job queue, so the interrupt reaches the turn that is actually running instead of queueing behind it. The user's next message then resumes the same session with its history intact — which is the point, since cancel exists so a wrong host or a missing detail can be corrected without starting over. Whatever the interrupted turn had produced is discarded, which is the desired outcome in these cases.

Two details worth calling out:

- **Interrupt targets the session, not the workspace.** A workspace can back several routes and chats at once, so `workspaces.interrupt` would stop whichever turns happen to be running, including other users'. The thread → session mapping already exists; this adds the forward lookup for it.
- **A failed interrupt is not an error.** Pressing cancel a moment after the turn completed is the common case, so it acknowledges with "nothing to cancel" rather than surfacing an API failure.

The route-owner client resolution moves into a helper, because `/cancel` needs the same ownership rules job creation already had: act as the route owner, or a shared connector whose route points at another user's workspace gets scoped out to a 404.

## Scope

WeCom only, matching where the command surface exists — the Slack connector has no `/new` either, so there is no established intercept point to extend there. Neither command is documented in docs-site today; this keeps that consistent rather than documenting one of the pair.

## Verification

`tsc --noEmit` and the existing channel-gateway suite (21 tests) pass; biome clean.

No new tests: `handleMessage` is not exported and the connector has no harness for it — the suite here covers exported pure helpers only. Building that harness is a larger change than the feature. The pieces this leans on are already exercised elsewhere (`sessions.interrupt` in the control plane, the `/new` intercept shape it mirrors), but the new path itself is verified by review and manual use rather than by test.