### PR TITLE
Refine the README against the website, and correct what had drifted

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://docs.neutree.ai/nap/">Docs</a> ·
+  <a href="https://neutree.ai/nap">Website</a> ·
+  <a href="https://docs.neutree.ai/nap/self-host/">Self-host guide</a>
+</p>
+
+<p align="center">
   <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
   <a href="CONTRIBUTING.md"><img alt="Contributions welcome" src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg"></a>
 </p>
@@ -14,44 +20,40 @@
 
 Neutree Agent Platform (NAP) turns AI agents into a hosted, multi-user service. Instead of every developer running an agent on their own laptop, a team gets one platform to **build** agents, **distribute** them through whatever channel users already live in, and **optimize** them as they run.
 
-## Build — more with less, on the platform
+## What it does
 
-- **Agent core** — a neutral, swappable frontier agent at the center. Claude Code and Codex are supported today, and the runtime extends to others. Shape its expertise with prompts, skills, and MCP.
-- **Agent middleware, batteries included** — sandbox, remote browser, agent-native shared filesystem, memory store, multi-agent orchestration, and MCP gateway are provided by the platform. Agents use them out of the box instead of each rebuilding them.
-- **Build it your way** — configure agents directly through the UI, or describe the expertise you want in natural language and let an agent assemble it for you.
-- **Custom human-in-the-loop UIs** — build UI plugins that place the right human checkpoints into an agent's workflow, so people can approve and steer at exactly the right moments.
-- **Resource library** — agent templates, prompts, and skills become shared, reusable assets, so a team standardizes and forks instead of starting over.
+- **Build** — a neutral, swappable frontier core, shaped with prompts, skills and MCP, on top of middleware the platform runs so no agent has to ship its own. Configure it in the UI, or describe what you want and let builder mode assemble it. Change the core and the configuration comes along: it belongs to the workspace, not to the core running it.
+- **Distribute** — one workspace, reachable five ways, served in whichever shape the workload needs. Nothing on the user's side: no install, no configuration, no key of their own.
+- **Optimize** — the agent reads its own session history and proposes changes to its prompts and skills. Nothing lands until a human approves it.
 
-## Distribute — build once, use everywhere
+| | |
+| --- | --- |
+| **Cores** | Claude Code, Codex, Goose |
+| **Middleware** | Code sandbox · Remote browser · Agent-to-agent calls · Cross-agent filesystem · Memory store · MCP connections |
+| **Ways in** | Native UI · Chat channels · HTTP API · Webhook · Schedule |
+| **Serving** | **Static** — fixed replicas, held whether or not anyone is asking. **Auto-scaling** — replicas follow demand and go down to zero, waking on the next turn with files and sessions intact. |
+| **Human in the loop** | UI plugins place approval checkpoints inside an agent's workflow |
+| **Sharing** | Prompts, skills and templates carry private / team / public scope, so a working agent is something colleagues pick up rather than retype |
 
-- **Access entry points** — drive an agent from the built-in web UI, from message channels like Slack/IM through the channel gateway, or embed it in your own web app with the HTTP API and UI SDK.
-- **Run modes** — run agents **resident** (always-on, zero cold start, for latency-sensitive workloads) or **serverless** (scale from zero, start on demand, pay for what you use).
+Two things are honest to say up front: auto-scaling is configured through the API at workspace creation, not yet in the web UI; and building an evaluation set out of session history — to check a change, or to see whether a cheaper model holds up — is still being built. The tuning loop above ships today.
 
