### PR TITLE
feat(slack): support /cancel, and share the route-client resolution

### DIFF
--- a/channel-gateway/src/connectors/slack.ts
+++ b/channel-gateway/src/connectors/slack.ts
@@ -2,6 +2,7 @@ import { SocketModeClient } from '@slack/socket-mode'
 import { WebClient } from '@slack/web-api'
 import pMap from 'p-map'
 import { NapClient } from '../../../internal/client/src/index'
+import { cancelThreadTurn } from '../lib/cancel-command'
 import { resolveRouteClient } from '../lib/route-client'
 import * as db from '../services/db'
 
@@ -368,49 +369,24 @@ Indexes are 1-based and match the attached images order.
 
     let cleanText = botUserId ? text.replace(new RegExp(`<@${botUserId}>`, 'g'), '').trim() : text
 
-    // Intercept /cancel before any of the work below. Interrupting has to
-    // bypass the job queue to be worth anything: inbound messages are
-    // serialized behind the running turn, so a queued interrupt would only
-    // arrive after the thing it meant to stop had finished. Going straight to
-    // cp reaches the turn that is actually in flight.
+    // Intercept /cancel before any of the work below — the thread-context
+    // fetch, the status update and the image downloads are all wasted for a
+    // command, and skipping them also keeps `/cancel` out of the context the
+    // agent later reads back.
     //
     // Unlike /new — which WeCom needs because its group chat is one flat
     // conversation — this has no natural equivalent here: starting a new
     // thread sidesteps a running turn but cannot stop it, and abandons the
     // context the user wants to keep.
