### PR TITLE
fix: probe Claude Code setup-token providers the way Claude Code does

### DIFF
--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -82,6 +82,24 @@ function isAnthropicType(pt: string): boolean {
   return pt === 'anthropic' || pt === 'anthropic-oauth' || pt === 'claude-code-oauth'
 }
 
+// A Claude Code setup token is a bearer token, not an API key: at runtime the
+// agent hands it to Claude Code as CLAUDE_CODE_OAUTH_TOKEN, which authenticates
+// with `Authorization: Bearer`. Probing it with `x-api-key` always 401s no
+// matter whether the token is valid. `anthropic-oauth` is deliberately left on
+// the x-api-key path — those providers front self-hosted gateways that accept it.
+function isClaudeCodeOauth(pt: string): boolean {
+  return pt === 'claude-code-oauth'
+}
+
+function anthropicAuthHeaders(pt: string, apiKey: string): Record<string, string> {
+  return isClaudeCodeOauth(pt) ? { Authorization: `Bearer ${apiKey}` } : { 'x-api-key': apiKey }
+}
+
+// A subscription OAuth token is only accepted on /v1/messages when the request
+// looks like Claude Code — without this system prompt the API rejects it with a
+// 429 rate_limit_error, which reads as a quota problem but is really a refusal.
+const CLAUDE_CODE_SYSTEM_PROMPT = "You are Claude Code, Anthropic's official CLI for Claude."
+
 // Both OpenAI-family types list models the same way (GET /v1/models); they
 // differ only in the chat wire protocol used at runtime and by the test probe:
 // `openai` = Responses API (Codex), `openai-chat` = Chat Completions (goose).
@@ -292,7 +310,7 @@ providers.openapi(listModelsRoute, async (c) => {
       const baseUrl = resolveAnthropicUrl(provider)
       const res = await fetch(`${baseUrl}/v1/models`, {
         headers: {
-          'x-api-key': provider.api_key,
+          ...anthropicAuthHeaders(provider.provider_type, provider.api_key),
           'anthropic-version': '2023-06-01',
         },
       })
@@ -387,13 +405,16 @@ providers.openapi(testRoute, async (c) => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-api-key': effective.api_key,
+          ...anthropicAuthHeaders(effective.provider_type, effective.api_key),
           'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
           model,
           max_tokens: 1,
           messages: [{ role: 'user', content: 'hi' }],
+          ...(isClaudeCodeOauth(effective.provider_type)
+            ? { system: [{ type: 'text', text: CLAUDE_CODE_SYSTEM_PROMPT }] }
+            : {}),
         }),
       })
     } else if (isOpenAIType(effective.provider_type)) {


### PR DESCRIPTION
## Problem

A `claude-code-oauth` provider stores a Claude Code **setup token**, not an API key. It authenticates with `Authorization: Bearer` — the same token the agent later exports as `CLAUDE_CODE_OAUTH_TOKEN` (`agents/claude-code/src/config.ts`).

Both provider probes in the control plane sent it as `x-api-key`, so for this provider type:

- `GET /providers/:id/models` always returned `401 invalid x-api-key`
- `POST /providers/:id/test` always returned 401

…regardless of whether the token was valid. The workspace model picker showed an empty list and a red 401 under the model field for every correctly configured setup-token provider.

## Fix

- Send `Authorization: Bearer` for `claude-code-oauth` on both probes.
- Give the `/v1/messages` probe the Claude Code system prompt. Without it a subscription token is turned away with `429 rate_limit_error`, which reads as a quota problem but is really a refusal.

`anthropic-oauth` is deliberately left on the `x-api-key` path — those providers front gateways that accept it today, and this change is scoped to the broken case.

## Verification

Ran the exact request shapes against `api.anthropic.com` with a real setup token:

| Request | Auth | Result |
| --- | --- | --- |
| `/v1/models` | `x-api-key` (before) | 401 `invalid x-api-key` |
| `/v1/models` | Bearer (after) | 200, full model catalogue |
| `/v1/messages` | Bearer, no system prompt | 429 `rate_limit_error` |
| `/v1/messages` | Bearer + system prompt (after) | 200 — for both a main and a small model |
| `/v1/models` | Bearer, bogus token | 401 — bad credentials still surface |

`anthropic-beta: oauth-2025-04-20` turned out not to be needed; the system prompt is the deciding factor.

`npx tsc --noEmit` passes in `control-plane`.