### PR TITLE
Notify with the agent's final answer, not its opening narration

### DIFF
--- a/control-plane/src/lib/sse.ts
+++ b/control-plane/src/lib/sse.ts
@@ -727,6 +727,10 @@ function createPersistMainTurnPlugin(ctx: PersistPluginCtx): TurnPlugin {
   // by the agent's buffered sink append to the existing DB row instead
   // of creating a second assistant message for the same turn.
   let textContent = ctx.initialAssistant?.content ?? ''
+  // The most recent assistant text block on its own. `textContent` accumulates
+  // every block of the turn, so its head is the agent's opening narration —
+  // useless as a notification summary. The last block is the actual answer.
+  let lastAssistantText = ''
   let assistantMessageId: string | null = ctx.initialAssistant?.id ?? null
   let eventOrdinal = ctx.initialAssistant?.blocks.length ?? 0
   // Dedup tool_call by call_id across replays: on recovery we reuse the same
@@ -983,8 +987,11 @@ function createPersistMainTurnPlugin(ctx: PersistPluginCtx): TurnPlugin {
             if (!state.sessionId) return
             await transitionSessionStatus(state.sessionId, 'human')
             console.log(`[SSE] Stored assistant message ${tag} session=${state.sessionId}`)
-            const summary =
-              textContent.length > 200 ? `${textContent.slice(0, 200)}...` : textContent
+            // Summarize the agent's final answer, not the head of the whole
+            // turn. 500 chars keeps the WeChat Work markdown message (2048
+            // bytes) under budget for CJK text plus the trailing link.
+            const final = lastAssistantText || textContent
+            const summary = final.length > 500 ? `${final.slice(0, 500)}...` : final
             getWorkspace(workspaceId)
               .then((ws) => {
                 if (!ws) return
@@ -1047,6 +1054,7 @@ function createPersistMainTurnPlugin(ctx: PersistPluginCtx): TurnPlugin {
             }
             if (addedText) {
               textContent += addedText
+              lastAssistantText = addedText
               if (!firstResponseLogged && sessionStartedAt) {
                 const ttfrSec = ((Date.now() - sessionStartedAt) / 1000).toFixed(1)
                 console.log(


### PR DESCRIPTION
## Problem

Users reported that the task-done notification (WeChat Work / inbox) shows the agent's *opening* thinking rather than its result, so they still have to open the session to find out what happened.

The notification body is built at `session.ended` from `textContent`, which accumulates **every** assistant text block of the turn (and is seeded from `initialAssistant` on the recovery path). `textContent.slice(0, 200)` is therefore the first thing the agent said after picking up the task.

## Fix

Track the last assistant text block separately and summarize that. Raised the cap from 200 to 500 chars — a 500-char CJK summary (~1500 bytes) plus the `[View](url)` suffix still fits WeChat Work's 2048-byte markdown message limit.

Single change point: the delivery layer (`services/notifications`, `scheduler` WeCom adapter) passes the body through untouched, so both channels benefit.

## Note

The summary is still truncated — long results are cut at 500 chars with the link to the full session.