### PR TITLE
Copy terminal selections to the system clipboard via OSC 52

### DIFF
--- a/agents/tmux.conf
+++ b/agents/tmux.conf
@@ -1,1 +1,15 @@
 set -g mouse on
+
+# With mouse on, tmux owns the drag: the highlight is tmux's copy-mode, not a
+# browser selection, so ⌘/Ctrl+C has nothing to copy. Emitting OSC 52 lets the
+# web terminal forward the copied text to the real clipboard. tmux only sends
+# OSC 52 when the outer terminal advertises the `Ms` capability, which ttyd's
+# TERM does not, so declare it here.
+set -g set-clipboard on
+set -as terminal-features ',*:clipboard'
+
+# Keep the highlight after the button is released. The default binding is
+# copy-selection-and-cancel, which clears it instantly — in a browser that
+# reads as "my selection got thrown away".
+bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-selection-no-clear
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-no-clear

--- a/web/src/components/workspace/WorkspaceTerminalPanel.tsx
+++ b/web/src/components/workspace/WorkspaceTerminalPanel.tsx
@@ -17,6 +17,7 @@ import { ChevronDown, ChevronUp, RefreshCw, Search, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { useTerminalTheme } from './terminal-themes'
 
 type WsState = 'connecting' | 'open' | 'closed' | 'error'
@@ -205,6 +206,25 @@ export function WorkspaceTerminalPanel({ workspaceId, instanceId }: WorkspaceTer
       return true
     })
 
+    // OSC 52 → system clipboard. tmux runs with `mouse on`, so a drag is
+    // consumed by tmux's copy-mode and never becomes a browser selection —
+    // without this bridge the copied text only lands in tmux's paste buffer
+    // and ⌘/Ctrl+C has nothing to copy. tmux (set-clipboard on) emits the
+    // selection as OSC 52; hand it to the real clipboard.
+    const oscDisposable = term.parser.registerOscHandler(52, (payload) => {
+      const text = decodeOsc52(payload)
+      // Reads (`?`) and malformed payloads: swallow rather than let the
+      // sequence fall through and get printed as garbage.
+      if (text === null) return true
+      navigator.clipboard?.writeText(text).catch(() => {
+        // Clipboard writes need a focused document, and Safari wants the write
+        // inside a user gesture — the OSC arrives a tick after mouseup, so this
+        // can legitimately fail. Point at the workaround that always works.
+        toast.error(i18n.t('components.workspaceTerminal.messages.copyFailed'))
+      })
+      return true
+    })
+
     termRef.current = term
     fitRef.current = fitAddon
     searchRef.current = searchAddon
@@ -219,6 +239,7 @@ export function WorkspaceTerminalPanel({ workspaceId, instanceId }: WorkspaceTer
 
     return () => {
       resultsDisposable.dispose()
+      oscDisposable.dispose()
       observer.disconnect()
       term.dispose()
       termRef.current = null
@@ -456,6 +477,25 @@ export function WorkspaceTerminalPanel({ workspaceId, instanceId }: WorkspaceTer
       </div>
     </>
   )
+}
+
+// OSC 52 payload is `<targets>;<base64>` — targets is a clipboard-selection
+// string (tmux sends `c`), and a lone `?` in place of the data is a *read*
+// request, which we don't serve. Returns null for anything we shouldn't copy.
+function decodeOsc52(payload: string): string | null {
+  const sep = payload.indexOf(';')
+  if (sep === -1) return null
+  const b64 = payload.slice(sep + 1)
+  if (b64 === '?' || b64 === '') return null
+  try {
+    const binary = atob(b64)
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
+    // tmux sends UTF-8; decoding through bytes keeps CJK output intact, which
+    // a naive atob-to-string would mangle.
+    return new TextDecoder().decode(bytes)
+  } catch {
+    return null
+  }
 }
 
 function sendResize(ws: WebSocket, cols: number, rows: number) {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2792,7 +2792,8 @@
       "messages": {
         "reconnecting": "Reconnecting...",
         "connectionClosed": "Connection closed",
-        "connectionError": "Connection error"
+        "connectionError": "Connection error",
+        "copyFailed": "Couldn't copy to the clipboard. Hold Shift while dragging to select, then press ⌘/Ctrl+C."
       }
     },
     "combobox": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2816,7 +2816,8 @@
       "messages": {
         "reconnecting": "重新连接中...",
         "connectionClosed": "连接已关闭",
-        "connectionError": "连接异常"
+        "connectionError": "连接异常",
+        "copyFailed": "无法写入剪贴板，可按住 Shift 拖拽选中后用 ⌘/Ctrl+C 复制"
       }
     },
     "combobox": {


### PR DESCRIPTION
## Problem

Selecting text in the web terminal with the mouse looked broken: the highlight vanished the moment the button was released, and Cmd/Ctrl+C copied nothing.

Not an xterm.js bug. `agents/tmux.conf` sets `mouse on`, so tmux enables mouse reporting and xterm.js forwards every mouse event to tmux instead of making a browser selection. The highlight is tmux's copy-mode, the drag-end binding (`copy-selection-and-cancel`) copies into tmux's *paste buffer* and exits copy-mode, and the browser — which never had a selection — has nothing to hand to the clipboard.

## Change

- `agents/tmux.conf`: `set-clipboard on` so tmux emits copied text as OSC 52, plus an explicit `clipboard` terminal feature (tmux only sends OSC 52 when the outer terminal advertises `Ms`, which ttyd's TERM does not).
- `agents/tmux.conf`: drag-end binds to `copy-selection-no-clear` in both copy-mode tables, so the highlight survives mouse-up.
- `WorkspaceTerminalPanel.tsx`: an OSC 52 handler decodes the payload and writes it to `navigator.clipboard`. Base64 is decoded through bytes + `TextDecoder` so CJK output survives; clipboard *read* requests (`?`) and malformed payloads are swallowed rather than printed as garbage.
- Clipboard writes can legitimately be refused (unfocused document, Safari's user-gesture rule), so a failure toasts the Shift+drag workaround — Shift bypasses mouse reporting and gives a native selection.

## Testing

- Verified the tmux config parses and applies on tmux 3.6a (`set-clipboard`, terminal feature, both drag-end bindings) — agent images ship tmux 3.3a, which supports all three.
- End-to-end against a live workspace with a local dev web: double-click copies a word, drag copies and keeps the highlight, both land in the system clipboard.
- `npx tsc --noEmit` clean.

## Rollout note

The tmux side needs the agent images (claude-code / codex / goose) rebuilt to take effect. The intermediate state is safe: old image + new web just means nobody emits OSC 52, i.e. today's behavior.

Known trade-off: `copy-selection-no-clear` leaves the pane in copy-mode after a drag, so `q`/`Esc` is needed before typing again. Accepted for now; a click-to-cancel binding is the follow-up if it annoys anyone.