### PR TITLE
fix(mcp): stop forwarding an encoding the proxy already decoded

### DIFF
--- a/control-plane/src/routes/mcp-proxy.ts
+++ b/control-plane/src/routes/mcp-proxy.ts
@@ -172,10 +172,20 @@ mcpProxy.all('/v1/mcp/:encodedOrigin/*', async (c) => {
       }
     }
 
-    // Return the upstream response with its headers and streaming body
+    // Return the upstream response with its headers and streaming body.
+    //
+    // `content-encoding` / `content-length` are dropped: `fetch` decoded the
+    // body before handing it over, so both describe bytes the client will
+    // never receive. Passing the encoding through left the client waiting on
+    // the rest of a gzip member that was never sent — headers delivered, body
+    // hanging. Only compressible replies were affected (an upstream serving
+    // `text/event-stream` is not compressed), which is why this surfaced as
+    // one MCP server going quiet rather than all of them.
     const responseHeaders = new Headers()
     for (const [key, value] of upstreamResp.headers.entries()) {
-      if (['transfer-encoding', 'connection'].includes(key.toLowerCase())) continue
+      const name = key.toLowerCase()
+      if (['transfer-encoding', 'connection', 'content-encoding', 'content-length'].includes(name))
+        continue
       responseHeaders.set(key, value)
     }
 

--- a/control-plane/src/routes/workspace/mcp-proxy.test.ts
+++ b/control-plane/src/routes/workspace/mcp-proxy.test.ts
@@ -90,4 +90,28 @@ describe('MCP proxy', () => {
     expect(res.status).toBe(401)
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  it('does not claim an encoding for a body fetch already decoded', async () => {
+    verify.mockResolvedValue({ workspaceId: 'ws1', userId: 'alice' })
+    // What an ingress that gzips JSON hands to `fetch`: the header survives on
+    // the Response, the body arrives decoded. Re-sending the header left the
+    // client waiting for the rest of a gzip member that was never coming.
+    fetchMock.mockResolvedValue(
+      new Response('{"jsonrpc":"2.0"}', {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-encoding': 'gzip',
+          'content-length': '42',
+        },
+      }),
+    )
+
+    const res = await call(`/v1/mcp/${encoded}/mcp`, 'ws_good')
+
+    expect(res.headers.get('content-encoding')).toBeNull()
+    expect(res.headers.get('content-length')).toBeNull()
+    expect(res.headers.get('content-type')).toBe('application/json')
+    expect(await res.text()).toBe('{"jsonrpc":"2.0"}')
+  })
 })

--- a/internal/mcp-forward/src/routes.ts
+++ b/internal/mcp-forward/src/routes.ts
@@ -32,6 +32,15 @@ export interface McpForwardDeps {
 const HOP_BY_HOP = new Set(['connection', 'keep-alive', 'transfer-encoding', 'upgrade', 'host'])
 
 /**
+ * `fetch` decodes a compressed response before we ever see it, so the upstream
+ * `Content-Encoding` describes bytes that no longer exist and the length no
+ * longer matches. Re-sending either leaves the client decoding a gzip stream
+ * that never arrives — it waits for the rest of a member that was never sent,
+ * and the request hangs with its headers already delivered.
+ */
+const DECODED_BY_FETCH = new Set(['content-encoding', 'content-length'])
+
+/**
  * Long-lived MCP streams end by being cut off — the client navigates away, the
  * upstream closes an idle SSE connection. Undici surfaces that as a socket
  * error mid-body, which would otherwise escape as an unhandled rejection on the
@@ -116,7 +125,9 @@ export function registerMcpForwardRoutes(
 
     const respHeaders = new Headers()
     for (const [k, v] of upstream.headers.entries()) {
-      if (!HOP_BY_HOP.has(k.toLowerCase())) respHeaders.set(k, v)
+      const key = k.toLowerCase()
+      if (HOP_BY_HOP.has(key) || DECODED_BY_FETCH.has(key)) continue
+      respHeaders.set(k, v)
     }
     return new Response(upstream.body ? tolerateStreamAbort(upstream.body) : null, {
       status: upstream.status,


### PR DESCRIPTION
An MCP server whose replies are JSON goes silent behind the proxy. The client receives `200` and the response headers, then nothing: the initialize response body never lands, the handshake never completes, and the server's tools never reach the model. What a user sees is a configured MCP server whose tools are simply absent, with no error anywhere.

**Cause.** Both proxy hops copy the upstream response headers wholesale. `fetch` transparently decodes a compressed response before handing it over, so `Content-Encoding: gzip` was being re-sent over a body that is already plain text. The client does as instructed and waits for the rest of a gzip member that never arrives.

Servers replying `text/event-stream` were unaffected, since an ingress does not compress a stream — which is why this presented as one MCP server misbehaving rather than a hop broken for everything compressible.

This was latent while the CLI talked to the control plane directly (that client does not ask for compression, so the ingress never compressed and the wrong header never appeared). The hop added in the MCP-forward change fetches with undici, which sends `Accept-Encoding: gzip` by default — that is what turned compression on and exposed it.

**Fix.** Drop `content-encoding` and `content-length` when re-emitting the upstream response, in the control-plane proxy and in the agent-side forward. `content-length` describes the encoded length and is equally wrong once the body is decoded.

**Verification**

- New regression test in `control-plane/src/routes/workspace/mcp-proxy.test.ts` — fails on the parent commit (`expected 'gzip' to be null`), passes with the fix.
- `vitest run` in `control-plane`: 385 passed. (`k8s-deployment-spec.test.ts` fails to collect on the parent commit as well — unrelated.)
- `tsc --noEmit` clean in `control-plane` and `agents/codex`.
- Reproduced against a live deployment before the fix: the same request with `Accept-Encoding: gzip` returned headers and then hung with 0 bytes until timeout, while `Accept-Encoding: identity` returned the 169-byte body immediately.
