### PR TITLE
Quote the positioning line verbatim in the README and both docs homes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <strong>Close your laptop. Your agents keep working.</strong><br/>
-  The open-source agent platform to <strong>build</strong>, <strong>distribute</strong>, and <strong>optimize</strong> AI agents — on infrastructure you own.
+  The open-source agent platform to <strong>build</strong>, <strong>distribute</strong>, and <strong>optimize</strong> AI agents, on infrastructure you own.
 </p>
 
 <p align="center">

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Neutree Agent Platform Docs
-description: "The open-source agent platform to build, distribute, and optimize AI agents — on infrastructure you own."
+description: "The open-source agent platform to build, distribute, and optimize AI agents, on infrastructure you own."
 template: splash
 hero:
   title: Neutree Agent Platform
-  tagline: The open-source agent platform to build, distribute, and optimize AI agents — on infrastructure you own.
+  tagline: The open-source agent platform to build, distribute, and optimize AI agents, on infrastructure you own.
 ---
 
 import LandingTerminal from '../../components/LandingTerminal.astro'

--- a/docs-site/src/content/docs/zh-cn/index.mdx
+++ b/docs-site/src/content/docs/zh-cn/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Neutree Agent Platform 文档
-description: 开源 Agent 平台：构建、分发、持续优化 AI Agent —— 跑在你自己的基础设施上。
+description: 开源 Agent 平台：构建、分发、持续优化 AI Agent，跑在你自己的基础设施上。
 template: splash
 hero:
   title: Neutree Agent Platform
-  tagline: 开源 Agent 平台：构建、分发、持续优化 AI Agent —— 跑在你自己的基础设施上。
+  tagline: 开源 Agent 平台：构建、分发、持续优化 AI Agent，跑在你自己的基础设施上。
 ---
 
 import LandingTerminal from '../../../components/LandingTerminal.astro'


### PR DESCRIPTION
The lockup's second line reads "on infrastructure you own" after a comma. The README and the two docs landing pages had it after an em dash, so a line that is meant to be quoted as-is existed in three near-variants. The Chinese page carried the same split with `——`.

- `README.md`
- `docs-site/src/content/docs/index.mdx` (description + hero tagline)
- `docs-site/src/content/docs/zh-cn/index.mdx` (description + hero tagline)

Swept the repo for any remaining em-dash variant of the line; none left.