### PR TITLE
feat(billing): log workspace runtime state as raw metering data

### DIFF
--- a/control-plane/migrations/134_workspace_runtime_meter.sql
+++ b/control-plane/migrations/134_workspace_runtime_meter.sql
@@ -1,0 +1,70 @@
+-- Runtime metering: an append-only state log of what each workspace was observed
+-- to be, and the coverage windows of the pass that writes it.
+--
+-- The log is raw: it records observations verbatim and derives nothing. Rounding,
+-- which replica count is billable, whether an errored pod is charged for, and any
+-- price at all belong to a rating layer built on top, so pricing can change and be
+-- recomputed without rewriting history.
+--
+-- No foreign key to workspaces, and user_id denormalised onto the row: a ledger
+-- has to outlive the workspace it accounts for. workspace_usage_events (the token
+-- ledger) is built the same way for the same reason.
+
+CREATE TABLE IF NOT EXISTS workspace_runtime_events (
+  id                        bigserial   PRIMARY KEY,
+  workspace_id              text        NOT NULL,
+  user_id                   text        NOT NULL,
+  -- When the workspace entered this state. An interval runs from one row to the
+  -- next row for the same workspace; there is no closing row to pair with, so a
+  -- crash between the two can never leave a half-written interval behind.
+  ts                        timestamptz NOT NULL,
+  -- The phase the runner reported, not the status cp exposes. 'unknown' is a
+  -- genuine value: cp has no observation, which is different from 'stopped'.
+  -- 'deleted' is written by the orphan sweep when a placement is gone.
+  phase                     text        NOT NULL,
+  -- Replicas actually ready, and the count the spec asks for. Both, because
+  -- which of them is billable is a pricing question, not a metering one — during
+  -- a scale-up they disagree for as long as the new pods take to become ready.
+  -- ready_replicas is null when the runner reported no ready set at all, which
+  -- is not the same as reporting an empty one.
+  ready_replicas            integer,
+  desired_replicas          integer     NOT NULL,
+  runtime_mode              text        NOT NULL,
+  -- Sizing at the time, so a later resize cannot reprice a past interval.
+  resources                 jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  -- The spec cp wants, and the pod template actually running. A resize advances
+  -- the first immediately and the second only once the runner has re-applied, so
+  -- keeping both lets rating charge for the size that was really deployed.
+  spec_version              integer,
+  observed_template_version integer,
+  -- True when the workspace's environment had no live runner: the phase on this
+  -- row is the last thing anyone saw, not a current observation.
+  env_offline               boolean     NOT NULL DEFAULT false,
+
+  -- Both enumerations mirror a TypeScript type: MeterPhase (= ObservedPhase plus
+  -- the terminal 'deleted') and RuntimeMode. Adding a variant to either type
+  -- without adding it here fails at insert time inside a cron, so change both.
+  CONSTRAINT workspace_runtime_events_phase_check
+    CHECK (phase IN ('pending', 'starting', 'running', 'stopped', 'error', 'unknown', 'deleted')),
+  CONSTRAINT workspace_runtime_events_runtime_mode_check
+    CHECK (runtime_mode IN ('static', 'auto-scaling'))
+);
+
+-- The meter's hot read: the newest row for one workspace, once per workspace per
+-- pass. INCLUDE carries every column that read needs, so it stays an index-only
+-- scan instead of a heap fetch per workspace every 15 seconds.
+CREATE INDEX IF NOT EXISTS idx_wre_workspace_ts
+  ON workspace_runtime_events (workspace_id, ts DESC, id DESC)
+  INCLUDE (phase, ready_replicas, desired_replicas, spec_version,
+           observed_template_version, env_offline);
+
+-- When the meter was running. An interval in the log stays open until the next
+-- row, so a stretch where cp was down would otherwise be indistinguishable from
+-- a workspace that genuinely stayed running. The gap between one window's
+-- covered_through and the next window's started_at is exactly the time the meter
+-- observed nothing, and rating decides what to do with it.
+CREATE TABLE IF NOT EXISTS runtime_meter_windows (
+  id              bigserial   PRIMARY KEY,
+  started_at      timestamptz NOT NULL,
+  covered_through timestamptz NOT NULL
+);

