### PR TITLE
Point the docs and the installer at the host that resolves

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,6 @@
 name: Deploy docs
 
-# Publishes the static docs-site to its public home at nap.docs.neutree.ai.
+# Publishes the static docs-site to its public home at nap.neutree.ai.
 #
 # The site is a plain Astro/Starlight static build (no use-cases in this repo —
 # that section is a downstream extension point), so the public deploy is just:
@@ -69,7 +69,7 @@ jobs:
             --cache-control "no-cache"
 
       # The one-line installer is served off the docs domain
-      # (https://nap.docs.neutree.ai/get.sh). It is not part of the Astro
+      # (https://nap.neutree.ai/get.sh). It is not part of the Astro
       # build, so the dist sync above excludes it from --delete and this step
       # keeps it current. no-cache so upgrades propagate immediately.
       - name: Publish get.sh

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -14,7 +14,7 @@ const hasUseCases =
   existsSync(useCasesDir) && readdirSync(useCasesDir).some((f) => /\.mdx?$/.test(f))
 
 export default defineConfig({
-  site: 'https://nap.docs.neutree.ai',
+  site: 'https://nap.neutree.ai',
   integrations: [
     preact(),
     starlight({

--- a/docs-site/src/components/LandingTerminal.astro
+++ b/docs-site/src/components/LandingTerminal.astro
@@ -9,7 +9,7 @@ interface Props {
   runningLine: string
 }
 const { copyLabel, copiedLabel, runningLine } = Astro.props
-const command = 'curl -sfL https://nap.docs.neutree.ai/get.sh | sudo sh -'
+const command = 'curl -sfL https://nap.neutree.ai/get.sh | sudo sh -'
 ---
 
 <div class="nap-terminal">

--- a/docs-site/src/content/docs/self-host/single-node.mdx
+++ b/docs-site/src/content/docs/self-host/single-node.mdx
@@ -16,7 +16,7 @@ Recommended spec: **8 vCPU / 32 GB / 200 GB disk** — comfortable for roughly *
 On a bare Linux machine with internet access, k3s is **not** required — the script installs it. Run as root:
 
 ```bash
-curl -sfL https://nap.docs.neutree.ai/get.sh | sudo sh -
+curl -sfL https://nap.neutree.ai/get.sh | sudo sh -
 ```
 
 It installs k3s if missing, generates every secret, autodetects the node IP, creates a random admin password, and prints the login URL + credentials when it finishes. Configuration lands in `/opt/nap/values.env`; re-running the same line upgrades in place.
@@ -25,11 +25,11 @@ Common overrides:
 
 ```bash
 # choose the host IP / admin password yourself
-curl -sfL https://nap.docs.neutree.ai/get.sh \
+curl -sfL https://nap.neutree.ai/get.sh \
   | sudo NAP_HOST=192.168.1.10 NAP_ADMIN_PASSWORD=your-password sh -
 
 # generate values.env only — review/edit it, then re-run without the flag to install
-curl -sfL https://nap.docs.neutree.ai/get.sh \
+curl -sfL https://nap.neutree.ai/get.sh \
   | sudo sh -s -- --prepare-only
 ```
 

--- a/docs-site/src/content/docs/zh-cn/self-host/single-node.mdx
+++ b/docs-site/src/content/docs/zh-cn/self-host/single-node.mdx
@@ -16,7 +16,7 @@ import AirgapBlock from '../../../../components/self-host/AirgapBlock.tsx'
 在一台可访问互联网的裸 Linux 主机上，**不需要**预装 k3s，脚本会自动安装。以 root 执行：
 
 ```bash
-curl -sfL https://nap.docs.neutree.ai/get.sh | sudo sh -
+curl -sfL https://nap.neutree.ai/get.sh | sudo sh -
 ```
 
 脚本会在缺失时安装 k3s，生成全部 secret，自动探测节点 IP，随机生成 admin 密码，完成后打印登录 URL 和凭据。配置落在 `/opt/nap/values.env`；重复执行同一行命令即为原地升级。
@@ -25,11 +25,11 @@ curl -sfL https://nap.docs.neutree.ai/get.sh | sudo sh -
 
 ```bash
 # 自行指定节点 IP / admin 密码
-curl -sfL https://nap.docs.neutree.ai/get.sh \
+curl -sfL https://nap.neutree.ai/get.sh \
   | sudo NAP_HOST=192.168.1.10 NAP_ADMIN_PASSWORD=your-password sh -
 
 # 只生成 values.env —— 人工确认或修改后，去掉该 flag 重新执行即开始安装
-curl -sfL https://nap.docs.neutree.ai/get.sh \
+curl -sfL https://nap.neutree.ai/get.sh \
   | sudo sh -s -- --prepare-only
 ```
 

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -24,7 +24,7 @@ if missing), autodetects the node IP, generates the admin password and prints
 the login URL + credentials at the end:
 
 ```bash
-curl -sfL https://nap.docs.neutree.ai/get.sh | sudo sh -
+curl -sfL https://nap.neutree.ai/get.sh | sudo sh -
 ```
 
 **Existing Kubernetes cluster** — uses your current kubeconfig; you must name
@@ -32,7 +32,7 @@ the host users reach the platform at and an RWX storage backend (external NFS,
 or a pre-existing RWX StorageClass):
 
 ```bash
-curl -sfL https://nap.docs.neutree.ai/get.sh \
+curl -sfL https://nap.neutree.ai/get.sh \
   | sh -s -- --k8s --host=<ip-or-hostname> --nfs-server=<ip> --nfs-path=</export/path>
 # or with an existing RWX StorageClass:
 #   ... | sh -s -- --k8s --host=<ip-or-hostname> --storage-class=<rwx-storageclass>

--- a/self-host/get.sh
+++ b/self-host/get.sh
@@ -6,7 +6,7 @@
 # POSIX sh — this script is meant to be piped from curl:
 #
 #   Single node, no Kubernetes (installs k3s for you; run as root):
-#     curl -sfL https://nap.docs.neutree.ai/get.sh | sh -
+#     curl -sfL https://nap.neutree.ai/get.sh | sh -
 #
 #   Existing Kubernetes cluster (uses your current kubeconfig):
 #     curl -sfL .../get.sh | sh -s -- --k8s --host=<ip-or-hostname> \
@@ -330,7 +330,7 @@ log "   URL:      http://$(get_kv NAP_HOST):$(get_kv NAP_NODE_PORT)"
 log "   Login:    $(get_kv ADMIN_USERNAME) / $(get_kv ADMIN_PASSWORD)"
 log ""
 log " Next:    set up an API provider and run your first agent —"
-log "          https://nap.docs.neutree.ai/guides/1-setup/"
+log "          https://nap.neutree.ai/guides/1-setup/"
 log ""
 log " Config:  $VALUES_FILE  (credentials live here — keep it safe)"
 log " Upgrade: re-run the same one-line command."


### PR DESCRIPTION
`nap.docs.neutree.ai` has **no DNS record**:

```
$ dig +short nap.docs.neutree.ai
$ dig +short nap.neutree.ai
3.175.227.24
3.175.227.15
```

The docs are served from `nap.neutree.ai`, and so is `get.sh` (200). But the install command printed on the docs home, in the self-host guide in both locales, and in `self-host/README.md` told readers to curl the name that does not exist — so the documented install path ended in a resolution failure:

```
curl -sfL https://nap.docs.neutree.ai/get.sh | sudo sh -
```

Every occurrence now names `nap.neutree.ai`. That includes `site` in `docs-site/astro.config.mjs`, which was feeding the same dead host into canonical URLs and the sitemap, `get.sh`'s own usage comment and its closing "next step" line, and the two comments in `deploy-docs.yml` that named the deploy target.

Nothing but the hostname changes — 14 lines, all of them that string.

Related: `neutree-ai/website#16` fixes the landing page, which was linking the docs under a `/docs/` prefix the deploy never wrote. Still outstanding and outside both repos: a CloudFront function 302s `nap.neutree.ai/` to that same `/docs/` prefix, so the docs home is currently reachable only as `/index.html`.