### PR TITLE
fix(self-host): complete the air-gapped bundle, and stop two silent exits

### DIFF
--- a/docs-site/src/components/self-host/ValuesGenerator.tsx
+++ b/docs-site/src/components/self-host/ValuesGenerator.tsx
@@ -255,7 +255,7 @@ const SCHEMA_ZH: {
     },
     AFS_STORAGE_SIZE: { hint: 'AFS RWX PVC 的大小' },
     AGENT_IMAGE_PREFIX: {
-      hint: '默认引用 REGISTRY；可填写完整前缀进行自定义',
+      hint: '留空即可 —— 安装器会按平台镜像前缀推导；仅当 agent 镜像放在别处时才填写完整前缀',
     },
     AGENT_STORAGE_CLASS: {
       hint: 'agent workspace PVC 使用的 StorageClass（ReadWriteOnce 即可）。卷根目录必须是 0777 —— 安装器自带的 nfs-subdir provisioner（nfs-nap）满足这一点。安装后请确认后端：kubectl get sc <class> -o jsonpath={.provisioner}；若为 nfs.csi.k8s.io / SFS，卷根目录是 0755，agent 会遇到 mkdir EACCES，需要设置 mountPermissions:"0777"',
@@ -562,8 +562,15 @@ const SCHEMA: SectionDef[] = [
         key: 'AGENT_IMAGE_PREFIX',
         kind: 'text',
         label: 'AGENT_IMAGE_PREFIX',
-        default: '${REGISTRY}/nap-agent',
-        hint: 'References REGISTRY by default; supply a full prefix to customize',
+        // Left blank on purpose: the installer derives it from
+        // PLATFORM_IMAGE_PREFIX. Writing the public nap-agent prefix in here
+        // pinned it for everyone, including a redistribution whose agent images
+        // carry a different prefix entirely — and since agents are spawned
+        // rather than templated, the wrong value surfaced only when someone
+        // started a workspace and it sat in ImagePullBackOff.
+        default: '',
+        placeholder: '${REGISTRY}/nap-agent',
+        hint: 'Leave empty unless your agent images live somewhere else — the installer derives it from the platform image prefix',
       },
       {
         key: 'AGENT_IMAGE_TAG',

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -291,8 +291,13 @@ check_app_prefix() {
   # a second, empty ${APP_PREFIX}-* stack (empty database included) beside the
   # old objects. Detect the existing prefix from its control-plane deployment.
   local existing
+  # `|| true`: with no cluster to talk to, kubectl exits non-zero, and under
+  # `set -e -o pipefail` that ended the script right here — with kubectl's
+  # stderr already sent to /dev/null, so it exited 1 having printed nothing at
+  # all. --render-only has no cluster by definition and hit this every time.
+  # An absent cluster simply means there is no existing install to compare to.
   existing=$(kubectl -n "${NAMESPACE}" get deploy -o name 2>/dev/null \
-    | sed -n 's|^deployment.apps/\(.*\)-cp$|\1|p' | head -1)
+    | sed -n 's|^deployment.apps/\(.*\)-cp$|\1|p' | head -1 || true)
   if [ -n "$existing" ] && [ "$existing" != "$APP_PREFIX" ]; then
     die "namespace '${NAMESPACE}' already has an install with prefix '${existing}' (deployment ${existing}-cp).
        Changing APP_PREFIX on an existing install would deploy a second, empty '${APP_PREFIX}-*' stack

--- a/self-host/offline/load-images.sh
+++ b/self-host/offline/load-images.sh
@@ -130,10 +130,13 @@ retag_push() {
 # prefix), excluding the target registry: a previous (possibly failed) run
 # leaves retagged ${TARGET_REGISTRY}/... images in the local store, and matching
 # one of those would point the sweep at the wrong registry.
+# `|| true`: no match makes grep exit non-zero, which under `set -e -o pipefail`
+# aborts here silently instead of reaching the diagnostic below — the one place
+# that can tell the operator their bundle or --app-prefix is wrong.
 SOURCE_REGISTRY=$("$CONTAINER_CLI" images --format '{{.Repository}}' \
   | grep -E "/${APP_PREFIX}-cp$" \
   | grep -vF "${TARGET_REGISTRY}/" \
-  | head -1 | sed "s|/${APP_PREFIX}-cp$||")
+  | head -1 | sed "s|/${APP_PREFIX}-cp$||" || true)
 
 if [ -z "$SOURCE_REGISTRY" ]; then
   echo "ERROR: could not find a '${APP_PREFIX}-cp' image in the loaded bundle." >&2

--- a/self-host/offline/save-images.sh
+++ b/self-host/offline/save-images.sh
@@ -55,16 +55,21 @@ echo "==> Rendering manifests to derive the authoritative image set ..."
 ( cd "$SELF_HOST_DIR" && ./install.sh --render-only >/dev/null )
 [ -d "$RENDERED_DIR" ] || { echo "ERROR: render produced no $RENDERED_DIR" >&2; exit 1; }
 
-# Pull the resolved `image:` values out of every rendered manifest. envsubst has
+# Pull the resolved image values out of every rendered manifest. envsubst has
 # already substituted REGISTRY / *_IMAGE / tags, so these are concrete refs
 # (first-party services, postgres, gotenberg, coturn, nfs-server, afs, the
 # language runtimes, pause, chromium-headful, and registry:2 from registry.yaml).
+#
+# imageName: counts too. The CNPG Cluster spec names the PostgreSQL image under
+# that key rather than image:, so grepping for image: alone leaves the database
+# out of the bundle — an air-gapped install then comes up with everything except
+# postgres, which is the one thing nothing else can wait for.
 RENDERED_IMAGES=()
 while IFS= read -r img; do
   [ -n "$img" ] && RENDERED_IMAGES+=("$img")
 done < <(
-  grep -hE '^[[:space:]]*image:[[:space:]]' "$RENDERED_DIR"/*.yaml \
-    | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/["'\'']//g' \
+  grep -hE '^[[:space:]]*(image|imageName):[[:space:]]' "$RENDERED_DIR"/*.yaml \
+    | sed -E 's/^[[:space:]]*(image|imageName):[[:space:]]*//; s/["'\'']//g' \
     | grep -v '\${' \
     | sort -u
 )
@@ -79,6 +84,7 @@ done < <(
 SUPPLEMENT_IMAGES=(
   "${AGENT_IMAGE_PREFIX}-claude-code:${AGENT_IMAGE_TAG}"
   "${AGENT_IMAGE_PREFIX}-codex:${AGENT_IMAGE_TAG}"
+  "${AGENT_IMAGE_PREFIX}-goose:${AGENT_IMAGE_TAG}"
   "${REGISTRY}/${APP_PREFIX}-memory-fuse:${IMAGE_TAG}"
   "ghcr.io/cloudnative-pg/cloudnative-pg:${CNPG_VERSION}"
   "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:${NFS_PROVISIONER_VERSION}"


### PR DESCRIPTION
Four bugs in the offline path, all of which are quiet until the site is already isolated.

## The bundle was missing two images

**postgres.** The image sweep reads `image:` lines out of the rendered manifests, but the CNPG `Cluster` spec names its image under `imageName:`. Every bundle built so far shipped without the database — the one component nothing else can start without. The sweep now matches both keys.

**the goose agent.** CI has built `nap-agent-goose` since that core landed, and no file under `self-host/` has ever mentioned it. An air-gapped workspace on the goose core fails to pull with nothing in the registry to pull from. Added to the supplement, next to claude-code and codex.

## The configuration generator pinned a prefix that isn't universal

`AGENT_IMAGE_PREFIX` was written into every generated `values.env` with the public `nap-agent` value, so a redistribution whose agent images carry a different prefix got a file that quietly pointed somewhere else. Agents are spawned rather than templated, so nothing catches it at install time — it surfaces when a user starts a workspace and it sits in `ImagePullBackOff`.

The field is empty by default now, with the old value as its placeholder, and `install.sh` derives it from `PLATFORM_IMAGE_PREFIX` exactly as it already does for anyone who left the line alone.

## Two probes exited the script instead of reporting

`existing=$(kubectl … | sed | head -1)` in `check_app_prefix`, and the source-registry lookup in `load-images.sh`, both exit non-zero when there is nothing to find. Under `set -e -o pipefail`, with kubectl's stderr already sent to `/dev/null`, that is an exit 1 that prints nothing at all.

`check_app_prefix` has no cluster during `--render-only` — which is precisely when `save-images.sh` renders to derive the image set — so the sweep aborted before reading a single manifest. In `load-images.sh` it pre-empted the diagnostic immediately below it, the one place that can tell an operator their bundle or `--app-prefix` is wrong.

## Verification

The equivalent changes were exercised end to end in a downstream distribution that carries this installer: rendering with no cluster reachable, and a derived image set that comes out complete (26 images, including the two that were missing) against the hand-written list it replaces.