--- a/control-plane/src/lib/reconcile.ts
+++ b/control-plane/src/lib/reconcile.ts
@@ -6,10 +6,12 @@ import {
   listAllUserCredentials,
   listUsersWithDeletingCredentials,
 } from '../services/db/credentials'
+import { closeDeletedWorkspaceIntervals } from '../services/db/runtime-meter'
 import { sweepSupersededWorkspaceTokens } from '../services/db/workspace-tokens'
 import { runEnvProjection } from '../services/env-projection'
 import { runIdleWorkspaceGC } from '../services/idle-workspace-gc'
 import { refreshReplicaRouter } from '../services/replica-router'
+import { runRuntimeMeter } from '../services/runtime-meter'
 import { sweepRunningWorkspaces } from '../services/usage/pull'
 import { runAutoscaler } from '../services/workspace-autoscaler'
 
@@ -105,6 +107,37 @@ export function startReconcileLoop() {
       .catch((e) =>
         console.error(
           '[Reconcile] replica router refresh error:',
+          e instanceof Error ? e.message : e,
+        ),
+      ),
+  )
+
+  // Runtime meter: append a row wherever a workspace's observed runtime state
+  // moved. Its own pass rather than a step inside the projection above, so that
+  // a failure of the billing log cannot stop cp from projecting status — and so
+  // that its coverage mark, which is what makes an outage visible to rating,
+  // depends only on the meter's own success. protect:true so a slow pass never
+  // stacks.
+  new Cron(ENV_PROJECTION_INTERVAL, { protect: true }, () =>
+    runRuntimeMeter(ENV_HEARTBEAT_TIMEOUT_SEC).catch((e) =>
+      console.error('[Reconcile] runtime meter error:', e instanceof Error ? e.message : e),
+    ),
+  )
+
+  // Deleted-workspace close-out for the meter: a workspace leaves the pass the
+  // moment its placement goes, so its last logged row would stay open forever.
+  // Reads the log rather than the placements, and an interval that ends a few
+  // minutes late on an already-deleted workspace changes nothing.
+  new Cron('*/5 * * * *', { protect: true }, () =>
+    closeDeletedWorkspaceIntervals()
+      .then((ids) => {
+        if (ids.length > 0) {
+          console.log(`[RuntimeMeter] closed ${ids.length} deleted workspace interval(s)`)
+        }
+      })
+      .catch((e) =>
+        console.error(
+          '[Reconcile] runtime meter close-out error:',
           e instanceof Error ? e.message : e,
         ),
       ),

--- a/control-plane/src/services/db/environments.ts
+++ b/control-plane/src/services/db/environments.ts
@@ -110,6 +110,28 @@ export async function getEnvironmentForUser(
 
 // ── Projection: drive workspaces.status from runner reports ──
 
+/**
+ * Whether a workspace's environment has no live runner, as a SQL fragment over
+ * an `environments e` alias, with the heartbeat threshold in `$1`.
+ *
+ * Shared rather than repeated because two passes read it for different reasons —
+ * the status projection turns it into the status users see, the runtime meter
+ * records it as "the phase on this row is a stale reading" — and a change to the
+ * heartbeat rule applied to only one of them would make the billing log disagree
+ * with the UI with nothing to surface the drift.
+ *
+ * False for the built-in environment by construction: its runner shares cp's own
+ * cluster and sends no heartbeat to go stale.
+ */
+export const ENV_OFFLINE_SQL = `NOT (
+              e.is_builtin
+              OR (
+                e.status = 'online'
+                AND e.last_heartbeat_at IS NOT NULL
+                AND e.last_heartbeat_at >= now() - make_interval(secs => $1)
+              )
+            )`
+
 export interface WorkspaceObservation {
   workspace_id: string
   environment_id: string
@@ -140,9 +162,8 @@ export interface WorkspaceObservation {
  * projection pass over N workspaces is one query rather than N: at steady state
  * almost every row is unchanged and the pass writes nothing.
  *
- * `env_offline` is false for the built-in environment by construction: its
- * runner shares cp's own cluster, and it sends no heartbeat to go stale.
- * `thresholdSec` is how long without a heartbeat makes a remote one offline.
+ * `thresholdSec` is how long without a heartbeat makes a remote environment
+ * offline; see {@link ENV_OFFLINE_SQL}.
  */
 export async function listWorkspaceObservations(
   thresholdSec: number,
@@ -150,14 +171,7 @@ export async function listWorkspaceObservations(
   const { rows } = await pool.query(
     `SELECT p.workspace_id, p.environment_id, e.is_builtin,
             p.observed_phase, p.observed_template_version,
-            NOT (
-              e.is_builtin
-              OR (
-                e.status = 'online'
-                AND e.last_heartbeat_at IS NOT NULL
-                AND e.last_heartbeat_at >= now() - make_interval(secs => $1)
-              )
-            ) AS env_offline,
+            ${ENV_OFFLINE_SQL} AS env_offline,
             p.endpoint->'readyReplicaIds' AS ready_replica_ids,
             w.status, w.runtime_version
        FROM workspace_placements p

--- a/control-plane/src/services/db/runtime-meter.ts
+++ b/control-plane/src/services/db/runtime-meter.ts
@@ -1,0 +1,208 @@
+import type { ComputeResources } from '../../../../internal/types/api'
+import type { ObservedPhase } from '../../../../internal/types/environments'
+import type { RuntimeMode } from '../../../../internal/types/runtime-mode'
+import { ENV_OFFLINE_SQL } from './environments'
+import { pool } from './pool'
+
+/**
+ * Storage for the runtime meter: an append-only state log of what every
+ * workspace was observed to be (`workspace_runtime_events`), plus the windows
+ * during which the meter was running (`runtime_meter_windows`). See migration
+ * 134 for what the columns mean and why the log has no foreign keys.
+ */
+
+/**
+ * The phases a logged row can carry: everything a runner reports, plus the
+ * terminal 'deleted' the close-out writes for a workspace whose placement is
+ * gone. The migration's CHECK constraint mirrors this type.
+ */
+type MeterPhase = ObservedPhase | 'deleted'
+
+/** A row to append to the log. */
+export interface RuntimeEventRow {
+  workspace_id: string
+  user_id: string
+  phase: MeterPhase
+  ready_replicas: number | null
+  desired_replicas: number
+  runtime_mode: RuntimeMode
+  resources: ComputeResources
+  spec_version: number | null
+  observed_template_version: number | null
+  env_offline: boolean
+}
+
+/** One workspace's current observation, next to the last one already logged. */
+export interface RuntimeMeterRow extends RuntimeEventRow {
+  last_phase: MeterPhase | null
+  last_ready_replicas: number | null
+  last_desired_replicas: number | null
+  last_spec_version: number | null
+  last_observed_template_version: number | null
+  last_env_offline: boolean | null
+}
+
+const INSERT_COLUMNS = `workspace_id, user_id, ts, phase, ready_replicas, desired_replicas,
+       runtime_mode, resources, spec_version, observed_template_version, env_offline`
+
+/**
+ * Every placed workspace's current observation joined to its newest logged row,
+ * so one query yields both sides of the comparison the meter makes.
+ *
+ * Reading the log back rather than remembering the last state in cp is what
+ * makes the pass level-triggered: it converges on whatever is already stored, so
+ * a restart, a failed write or a missed tick all self-correct on the next pass
+ * instead of leaving a permanent hole.
+ *
+ * The ready-replica count stays null when the runner reported no set at all,
+ * unlike getWorkspaceReplicaStatus() in ./env-placements, which collapses that
+ * to 0. The distinction matters here and nowhere else: "not reported" and "zero
+ * ready" would bill differently, so do not unify the two expressions.
+ *
+ * `thresholdSec` is how long without a heartbeat makes a remote environment
+ * offline — the same rule the status projection applies, because an offline
+ * environment's phase is a stale reading in both.
+ */
+export async function listRuntimeMeterRows(thresholdSec: number): Promise<RuntimeMeterRow[]> {
+  const { rows } = await pool.query(
+    `SELECT p.workspace_id,
+            w.user_id,
+            COALESCE(p.observed_phase, 'unknown') AS phase,
+            CASE WHEN jsonb_typeof(p.endpoint->'readyReplicaIds') = 'array'
+                 THEN jsonb_array_length(p.endpoint->'readyReplicaIds') END AS ready_replicas,
+            COALESCE((p.spec->>'replicas')::int, 1) AS desired_replicas,
+            p.runtime_mode,
+            COALESCE(p.spec->'resources', '{}'::jsonb) AS resources,
+            p.spec_version,
+            p.observed_template_version,
+            ${ENV_OFFLINE_SQL} AS env_offline,
+            last.phase AS last_phase,
+            last.ready_replicas AS last_ready_replicas,
+            last.desired_replicas AS last_desired_replicas,
+            last.spec_version AS last_spec_version,
+            last.observed_template_version AS last_observed_template_version,
+            last.env_offline AS last_env_offline
+       FROM workspace_placements p
+       JOIN environments e ON e.id = p.environment_id
+       JOIN workspaces w ON w.id = p.workspace_id
+       LEFT JOIN LATERAL (
+         SELECT r.phase, r.ready_replicas, r.desired_replicas,
+                r.spec_version, r.observed_template_version, r.env_offline
+           FROM workspace_runtime_events r
+          WHERE r.workspace_id = p.workspace_id
+          ORDER BY r.ts DESC, r.id DESC
+          LIMIT 1
+       ) last ON true
+      WHERE p.desired_phase <> 'deleted'`,
+    [thresholdSec],
+  )
+  return rows as RuntimeMeterRow[]
+}
+
+/**
+ * Append rows to the log, all stamped with one server-side `now()` so a pass
+ * lands at a single instant rather than smeared across its own runtime.
+ *
+ * No dedup key, and none is needed even with two cp instances writing (a
+ * rolling update): a row says "from here, this state", so a duplicate of the
+ * same state splits one interval into two adjacent identical ones and sums to
+ * exactly the same time. Nothing downstream has to reconcile it.
+ */
+export async function insertRuntimeEvents(rows: RuntimeEventRow[]): Promise<number> {
+  if (rows.length === 0) return 0
+  const { rowCount } = await pool.query(
+    `INSERT INTO workspace_runtime_events (${INSERT_COLUMNS})
+     SELECT x.workspace_id, x.user_id, now(), x.phase, x.ready_replicas, x.desired_replicas,
+            x.runtime_mode, x.resources, x.spec_version, x.observed_template_version, x.env_offline
+       FROM jsonb_to_recordset($1::jsonb) AS x(
+         workspace_id TEXT, user_id TEXT, phase TEXT,
+         ready_replicas INT, desired_replicas INT, runtime_mode TEXT, resources JSONB,
+         spec_version INT, observed_template_version INT, env_offline BOOLEAN
+       )`,
+    [JSON.stringify(rows)],
+  )
+  return rowCount ?? 0
+}
+
+/**
+ * Record that the meter ran: extend the newest coverage window to now, or open a
+ * new one when the previous pass is further back than `gapSec`. Returns true
+ * when a window was opened.
+ *
+ * The gap itself is not computed here — it is the distance between one window's
+ * covered_through and the next window's started_at, which rating reads directly.
+ * A gap is the meter's own downtime, not the workspaces': they keep running
+ * while cp is not looking, so this records the blind spot rather than resolving
+ * it.
+ */
+export async function markMeterCoverage(gapSec: number): Promise<boolean> {
+  const { rows } = await pool.query(
+    `WITH extended AS (
+       UPDATE runtime_meter_windows w
+          SET covered_through = now()
+         FROM (SELECT id FROM runtime_meter_windows ORDER BY covered_through DESC LIMIT 1) newest
+        WHERE w.id = newest.id
+          AND w.covered_through >= now() - make_interval(secs => $1)
+       RETURNING w.id
+     )
+     INSERT INTO runtime_meter_windows (started_at, covered_through)
+     SELECT now(), now()
+      WHERE NOT EXISTS (SELECT 1 FROM extended)
+     RETURNING id`,
+    [gapSec],
+  )
+  return rows.length > 0
+}
+
+/**
+ * Close out workspaces whose placement is gone: the last row for them still says
+ * they were running, and nothing will ever follow it because they no longer
+ * appear in the meter's pass. Writes one terminal 'deleted' row each.
+ *
+ * `ids` is a loose index scan — the recursive walk that Postgres will not
+ * generate for `DISTINCT ON`, which reads the whole log instead and so gets
+ * slower forever as history accumulates. Here the work is one index descent per
+ * distinct workspace, flat in the size of the log.
+ *
+ * Returns the ids closed.
+ */
+export async function closeDeletedWorkspaceIntervals(): Promise<string[]> {
+  const { rows } = await pool.query(
+    `WITH RECURSIVE ids AS (
+       (SELECT workspace_id FROM workspace_runtime_events ORDER BY workspace_id LIMIT 1)
+       UNION ALL
+       SELECT (SELECT r.workspace_id
+                 FROM workspace_runtime_events r
+                WHERE r.workspace_id > ids.workspace_id
+                ORDER BY r.workspace_id
+                LIMIT 1)
+         FROM ids
+        WHERE ids.workspace_id IS NOT NULL
+     ),
+     open AS (
+       SELECT last.*
+         FROM ids
+         CROSS JOIN LATERAL (
+           SELECT r.workspace_id, r.user_id, r.phase, r.runtime_mode, r.resources,
+                  r.spec_version, r.observed_template_version
+             FROM workspace_runtime_events r
+            WHERE r.workspace_id = ids.workspace_id
+            ORDER BY r.ts DESC, r.id DESC
+            LIMIT 1
+         ) last
+        WHERE ids.workspace_id IS NOT NULL
+     )
+     INSERT INTO workspace_runtime_events (${INSERT_COLUMNS})
+     SELECT o.workspace_id, o.user_id, now(), 'deleted', 0, 0,
+            o.runtime_mode, o.resources, o.spec_version, o.observed_template_version, false
+       FROM open o
+      WHERE o.phase <> 'deleted'
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_placements p
+           WHERE p.workspace_id = o.workspace_id
+             AND p.desired_phase <> 'deleted'
+        )
+     RETURNING workspace_id`,
+  )
+  return rows.map((r) => r.workspace_id as string)
+}

--- a/control-plane/src/services/runtime-meter.test.ts
+++ b/control-plane/src/services/runtime-meter.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeMeterRow } from './db/runtime-meter'
+
+vi.mock('./db/runtime-meter', () => ({
+  listRuntimeMeterRows: vi.fn(),
+  insertRuntimeEvents: vi.fn().mockResolvedValue(0),
+  markMeterCoverage: vi.fn().mockResolvedValue(null),
+  closeDeletedWorkspaceIntervals: vi.fn().mockResolvedValue([]),
+}))
+
+import { insertRuntimeEvents, listRuntimeMeterRows, markMeterCoverage } from './db/runtime-meter'
+import { runRuntimeMeter, stateChanged } from './runtime-meter'
+
+/** A workspace running steadily: current observation equals what was last logged. */
+function steady(over: Partial<RuntimeMeterRow> = {}): RuntimeMeterRow {
+  return {
+    workspace_id: 'ws1',
+    user_id: 'u1',
+    phase: 'running',
+    ready_replicas: 1,
+    desired_replicas: 1,
+    runtime_mode: 'static',
+    resources: { cpu_request: '1000m', cpu_limit: '4000m' },
+    spec_version: 3,
+    observed_template_version: 3,
+    env_offline: false,
+    last_phase: 'running',
+    last_ready_replicas: 1,
+    last_desired_replicas: 1,
+    last_spec_version: 3,
+    last_observed_template_version: 3,
+    last_env_offline: false,
+    ...over,
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('stateChanged', () => {
+  it('is false while the observation matches the newest logged row', () => {
+    expect(stateChanged(steady())).toBe(false)
+  })
+
+  it('is true for a workspace with nothing logged yet (needs an opening anchor)', () => {
+    expect(
+      stateChanged(
+        steady({
+          last_phase: null,
+          last_ready_replicas: null,
+          last_desired_replicas: null,
+          last_spec_version: null,
+          last_observed_template_version: null,
+          last_env_offline: null,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true when only the replica count moved — the case a status hook would miss', () => {
+    expect(stateChanged(steady({ ready_replicas: 3, desired_replicas: 3 }))).toBe(true)
+  })
+
+  it('is true when only the spec version moved (a resize, status still running)', () => {
+    expect(stateChanged(steady({ spec_version: 4 }))).toBe(true)
+  })
+
+  it('is true when the pod template caught up to a new spec', () => {
+    expect(
+      stateChanged(steady({ observed_template_version: 4, last_observed_template_version: 3 })),
+    ).toBe(true)
+  })
+
+  it('is true when the environment went offline, so the phase is no longer a live reading', () => {
+    expect(stateChanged(steady({ env_offline: true }))).toBe(true)
+  })
+
+  it('distinguishes "no ready set reported" from "an empty ready set"', () => {
+    expect(stateChanged(steady({ ready_replicas: null, last_ready_replicas: 0 }))).toBe(true)
+  })
+})
+
+describe('runRuntimeMeter', () => {
+  it('writes nothing at steady state, but still marks coverage', async () => {
+    vi.mocked(listRuntimeMeterRows).mockResolvedValue([steady(), steady({ workspace_id: 'ws2' })])
+
+    await runRuntimeMeter(60)
+
+    expect(insertRuntimeEvents).not.toHaveBeenCalled()
+    expect(markMeterCoverage).toHaveBeenCalled()
+  })
+
+  it('logs only the moved workspaces, without the comparison columns', async () => {
+    vi.mocked(listRuntimeMeterRows).mockResolvedValue([
+      steady(),
+      steady({ workspace_id: 'ws2', phase: 'stopped', ready_replicas: 0 }),
+    ])
+
+    await runRuntimeMeter(60)
+
+    expect(insertRuntimeEvents).toHaveBeenCalledWith([
+      {
+        workspace_id: 'ws2',
+        user_id: 'u1',
+        phase: 'stopped',
+        ready_replicas: 0,
+        desired_replicas: 1,
+        runtime_mode: 'static',
+        resources: { cpu_request: '1000m', cpu_limit: '4000m' },
+        spec_version: 3,
+        observed_template_version: 3,
+        env_offline: false,
+      },
+    ])
+  })
+
+  it('leaves coverage un-extended when the write fails, so a real outage is recorded', async () => {
+    vi.mocked(listRuntimeMeterRows).mockResolvedValue([steady({ phase: 'error' })])
+    vi.mocked(insertRuntimeEvents).mockRejectedValueOnce(new Error('db down'))
+
+    await expect(runRuntimeMeter(60)).rejects.toThrow('db down')
+    expect(markMeterCoverage).not.toHaveBeenCalled()
+  })
+})

--- a/control-plane/src/services/runtime-meter.ts
+++ b/control-plane/src/services/runtime-meter.ts
@@ -1,0 +1,85 @@
+import {
+  type RuntimeEventRow,
+  type RuntimeMeterRow,
+  insertRuntimeEvents,
+  listRuntimeMeterRows,
+  markMeterCoverage,
+} from './db/runtime-meter'
+
+// Runtime metering — the raw half of workspace billing.
+//
+// Each pass reads what every placed workspace is observed to be and appends a
+// row wherever that differs from the newest row already logged. An interval runs
+// from one row to the next, so the log needs no closing row, no pairing, and no
+// repair after a crash: whatever state a workspace is in, the next pass records
+// it, and the intervals still add up.
+//
+// The pass is level-triggered rather than hooked onto status transitions. It has
+// to be: replica count and pod size change without the status ever leaving
+// 'running', so an edge hook on applyStatusChange would miss exactly the
+// variation billing is about. Reading the log back each pass is also what makes
+// a dropped write self-correcting — the state still differs next time.
+//
+// Nothing here prices anything; see migration 134 for why the log is raw.
+
+/** How far back the previous pass may be before the meter counts it as a gap. */
+const COVERAGE_GAP_SEC = Number(process.env.RUNTIME_METER_GAP_SEC) || 60
+
+/**
+ * Whether a workspace's current observation differs from the newest logged row.
+ *
+ * Two fields are deliberately outside the comparison. `resources` is covered by
+ * spec_version, since every path that changes a workspace's sizing goes through
+ * bumpWorkspaceSpec. `runtime_mode` is fixed when the workspace is created and
+ * cannot change at all — it is logged so a rated row needs no join to a
+ * placement that will be deleted with the workspace, not because it can move.
+ *
+ * A workspace with no rows at all always counts as changed: the log needs an
+ * opening anchor for it.
+ */
+export function stateChanged(row: RuntimeMeterRow): boolean {
+  return (
+    row.last_phase === null ||
+    row.phase !== row.last_phase ||
+    row.ready_replicas !== row.last_ready_replicas ||
+    row.desired_replicas !== row.last_desired_replicas ||
+    row.spec_version !== row.last_spec_version ||
+    row.observed_template_version !== row.last_observed_template_version ||
+    row.env_offline !== row.last_env_offline
+  )
+}
+
+/** Drop the comparison columns, leaving exactly the row to append. */
+function toEvent(row: RuntimeMeterRow): RuntimeEventRow {
+  const {
+    last_phase,
+    last_ready_replicas,
+    last_desired_replicas,
+    last_spec_version,
+    last_observed_template_version,
+    last_env_offline,
+    ...event
+  } = row
+  return event
+}
+
+/**
+ * One metering pass: log every workspace whose observed state moved, then mark
+ * the pass's own coverage.
+ *
+ * Coverage is marked last on purpose. It means "the meter logged successfully up
+ * to here", so a failed write leaves it behind and, if the failure persists past
+ * the gap threshold, the outage shows up in the windows table instead of being
+ * silently papered over.
+ */
+export async function runRuntimeMeter(thresholdSec: number): Promise<void> {
+  const changed = (await listRuntimeMeterRows(thresholdSec)).filter(stateChanged).map(toEvent)
+  if (changed.length > 0) {
+    await insertRuntimeEvents(changed)
+    console.log(`[RuntimeMeter] logged ${changed.length} state change(s)`)
+  }
+
+  if (await markMeterCoverage(COVERAGE_GAP_SEC)) {
+    console.log('[RuntimeMeter] opened a new coverage window — the previous pass is a gap behind')
+  }
+}


### PR DESCRIPTION
The raw half of workspace billing: an append-only log of what every workspace was observed to be. Nothing is rated or priced on top of it yet — that is a separate layer, so pricing can change and be recomputed without rewriting history.

## Shape

One row means **"from `ts`, this workspace is in this state"**. An interval runs from one row to the next; there is no closing row.

```
ts        phase     ready  desired  spec_v  obs_v
10:00:00  stopped   0      1        10      null    ← stopped, 65 min
11:05:15  starting  0      1        10      null    ← cold start, ~90s
11:06:45  running   1      1        10      10
14:30:00  running   1      1        11      10      ← resized; pod not replaced yet
14:32:15  running   1      1        11      11      ← new size actually running
```

That shape buys three things over paired enter/leave events:

- **No dangling intervals.** A crash cannot leave half an interval behind — the last row is simply open, and the next one closes it. No startup repair step.
- **Duplicate writes are harmless.** Writing the same state twice splits one interval into two adjacent identical ones that sum to the same time, so the log needs no dedup key even while two cp instances overlap during a rollout.
- **Replica changes need no special case.** A replica count moving is the same event as a phase moving, rather than a `running → running` transition needing its own path.

## Why a separate level-triggered pass

The meter deliberately does **not** hook `applyStatusChange`:

1. **It cannot see what billing is about.** Replica count and pod size change while status stays `running` the whole time.
2. **It records projected status, not observation.** `mapObservedToStatus` already merges meanings (a built-in workspace with nothing provisioned reads as `stopped`); a ledger should not inherit that interpretation.
3. **Level-triggered self-corrects.** Comparing against the stored log each pass means a failed write, a skipped tick or a restart all converge next pass. An edge hook that misses an event has missed it permanently.

It runs *beside* the status projection rather than inside it, so a failure of the billing log cannot stop cp from projecting status, and so the coverage mark depends only on the meter's own success.

## Deciding later, not now

Wherever two readings could be billed differently, both are recorded — `ready_replicas` / `desired_replicas`, `spec_version` / `observed_template_version`. `resources` is snapshotted per row so a later resize cannot reprice a past interval, and `user_id` is denormalised with no FK so the log outlives the workspace (matching `workspace_usage_events`).

`runtime_meter_windows` records when the meter itself was running. Since an interval stays open until the next row, a stretch where cp was down would otherwise be indistinguishable from a workspace that genuinely kept running. Pods keep running while cp is not looking, so the gap is recorded rather than resolved — what to do with it is a rating decision.

Also extracts the offline-environment predicate into `ENV_OFFLINE_SQL`, shared with the status projection so the two cannot drift on what "offline" means.

## Verification

SQL was exercised against a real database using session-local `TEMP` tables shadowing the two new ones, so the joins ran against the live `workspace_placements` / `workspaces` / `environments` (989 placements) without touching any schema or data.

- `listRuntimeMeterRows` — 989 rows; the `LATERAL` newest-row-per-workspace lookup measured 10.7ms on an empty log and 30.9ms at 2M rows, growth coming only from deeper index descents
- coverage windows — first open, steady extend, and open-after-gap all behave
- close-out — writes one terminal row per vanished workspace, idempotent on re-run
- 460 unit tests, typecheck and knip clean

The close-out originally used `SELECT DISTINCT ON (workspace_id)`, which measured **15.5s and ~15GB of I/O per pass at 2M rows** and grew linearly forever. It is now a recursive loose index scan: **28.3ms** on the same data, flat as the log grows.

## Worth watching after deploy

- **`ready_replicas` is NULL until #226 is deployed.** 988 of 989 placements currently report no `endpoint.readyReplicaIds`. The column is nullable on purpose — "not reported" and "zero ready" would bill differently — but rating must fall back to `desired_replicas` for rows written before that lands.
- **The first pass writes ~989 anchor rows** (one per workspace), then steady state writes none. Those anchors are stamped at deploy time, not when each workspace actually entered its state, so the first interval per workspace is not a real start. Metering begins at the first `runtime_meter_windows.started_at`.
- Migration 134 only creates tables and touches nothing existing.