-    //
-    // The follow-up message then resumes the same session with its history,
-    // which is the point: cancel exists so a wrong host or a missing detail
-    // can be corrected without starting over. Whatever the interrupted turn
-    // had produced so far is discarded, which is the desired outcome.
     if (cleanText === '/cancel') {
-      const sessionId = await db.getThreadSessionId(route.id, threadTs)
-      let ack = 'No active session in this thread.'
-      if (sessionId) {
-        const client = await resolveRouteClient(
-          `[Slack] ${connector.name}`,
-          route,
-          connector,
-          napClient,
-        )
-        if (!client) return
-        try {
-          // Interrupt the session, not the workspace: a workspace can back
-          // several routes and threads at once, and workspaces.interrupt
-          // would stop other people's turns along with this one.
-          await client.sessions.interrupt(route.workspace_id, sessionId)
-          ack = 'Cancelled. Send your correction and I will continue from here.'
-        } catch (e) {
-          // A turn that already finished is the common case, not a failure —
-          // the user pressed cancel a moment too late. Say so plainly instead
-          // of surfacing an API error.
-          console.warn(`[Slack] ${connector.name}: /cancel failed session=${sessionId}:`, e)
-          ack = 'Nothing to cancel — the current turn already finished.'
-        }
-      }
-      console.log(
-        `[Slack] ${connector.name}: /cancel user=${user} thread=${threadTs} session=${sessionId ?? 'none'}`,
+      const ack = await cancelThreadTurn(
+        `[Slack] ${connector.name}`,
+        route,
+        connector,
+        napClient,
+        threadTs,
       )
+      if (ack === null) return
       await web.chat
         .postMessage({ channel, thread_ts: threadTs, text: ack })
         .catch((e) => console.warn(`[Slack] ${connector.name}: failed to ack /cancel:`, e))

--- a/channel-gateway/src/connectors/slack.ts
+++ b/channel-gateway/src/connectors/slack.ts
@@ -2,6 +2,7 @@ import { SocketModeClient } from '@slack/socket-mode'
 import { WebClient } from '@slack/web-api'
 import pMap from 'p-map'
 import { NapClient } from '../../../internal/client/src/index'
+import { resolveRouteClient } from '../lib/route-client'
 import * as db from '../services/db'
 
 const NAP_API_URL = process.env.NAP_API_URL || 'http://localhost:3000'
@@ -367,6 +368,55 @@ Indexes are 1-based and match the attached images order.
 
     let cleanText = botUserId ? text.replace(new RegExp(`<@${botUserId}>`, 'g'), '').trim() : text
 
+    // Intercept /cancel before any of the work below. Interrupting has to
+    // bypass the job queue to be worth anything: inbound messages are
+    // serialized behind the running turn, so a queued interrupt would only
+    // arrive after the thing it meant to stop had finished. Going straight to
+    // cp reaches the turn that is actually in flight.
+    //
+    // Unlike /new — which WeCom needs because its group chat is one flat
+    // conversation — this has no natural equivalent here: starting a new
+    // thread sidesteps a running turn but cannot stop it, and abandons the
+    // context the user wants to keep.
+    //
+    // The follow-up message then resumes the same session with its history,
+    // which is the point: cancel exists so a wrong host or a missing detail
+    // can be corrected without starting over. Whatever the interrupted turn
+    // had produced so far is discarded, which is the desired outcome.
+    if (cleanText === '/cancel') {
+      const sessionId = await db.getThreadSessionId(route.id, threadTs)
+      let ack = 'No active session in this thread.'
+      if (sessionId) {
+        const client = await resolveRouteClient(
+          `[Slack] ${connector.name}`,
+          route,
+          connector,
+          napClient,
+        )
+        if (!client) return
+        try {
+          // Interrupt the session, not the workspace: a workspace can back
+          // several routes and threads at once, and workspaces.interrupt
+          // would stop other people's turns along with this one.
+          await client.sessions.interrupt(route.workspace_id, sessionId)
+          ack = 'Cancelled. Send your correction and I will continue from here.'
+        } catch (e) {
+          // A turn that already finished is the common case, not a failure —
+          // the user pressed cancel a moment too late. Say so plainly instead
+          // of surfacing an API error.
+          console.warn(`[Slack] ${connector.name}: /cancel failed session=${sessionId}:`, e)
+          ack = 'Nothing to cancel — the current turn already finished.'
+        }
+      }
+      console.log(
+        `[Slack] ${connector.name}: /cancel user=${user} thread=${threadTs} session=${sessionId ?? 'none'}`,
+      )
+      await web.chat
+        .postMessage({ channel, thread_ts: threadTs, text: ack })
+        .catch((e) => console.warn(`[Slack] ${connector.name}: failed to ack /cancel:`, e))
+      return
+    }
+
     const images = await fetchImageAttachments(event)
 
     // Voice clips: prefer Slack's built-in transcript, otherwise fall back to
@@ -431,22 +481,13 @@ Indexes are 1-based and match the attached images order.
     // Chat API requires non-empty message; substitute a placeholder when the user sent only images.
     if (!cleanText && allImages.length) cleanText = '[image]'
 
-    // Create the job as the route owner (route.user_id), not the connector
-    // owner. The job targets route.workspace_id; with a shared connector whose
-    // route points at another user's workspace, calling cp as the connector
-    // owner gets scoped out → 404 "Workspace not found". Reuse the connector
-    // client when owners match to avoid an extra token lookup per message.
-    let jobClient = napClient
-    if (route.user_id !== connector.user_id) {
-      const routeToken = await db.getPlatformToken(route.user_id)
-      if (!routeToken) {
-        console.error(
-          `[Slack] ${connector.name}: no platform token for route owner=${route.user_id}`,
-        )
-        return
-      }
-      jobClient = new NapClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
-    }
+    const jobClient = await resolveRouteClient(
+      `[Slack] ${connector.name}`,
+      route,
+      connector,
+      napClient,
+    )
+    if (!jobClient) return
 
     try {
       const result = await jobClient.jobs.create(route.workspace_id, {

--- a/channel-gateway/src/connectors/wecom.ts
+++ b/channel-gateway/src/connectors/wecom.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto'
 import WebSocket from 'ws'
 import { NapClient } from '../../../internal/client/src/index'
+import { cancelThreadTurn } from '../lib/cancel-command'
 import { resolveRouteClient } from '../lib/route-client'
 import * as db from '../services/db'
 import { handleRespondAck, wecomSend, wecomSendStream } from './wecom-sender'
@@ -505,41 +506,17 @@ async function handleMessage(
     return
   }
 
-  // Intercept /cancel the same way. Interrupting has to bypass the job queue
-  // to be worth anything: inbound messages are serialized behind the running
-  // turn, so a queued interrupt would only arrive after the thing it meant to
-  // stop had finished. Going straight to cp reaches the turn that is actually
-  // in flight.
-  //
-  // The user's follow-up then resumes the same session normally, keeping the
-  // history — which is the point: cancel exists so a wrong IP or a missing
-  // detail can be corrected without starting over. Whatever the interrupted
-  // turn had produced so far is discarded, which is the desired outcome here.
+  // Intercept /cancel the same way, before the job queue — see
+  // cancelThreadTurn for why that placement is what makes it work.
   if (cleanText === '/cancel') {
-    const sessionId = await db.getThreadSessionId(route.id, chatId)
-    let ack = 'No active session.'
-    if (sessionId) {
-      const client = await resolveRouteClient(
-        `[WeCom] ${connector.name}`,
-        activeRoute,
-        connector,
-        napClient,
-      )
-      if (!client) return
-      try {
-        await client.sessions.interrupt(route.workspace_id, sessionId)
-        ack = 'Cancelled. Send your correction and I will continue from here.'
-      } catch (e) {
-        // A turn that already finished is the common case, not a failure —
-        // the user pressed cancel a moment too late. Say so plainly instead
-        // of surfacing an API error.
-        console.warn(`[WeCom] ${connector.name}: /cancel failed session=${sessionId}:`, e)
-        ack = 'Nothing to cancel — the current turn already finished.'
-      }
-    }
-    console.log(
-      `[WeCom] ${connector.name}: /cancel from=${from} chat=${chatId} session=${sessionId ?? 'none'}`,
+    const ack = await cancelThreadTurn(
+      `[WeCom] ${connector.name}`,
+      activeRoute,
+      connector,
+      napClient,
+      chatId,
     )
+    if (ack === null) return
     try {
       await wecomSend(connector, route, ack, { chat_id: chatId, req_id: reqId })
     } catch (e) {
@@ -549,13 +526,7 @@ async function handleMessage(
       route_id: route.id,
       connector_id: connector.id,
       event_type: 'mention',
-      payload: {
-        user: from,
-        chat_id: chatId,
-        text: content,
-        command: '/cancel',
-        session_id: sessionId,
-      },
+      payload: { user: from, chat_id: chatId, text: content, command: '/cancel' },
       status: 'success',
     })
     return

--- a/channel-gateway/src/connectors/wecom.ts
+++ b/channel-gateway/src/connectors/wecom.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto'
 import WebSocket from 'ws'
 import { NapClient } from '../../../internal/client/src/index'
+import { resolveRouteClient } from '../lib/route-client'
 import * as db from '../services/db'
 import { handleRespondAck, wecomSend, wecomSendStream } from './wecom-sender'
 
@@ -454,24 +455,6 @@ async function handleMessage(
   }
   const activeRoute = route
 
-  // Act as the route owner (route.user_id), not the connector owner. Every
-  // call below targets route.workspace_id; with a shared connector whose route
-  // points at another user's workspace, calling cp as the connector owner gets
-  // scoped out → 404 "Workspace not found". Reuse the connector client when
-  // owners match to avoid an extra token lookup per message. Null means the
-  // route owner has no platform token — already logged, caller should bail.
-  const resolveRouteClient = async (): Promise<NapClient | null> => {
-    if (activeRoute.user_id === connector.user_id) return napClient
-    const routeToken = await db.getPlatformToken(activeRoute.user_id)
-    if (!routeToken) {
-      console.error(
-        `[WeCom] ${connector.name}: no platform token for route owner=${activeRoute.user_id}`,
-      )
-      return null
-    }
-    return new NapClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
-  }
-
   // Voice transcription failure → reply error and abort. Do this only when a
   // voice segment was actually present; otherwise voiceError stays null.
   if (hadVoiceSeg && voiceError) {
@@ -536,7 +519,12 @@ async function handleMessage(
     const sessionId = await db.getThreadSessionId(route.id, chatId)
     let ack = 'No active session.'
     if (sessionId) {
-      const client = await resolveRouteClient()
+      const client = await resolveRouteClient(
+        `[WeCom] ${connector.name}`,
+        activeRoute,
+        connector,
+        napClient,
+      )
       if (!client) return
       try {
         await client.sessions.interrupt(route.workspace_id, sessionId)
@@ -607,7 +595,12 @@ async function handleMessage(
     )
   }
 
-  const jobClient = await resolveRouteClient()
+  const jobClient = await resolveRouteClient(
+    `[WeCom] ${connector.name}`,
+    activeRoute,
+    connector,
+    napClient,
+  )
   if (!jobClient) return
 
   try {

--- a/channel-gateway/src/lib/cancel-command.ts
+++ b/channel-gateway/src/lib/cancel-command.ts
@@ -1,0 +1,50 @@
+import type { NapClient } from '../../../internal/client/src/index'
+import * as db from '../services/db'
+import { resolveRouteClient } from './route-client'
+
+/**
+ * Interrupt the turn running in a chat thread, for the `/cancel` command.
+ *
+ * Connectors intercept `/cancel` before the job queue on purpose: inbound
+ * messages are serialized behind the running turn, so a queued interrupt would
+ * only arrive after the thing it meant to stop had finished. Going straight to
+ * cp reaches the turn that is actually in flight. The user's follow-up then
+ * resumes the same session with its history — cancel exists so a wrong host or
+ * a missing detail can be corrected without starting over, and whatever the
+ * interrupted turn had produced is discarded, which is the point.
+ *
+ * Returns the text to acknowledge with — each connector delivers it its own
+ * way — or null when the route owner has no platform token, in which case the
+ * caller should bail quietly (already logged).
+ */
+export async function cancelThreadTurn(
+  label: string,
+  route: db.Route,
+  connector: db.Connector,
+  connectorClient: NapClient,
+  threadId: string,
+): Promise<string | null> {
+  const sessionId = await db.getThreadSessionId(route.id, threadId)
+  if (!sessionId) {
+    console.log(`${label}: /cancel thread=${threadId} session=none`)
+    return 'No active session.'
+  }
+
+  const client = await resolveRouteClient(label, route, connector, connectorClient)
+  if (!client) return null
+
+  try {
+    // Interrupt the session, not the workspace: one workspace can back several
+    // routes and threads at once, and `workspaces.interrupt` would stop other
+    // people's turns along with this one.
+    await client.sessions.interrupt(route.workspace_id, sessionId)
+    console.log(`${label}: /cancel thread=${threadId} session=${sessionId}`)
+    return 'Cancelled. Send your correction and I will continue from here.'
+  } catch (e) {
+    // A turn that already finished is the common case, not a failure — the
+    // user pressed cancel a moment too late. Say so plainly instead of
+    // surfacing an API error.
+    console.warn(`${label}: /cancel failed session=${sessionId}:`, e)
+    return 'Nothing to cancel — the current turn already finished.'
+  }
+}

--- a/channel-gateway/src/lib/route-client.ts
+++ b/channel-gateway/src/lib/route-client.ts
@@ -1,0 +1,32 @@
+import { NapClient } from '../../../internal/client/src/index'
+import * as db from '../services/db'
+
+const NAP_API_URL = process.env.NAP_API_URL || 'http://localhost:3000'
+
+/**
+ * Build the platform client to act as when serving a route.
+ *
+ * Every call a connector makes targets `route.workspace_id`, so it has to run
+ * as the route owner rather than the connector owner: a shared connector whose
+ * route points at another user's workspace gets scoped out to a 404
+ * "Workspace not found" otherwise. When the owners match — the common case —
+ * the connector's own client is reused so the hot path costs no extra token
+ * lookup.
+ *
+ * Returns null when the route owner has no platform token. That is logged
+ * here; callers should bail quietly.
+ */
+export async function resolveRouteClient(
+  label: string,
+  route: { user_id: string },
+  connector: { user_id: string },
+  connectorClient: NapClient,
+): Promise<NapClient | null> {
+  if (route.user_id === connector.user_id) return connectorClient
+  const routeToken = await db.getPlatformToken(route.user_id)
+  if (!routeToken) {
+    console.error(`${label}: no platform token for route owner=${route.user_id}`)
+    return null
+  }
+  return new NapClient({ baseUrl: NAP_API_URL, serviceToken: routeToken })
+}


### PR DESCRIPTION
Follow-up to #205, which added `/cancel` to WeCom.

## Why Slack needs this one but not `/new`

The Slack connector has no command intercept at all. For `/new` that is defensible: Slack keys sessions on `thread_ts`, so starting a new thread already starts a new session. WeCom's group chat is one flat conversation, which is why the command exists there.

`/cancel` has no such equivalent. Opening a new thread sidesteps a running turn but cannot stop it, and abandons the context the user wants to keep — so a Slack user who spots a wrong parameter mid-run is stuck waiting it out, exactly as WeCom users were before #205.

## Placement

The intercept sits right after the mention strip, ahead of the thread-context fetch, the thread status update and the image downloads. None of that work is wanted for a command, and doing it first would mean paying for a thread history round-trip to answer "cancelled". Skipping it also keeps `/cancel` out of the context the agent later reads back.

## Two extractions

Adding a second `/cancel` turned two latent duplications into real ones, so both are folded here rather than left to a third connector to discover.

**`lib/route-client.ts`** — both connectors carried a verbatim copy of the route-owner client resolution, same logic and same comment, and `/cancel` needed a third. The rule now lives in one place: act as the route owner, or a shared connector whose route points at another user's workspace gets scoped out to a 404.

**`lib/cancel-command.ts`** — the two intercepts were otherwise near-identical: same session lookup, same interrupt call, same three user-facing strings, same log line. Only the acknowledgement delivery genuinely differs (`wecomSend` with a `req_id` versus a threaded `postMessage`), plus the event row WeCom writes and Slack does not. The duplicated wording was the real hazard: rephrasing one and not the other leaves two channels describing the same feature differently. `cancelThreadTurn` owns the decision and returns the text to say; each connector delivers it its own way.

Net effect on the connectors is 53 lines lighter than before this PR, and a third channel gets `/cancel` for the cost of an ack call.

As in #205, the interrupt targets the session bound to the thread rather than the workspace: one workspace can back several routes and threads at once, and `workspaces.interrupt` would stop other people's turns along with this one. An interrupt that fails because the turn already completed is acknowledged as "nothing to cancel" rather than surfaced as an error.

## Verification

`tsc --noEmit`, the existing channel-gateway suite (21 tests), knip and biome all pass.

Same testing caveat as #205: the dispatch path is inside a closure over the connector's socket setup and is not exported, so there is no harness to exercise it. `cancelThreadTurn` is now a plain exported function and would be straightforward to test against a stubbed client — worth doing when this area next gets touched, but it needs a db mock the package does not currently have.