-## Optimize — agents that improve with use
+The [website](https://neutree.ai/nap) walks through all three with diagrams; the [docs](https://docs.neutree.ai/nap/) are the reference.
 
-- **Autonomous tuning** — mine session history for where an agent underperforms and continuously refine its prompts and skills, so it gets cheaper and better the more it runs.
-- **Model swapping** *(planned)* — automatically evaluate against cheaper models and switch when quality holds, to keep pushing cost down.
+## Local and managed, one setup
 
-## Architecture
-
-NAP is a set of services that share a PostgreSQL control plane.
-
-| Component | Package | Role |
-| --- | --- | --- |
-| **control-plane** | `@neutree-ai/control-plane` | Core API + orchestrator: workspaces, sessions, agents, prompts, templates, skills, providers, credentials, teams. PostgreSQL-backed. |
-| **web** | `@neutree-ai/web` | React front-end (Vite + Tailwind + shadcn/ui). |
-| **channel-gateway** | `@neutree-ai/channel-gateway` | Bridges external channels into the platform. |
-| **scheduler** | `@neutree-ai/scheduler` | Runs scheduled / recurring agent tasks. |
-| **browser-service** | `@neutree-ai/browser-service` | Remote browser agents drive, streamed to users over WebRTC. |
-| **sandbox-service** | `@neutree-ai/sandbox-service` | Code sandbox control, backed by [OpenSandbox](https://github.com/alibaba/OpenSandbox). |
-| **skills-content-service** | `@neutree-ai/skills-content-service` | Serves agent skill content. |
-| **memory-fuse** | — | FUSE layer exposing agent memory as a filesystem. |
-| **agents/** | — | Agent runtime adapters (`claude-code`, `codex`). |
-| **internal/** | `@neutree-ai/*` | Shared libraries (client, types, oauth-client, theme, prompt, …). |
+A local agent and a managed agent are the same craft at two scales. NAP invents no new core, and no new way to shape one: the prompt, the skills and the MCP servers are the ones your local agent already uses. A setup carries over without a rewrite, your local agent can create and manage hosted ones through the API, and what you publish here can be installed back into a local agent.
 
 ## Quick start
 
-The fastest way to stand up the whole platform is the self-host installer, which deploys to a Kubernetes cluster (multi-node or a single k3s node):
+One Linux machine, one command:
+
+```bash
+curl -sfL https://docs.neutree.ai/nap/get.sh | sudo sh -
+```
+
+It installs a single-node k3s cluster and the whole platform on it, then prints the URL and the admin credentials. 8 vCPU / 32 GB / 200 GB is enough for around ten workspaces.
+
+To deploy into a cluster you already run, or to set anything by hand:
 
 ```bash
 cd self-host
@@ -61,7 +63,39 @@ vi values.env                    # set host, admin password, storage, …
 ./install.sh
 ```
 
-When it finishes, open the web UI and log in with the admin credentials from `values.env`. The Code Sandbox and Remote Browser capabilities are optional and can be enabled later without reinstalling — see [`self-host/README.md`](self-host/README.md) for the full guide, configuration reference, and optional-capability setup.
+Code Sandbox and Remote Browser are optional and can be turned on later without reinstalling. [`self-host/README.md`](self-host/README.md) is the full guide, configuration reference and optional-capability setup.
+
+## Architecture
+
+NAP is a set of services that share a PostgreSQL control plane. One control plane serves as many clusters as you need: workspaces run beside it, or in a remote cluster whose runner dials the control plane and keeps the line open — their network, your workspaces.
+
+<p align="center">
+  <img src="docs/architecture.svg" alt="Entry points reach the control plane, which places workspaces — each running one pluggable agent core — onto Kubernetes clusters, with platform middleware brokered to them as MCP tools and mounts" width="880">
+</p>
+
+| Component | Package | Role |
+| --- | --- | --- |
+| **control-plane** | `@neutree-ai/control-plane` | Core API + orchestrator: workspaces, sessions, agents, prompts, templates, skills, providers, credentials, teams. PostgreSQL-backed. |
+| **web** | `@neutree-ai/web` | React front-end (Vite + Tailwind + shadcn/ui). |
+| **channel-gateway** | `@neutree-ai/channel-gateway` | Bridges external channels into the platform. |
+| **scheduler** | `@neutree-ai/scheduler` | Runs scheduled / recurring agent tasks. |
+| **browser-service** | `@neutree-ai/browser-service` | Remote browsers agents drive, streamed to users over WebRTC. |
+| **sandbox-service** | `@neutree-ai/sandbox-service` | Code sandbox control, backed by [OpenSandbox](https://github.com/alibaba/OpenSandbox). |
+| **skills-content-service** | `@neutree-ai/skills-content-service` | Serves agent skill content. |
+| **env-runner-k8s** | `@neutree-ai/env-runner-k8s` | Places and supervises workspace containers on Kubernetes. |
+| **memory-fuse** | — | FUSE layer exposing agent memory as a filesystem. |
+| **agents/** | — | Agent runtime adapters (`claude-code`, `codex`, `goose`). |
+| **internal/** | `@neutree-ai/*` | Shared libraries — client, types, ACP adapter, agent skills, OAuth, theme, platform prompt, and the published [`ui-sdk`](internal/ui-sdk). |
+| **packages/sandbox** | `@neutree-ai/sandbox` | Published SDK for driving sandboxes from your own code. |
+| **docs-site** | `@neutree-ai/docs-site` | The documentation at [docs.neutree.ai/nap](https://docs.neutree.ai/nap/) (Astro + Starlight, en / zh-CN). |
+
+### Where to start reading
+
+- `control-plane/src/routes` — the API surface, and the quickest map of what the platform can do
+- `control-plane/src/services` — orchestration and the PostgreSQL layer under it
+- `agents/<core>/src` — how one frontier core is adapted; the three are worth diffing against each other
+- `web/src` — the shell users actually operate
+- `self-host/` — how the whole thing is deployed, including the air-gapped path
 
 ## Container images
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 600" width="980" height="600" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow-indigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6366F1"/>
+    </marker>
+    <marker id="arrow-gray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="980" height="600" fill="#FFFFFF"/>
+
+  <!-- ===== access entry points ===== -->
+  <g>
+    <rect x="30" y="16" width="200" height="56" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
+    <text x="130" y="42" text-anchor="middle" font-size="13" font-weight="600" fill="#1F2937">Web UI</text>
+    <text x="130" y="60" text-anchor="middle" font-size="10" fill="#64748B">built in</text>
+
+    <rect x="250" y="16" width="200" height="56" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
+    <text x="350" y="42" text-anchor="middle" font-size="13" font-weight="600" fill="#1F2937">Channel Gateway</text>
+    <text x="350" y="60" text-anchor="middle" font-size="10" fill="#64748B">Slack · IM · webhooks</text>
+
+    <rect x="470" y="16" width="200" height="56" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
+    <text x="570" y="42" text-anchor="middle" font-size="13" font-weight="600" fill="#1F2937">Embed</text>
+    <text x="570" y="60" text-anchor="middle" font-size="10" fill="#64748B">HTTP API · UI SDK</text>
+  </g>
+
+  <path d="M 130 72 L 280 108" stroke="#6366F1" stroke-width="1.5" fill="none" marker-end="url(#arrow-indigo)"/>
+  <path d="M 350 72 L 350 108" stroke="#6366F1" stroke-width="1.5" fill="none" marker-end="url(#arrow-indigo)"/>
+  <path d="M 570 72 L 420 108" stroke="#6366F1" stroke-width="1.5" fill="none" marker-end="url(#arrow-indigo)"/>
+
+  <!-- ===== control plane ===== -->
+  <g>
+    <rect x="140" y="110" width="420" height="152" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+    <text x="350" y="141" text-anchor="middle" font-size="15" font-weight="700" fill="#1F2937">Control Plane</text>
+    <line x1="164" y1="156" x2="536" y2="156" stroke="#C7D2FE"/>
+
+    <rect x="208" y="176" width="96" height="28" rx="6" fill="#FFFFFF" stroke="#C7D2FE"/>
+    <text x="256" y="194" text-anchor="middle" font-size="11" fill="#1F2937">users &amp; teams</text>
+    <rect x="318" y="176" width="86" height="28" rx="6" fill="#FFFFFF" stroke="#C7D2FE"/>
+    <text x="361" y="194" text-anchor="middle" font-size="11" fill="#1F2937">workspaces</text>
+    <rect x="418" y="176" width="74" height="28" rx="6" fill="#FFFFFF" stroke="#C7D2FE"/>
+    <text x="455" y="194" text-anchor="middle" font-size="11" fill="#1F2937">sessions</text>
+
+    <rect x="264" y="214" width="172" height="28" rx="6" fill="#FFFFFF" stroke="#C7D2FE"/>
+    <text x="350" y="232" text-anchor="middle" font-size="11" fill="#1F2937">templates · prompts · skills</text>
+  </g>
+
+  <!-- ===== platform middleware ===== -->
+  <g>
+    <rect x="740" y="110" width="210" height="252" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="845" y="141" text-anchor="middle" font-size="13" font-weight="700" fill="#1F2937">Platform middleware</text>
+    <line x1="760" y1="156" x2="930" y2="156" stroke="#A7F3D0"/>
+
+    <rect x="760" y="172" width="170" height="24" rx="6" fill="#FFFFFF" stroke="#A7F3D0"/>
+    <text x="845" y="188" text-anchor="middle" font-size="11" fill="#1F2937">code sandbox</text>
+    <rect x="760" y="202" width="170" height="24" rx="6" fill="#FFFFFF" stroke="#A7F3D0"/>
+    <text x="845" y="218" text-anchor="middle" font-size="11" fill="#1F2937">remote browser</text>
+    <rect x="760" y="232" width="170" height="24" rx="6" fill="#FFFFFF" stroke="#A7F3D0"/>
+    <text x="845" y="248" text-anchor="middle" font-size="11" fill="#1F2937">agent-to-agent calls</text>
+    <rect x="760" y="262" width="170" height="24" rx="6" fill="#FFFFFF" stroke="#A7F3D0"/>
+    <text x="845" y="278" text-anchor="middle" font-size="11" fill="#1F2937">cross-agent filesystem</text>
+    <rect x="760" y="292" width="170" height="24" rx="6" fill="#FFFFFF" stroke="#A7F3D0"/>
+    <text x="845" y="308" text-anchor="middle" font-size="11" fill="#1F2937">memory store</text>
+    <rect x="760" y="322" width="170" height="24" rx="6" fill="#FFFFFF" stroke="#A7F3D0"/>
+    <text x="845" y="338" text-anchor="middle" font-size="11" fill="#1F2937">MCP connections</text>
+  </g>
+
+  <!-- CP -> middleware -->
+  <path d="M 560 186 L 736 186" stroke="#6366F1" stroke-width="1.5" fill="none" marker-end="url(#arrow-indigo)"/>
+  <rect x="574" y="164" width="152" height="40" fill="#FFFFFF"/>
+  <text x="650" y="181" text-anchor="middle" font-size="10" fill="#4B5563">brokers as MCP tools</text>
+  <text x="650" y="195" text-anchor="middle" font-size="10" fill="#4B5563">and mounts</text>
+
+  <!-- CP <-> environment -->
+  <path d="M 350 262 L 350 316" stroke="#6366F1" stroke-width="1.5" fill="none" marker-start="url(#arrow-indigo)" marker-end="url(#arrow-indigo)"/>
+  <rect x="360" y="278" width="130" height="20" fill="#FFFFFF"/>
+  <text x="365" y="293" font-size="10" fill="#4B5563">config &amp; tool access</text>
+
+  <!-- CP -.-> elided environment -->
+  <path d="M 480 262 L 756 318" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="5 4" fill="none" marker-end="url(#arrow-gray)"/>
+
+  <!-- ===== environment ===== -->
+  <g>
+    <rect x="140" y="320" width="460" height="250" rx="10" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.5"/>
+    <text x="164" y="346" font-size="13" font-weight="700" fill="#1F2937">Environment</text>
+    <text x="164" y="363" font-size="10" fill="#64748B">Kubernetes cluster</text>
+
+    <rect x="168" y="374" width="404" height="174" rx="8" fill="#FFF1E6" stroke="#F97316" stroke-width="1.5"/>
+    <text x="370" y="397" text-anchor="middle" font-size="12" font-weight="700" fill="#1F2937">Workspace</text>
+    <line x1="190" y1="407" x2="550" y2="407" stroke="#FED7AA"/>
+
+    <text x="370" y="425" text-anchor="middle" font-size="10" fill="#9A3412">pluggable agent core · one per workspace</text>
+    <rect x="242" y="434" width="96" height="28" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="290" y="452" text-anchor="middle" font-size="11" fill="#1F2937">Claude Code</text>
+    <rect x="352" y="434" width="66" height="28" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="385" y="452" text-anchor="middle" font-size="11" fill="#1F2937">Codex</text>
+    <rect x="432" y="434" width="66" height="28" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="465" y="452" text-anchor="middle" font-size="11" fill="#1F2937">Goose</text>
+
+    <line x1="190" y1="480" x2="550" y2="480" stroke="#FED7AA"/>
+    <text x="370" y="498" text-anchor="middle" font-size="10" fill="#9A3412">shaped by</text>
+    <rect x="235" y="506" width="62" height="26" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="266" y="523" text-anchor="middle" font-size="11" fill="#1F2937">prompt</text>
+    <rect x="307" y="506" width="56" height="26" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="335" y="523" text-anchor="middle" font-size="11" fill="#1F2937">skills</text>
+    <rect x="373" y="506" width="54" height="26" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="400" y="523" text-anchor="middle" font-size="11" fill="#1F2937">MCP</text>
+    <rect x="437" y="506" width="68" height="26" rx="6" fill="#FFFFFF" stroke="#FDBA74"/>
+    <text x="471" y="523" text-anchor="middle" font-size="11" fill="#1F2937">settings</text>
+  </g>
+
+  <!-- ===== elided environments ===== -->
+  <g>
+    <rect x="650" y="320" width="300" height="250" rx="10" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5" stroke-dasharray="6 5"/>
+    <text x="800" y="428" text-anchor="middle" font-size="30" fill="#9CA3AF">…</text>
+    <text x="800" y="466" text-anchor="middle" font-size="11" fill="#6B7280">more clusters</text>
+    <text x="800" y="486" text-anchor="middle" font-size="11" fill="#6B7280">other infrastructure types</text>
+  </g>
+</svg>


### PR DESCRIPTION
The README was re-telling build / distribute / optimize in fifteen bullets. That is the website's job, and [the website](https://neutree.ai/nap) does it with diagrams. Someone who lands on the repo is in a different mode: evaluating the implementation, about to contribute, or looking for where the code lives.

So the pitch compresses to three lines plus a table of facts — a table because an evaluator wants a checkable list, not rhetoric — and the space goes to what only the repo can give.

## Corrections

Six things were no longer true. Each was checked against the code, not against the site:

| | was | is |
| --- | --- | --- |
| Cores | "Claude Code and Codex are supported today" | `agents/goose` has existed for a while — three cores |
| Serving | "**resident** or **serverless**" | the column is `auto_scaling`, and the shapes are **static** and **auto-scaling**. `resident` appears nowhere in `control-plane/` or `web/` |
| Middleware | "multi-agent orchestration", "MCP **gateway**" | agent-to-agent calls, MCP **connections** — "gateway" overclaims what it is |
| Ways in | web UI / channels / HTTP API | five: webhook and schedule were missing |
| Architecture table | 11 rows | missing `env-runner-k8s`, `docs-site`, and `packages/sandbox` — the last one is a published SDK and worth surfacing, as is `internal/ui-sdk` |
| Quick start | `clone` + `./install.sh` | the one-line installer, with the by-hand path second — every other surface leads with it now |

It also **overclaimed auto-scaling**: written as a plain feature, when it is configured through the API at workspace creation and has no switch in the web UI (`web/src` mentions it zero times). That caveat is restored, along with the one about evaluation-from-session-history still being built (`control-plane/src/routes` has no eval route).

## Additions

- **Header links** to Docs, the website, and the self-host guide. The site pointed at the repo; the repo pointed nowhere back.
- **`docs/architecture.svg`**, rendered under Architecture. The README was text-only.
- **"Local and managed, one setup"** — a local agent and a managed agent are the same craft at two scales; a setup carries over, and what you publish here installs back into a local agent. Nothing on the website says this, and it is the most relevant claim there is for someone reading on GitHub.
- **"Where to start reading"** — five entry points into the tree, with why each is worth opening.

Both the diagram and that section were written on an abandoned branch (`docs/nap-neutree-ai-domain`, the one that planned to serve docs under `nap.neutree.ai/docs`) and were never merged. The claims were re-verified before being brought over. The diagram itself was four middleware items behind: agent-to-agent calls and MCP connections are added, `memory` is renamed `memory store`, and the order now matches the table beside it.

Every repo path and external link in the file was resolved before pushing.