### PR TITLE
Bind a chat thread to its session when the turn starts, not when it ends

### DIFF
--- a/channel-gateway/src/lib/cancel-command.ts
+++ b/channel-gateway/src/lib/cancel-command.ts
@@ -24,7 +24,9 @@ export async function cancelThreadTurn(
   connectorClient: NapClient,
   threadId: string,
 ): Promise<string | null> {
-  const sessionId = await db.getThreadSessionId(route.id, threadId)
+  const sessionTtlHours =
+    ((route.config as Record<string, unknown>)?.session_ttl_hours as number) ?? 24
+  const sessionId = await db.getThreadSessionId(route.id, threadId, sessionTtlHours)
   if (!sessionId) {
     console.log(`${label}: /cancel thread=${threadId} session=none`)
     return 'No active session.'

--- a/channel-gateway/src/services/db.ts
+++ b/channel-gateway/src/services/db.ts
@@ -533,15 +533,21 @@ export async function getThreadSessionCursor(
  *  Interrupting needs the session, not just the workspace: a workspace can be
  *  the target of several routes and chats at once, and `workspaces.interrupt`
  *  would stop whichever turns happen to be running — including other people's.
+ *
+ *  The TTL must match the one the scheduler resumes by: past it, the next
+ *  message starts a fresh session, so a row older than the TTL names a session
+ *  that is already over and interrupting it would report a phantom result.
  */
 export async function getThreadSessionId(
   routeId: string,
   threadId: string,
+  sessionTtlHours = 24,
 ): Promise<string | null> {
   const { rows } = await pool.query(
     `SELECT session_id FROM channel.thread_sessions
-     WHERE route_id = $1 AND external_thread_id = $2`,
-    [routeId, threadId],
+     WHERE route_id = $1 AND external_thread_id = $2
+       AND last_active_at > NOW() - make_interval(hours => $3)`,
+    [routeId, threadId, sessionTtlHours],
   )
   return rows[0]?.session_id ?? null
 }

--- a/scheduler/src/handler.ts
+++ b/scheduler/src/handler.ts
@@ -193,6 +193,24 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
     console.log(
       `[Scheduler] ${existingSessionId ? 'Continuing' : 'Starting new'} session job=${job.id}${streamSink ? ' (streaming)' : ''}`,
     )
+
+    // Bind the thread to its session as soon as `session.started` arrives, not
+    // when the turn ends. `/cancel` resolves the session through this row, so
+    // the first turn of a fresh thread would otherwise answer "No active
+    // session." for its entire duration — exactly when cancelling matters most.
+    // The post-reply upsert below still runs; it advances `last_active_at`.
+    const bindThreadSession =
+      routeId && threadId
+        ? (sessionId: string) => {
+            const channelId = replyContext?.channel_id as string | undefined
+            void db
+              .upsertThreadSession(routeId, threadId, sessionId, workspace_id, channelId)
+              .catch((e) =>
+                console.warn(`[Scheduler] Early thread-session bind failed job=${job.id}:`, e),
+              )
+          }
+        : undefined
+
     let sseResult = await startAndConsumeSession(
       chatEndpoint,
       workspace_id,
@@ -203,6 +221,7 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
       source,
       images,
       streamSink,
+      bindThreadSession,
     )
 
     // If resuming failed, fallback to a fresh session
@@ -218,6 +237,7 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
         source,
         images,
         streamSink,
+        bindThreadSession,
       )
     }
 
@@ -481,6 +501,7 @@ async function startAndConsumeSession(
   source?: string,
   images?: Array<{ data: string; media_type: string }>,
   streamSink?: StreamSink | null,
+  onSessionStarted?: (sessionId: string) => void,
 ): Promise<JobResult | null> {
   const body = JSON.stringify({
     message: prompt,
@@ -532,7 +553,12 @@ async function startAndConsumeSession(
   // primary stream ends before `session.ended`, runTurn re-attaches via cp's
   // `/cp-reconnect`; paired with the replacement cp's recoverOrphanedSessions
   // re-attaching cp→agent, a single cp restart stays transparent to the turn.
-  const { plugin, sink } = createSchedulerPlugin(workspaceId, onStatus, streamSink)
+  const { plugin, sink } = createSchedulerPlugin(
+    workspaceId,
+    onStatus,
+    streamSink,
+    onSessionStarted,
+  )
   const captured = response
   const result = await runTurn(
     {
@@ -681,6 +707,7 @@ function createSchedulerPlugin(
   workspaceId: string,
   onStatus?: StatusCallback,
   streamSink?: StreamSink | null,
+  onSessionStarted?: (sessionId: string) => void,
 ): { plugin: TurnPlugin; sink: SchedulerSink } {
   const sink: SchedulerSink = { sessionId: null, textContent: '' }
 
@@ -689,7 +716,10 @@ function createSchedulerPlugin(
     onEvent: (evt) => {
       switch (evt.type) {
         case 'session.started':
-          if (evt.session_id) sink.sessionId = evt.session_id
+          if (evt.session_id) {
+            sink.sessionId = evt.session_id
+            onSessionStarted?.(evt.session_id)
+          }
           onStatus?.('is thinking...')
           break
 


### PR DESCRIPTION
## Problem

Reported from Slack: `/cancel` sometimes answers `No active session.` even though a turn is clearly running.

`cancelThreadTurn` resolves the session to interrupt from `channel.thread_sessions`. That table has exactly one writer — the scheduler's upsert at `handler.ts`, which runs *after* `startAndConsumeSession` has consumed the whole SSE stream and the reply has been sent.

So on the **first turn of a fresh thread** there is no row for the entire duration of the turn, and cancel is dead the whole time — which for a long-running task is minutes. Subsequent turns only work because the previous turn left a row behind. That's the "sometimes."

## Fix

The session id is already known at `session.started` (the scheduler plugin stores it in `sink.sessionId`); it just wasn't persisted until the end. Pass an `onSessionStarted` callback through `startAndConsumeSession` → `createSchedulerPlugin` and upsert the row right there.

The post-reply upsert is kept deliberately: its `ON CONFLICT` bump of `last_active_at` must land *after* the bot's own reply, or the next turn's incremental context cursor reads the bot's message back as bystander context.

## Also fixed

`getThreadSessionId` had no TTL filter while the scheduler resumes via `getThreadSession(..., session_ttl_hours)`. A thread idle past the TTL therefore starts a **new** session, while `/cancel` still read the stale row and interrupted an already-finished session — surfacing as `Nothing to cancel — the current turn already finished.`, equally wrong. The lookup now takes the same TTL from `route.config.session_ttl_hours`.

## Verification

`tsc --noEmit` clean in both packages; channel-gateway vitest suite 21/21 pass.