### PR TITLE
feat(billing): record where a workspace ran and whose keys paid for its tokens

### DIFF
--- a/control-plane/migrations/135_meter_attribution.sql
+++ b/control-plane/migrations/135_meter_attribution.sql
@@ -1,0 +1,48 @@
+-- Attribution columns for the two ledgers: where a workspace ran, and whose
+-- model credentials its tokens were spent through.
+--
+-- Both are snapshots on the ledger row for the same reason user_id already is:
+-- the rows they would otherwise be joined to are deleted with the workspace,
+-- and a ledger has to be answerable after that.
+--
+-- Neither exists to exclude anything from metering. A workspace is metered the
+-- same wherever it runs; these columns are what let a later rating layer tell
+-- the cases apart — our own infrastructure cost covers only the built-in
+-- environment, a user's consumption report covers everything they ran, and an
+-- environment's owner may be billing their own users for what ran on theirs.
+-- Which party is billed is a rating decision, and it needs this dimension to
+-- be expressible at all.
+
+ALTER TABLE workspace_runtime_events
+  ADD COLUMN IF NOT EXISTS environment_id text,
+  -- Whether that environment is the platform's own. Carried rather than joined
+  -- because it is the one fact rating always needs and an environment row can
+  -- outlive its usefulness or be removed.
+  ADD COLUMN IF NOT EXISTS is_builtin boolean;
+
+-- The log ships empty (migration 134 creates it), so there is nothing to
+-- backfill and the columns can be required from the first row.
+ALTER TABLE workspace_runtime_events
+  ALTER COLUMN environment_id SET NOT NULL,
+  ALTER COLUMN is_builtin SET NOT NULL;
+
+-- The meter's newest-row-per-workspace read now also returns environment_id, so
+-- it has to ride along in the covering index or that read falls back to a heap
+-- fetch per workspace every 15 seconds.
+DROP INDEX IF EXISTS idx_wre_workspace_ts;
+CREATE INDEX idx_wre_workspace_ts
+  ON workspace_runtime_events (workspace_id, ts DESC, id DESC)
+  INCLUDE (environment_id, phase, ready_replicas, desired_replicas, spec_version,
+           observed_template_version, env_offline);
+
+-- The model provider a workspace's tokens were spent through, as configured at
+-- the moment the usage was ingested. Nullable: rows predating this column have
+-- no answer, and a workspace can have no provider configured. Ownership of the
+-- provider (a user's own key vs a shared one) resolves through model_providers
+-- and is deliberately not copied here — it can change hands, and a stale copy
+-- would contradict the truth rather than preserve it.
+ALTER TABLE workspace_usage_events
+  ADD COLUMN IF NOT EXISTS provider_id text;
+
+CREATE INDEX IF NOT EXISTS idx_wue_provider ON workspace_usage_events (provider_id)
+  WHERE provider_id IS NOT NULL;

--- a/control-plane/src/services/db/runtime-meter.ts
+++ b/control-plane/src/services/db/runtime-meter.ts
@@ -22,6 +22,12 @@ type MeterPhase = ObservedPhase | 'deleted'
 export interface RuntimeEventRow {
   workspace_id: string
   user_id: string
+  /**
+   * Where the workspace ran. A workspace can be re-placed onto a different
+   * environment, so this moves with it and is part of the change comparison.
+   */
+  environment_id: string
+  is_builtin: boolean
   phase: MeterPhase
   ready_replicas: number | null
   desired_replicas: number
@@ -34,6 +40,7 @@ export interface RuntimeEventRow {
 
 /** One workspace's current observation, next to the last one already logged. */
 export interface RuntimeMeterRow extends RuntimeEventRow {
+  last_environment_id: string | null
   last_phase: MeterPhase | null
   last_ready_replicas: number | null
   last_desired_replicas: number | null
@@ -42,8 +49,9 @@ export interface RuntimeMeterRow extends RuntimeEventRow {
   last_env_offline: boolean | null
 }
 
-const INSERT_COLUMNS = `workspace_id, user_id, ts, phase, ready_replicas, desired_replicas,
-       runtime_mode, resources, spec_version, observed_template_version, env_offline`
+const INSERT_COLUMNS = `workspace_id, user_id, environment_id, is_builtin, ts, phase,
+       ready_replicas, desired_replicas, runtime_mode, resources, spec_version,
+       observed_template_version, env_offline`
 
 /**
  * Every placed workspace's current observation joined to its newest logged row,
@@ -67,6 +75,8 @@ export async function listRuntimeMeterRows(thresholdSec: number): Promise<Runtim
   const { rows } = await pool.query(
     `SELECT p.workspace_id,
             w.user_id,
+            p.environment_id,
+            e.is_builtin,
             COALESCE(p.observed_phase, 'unknown') AS phase,
             CASE WHEN jsonb_typeof(p.endpoint->'readyReplicaIds') = 'array'
                  THEN jsonb_array_length(p.endpoint->'readyReplicaIds') END AS ready_replicas,
@@ -76,6 +86,7 @@ export async function listRuntimeMeterRows(thresholdSec: number): Promise<Runtim
             p.spec_version,
             p.observed_template_version,
             ${ENV_OFFLINE_SQL} AS env_offline,
+            last.environment_id AS last_environment_id,
             last.phase AS last_phase,
             last.ready_replicas AS last_ready_replicas,
             last.desired_replicas AS last_desired_replicas,
@@ -86,7 +97,7 @@ export async function listRuntimeMeterRows(thresholdSec: number): Promise<Runtim
        JOIN environments e ON e.id = p.environment_id
        JOIN workspaces w ON w.id = p.workspace_id
        LEFT JOIN LATERAL (
-         SELECT r.phase, r.ready_replicas, r.desired_replicas,
+         SELECT r.environment_id, r.phase, r.ready_replicas, r.desired_replicas,
                 r.spec_version, r.observed_template_version, r.env_offline
            FROM workspace_runtime_events r
           WHERE r.workspace_id = p.workspace_id
@@ -112,10 +123,11 @@ export async function insertRuntimeEvents(rows: RuntimeEventRow[]): Promise<numb
   if (rows.length === 0) return 0
   const { rowCount } = await pool.query(
     `INSERT INTO workspace_runtime_events (${INSERT_COLUMNS})
-     SELECT x.workspace_id, x.user_id, now(), x.phase, x.ready_replicas, x.desired_replicas,
-            x.runtime_mode, x.resources, x.spec_version, x.observed_template_version, x.env_offline
+     SELECT x.workspace_id, x.user_id, x.environment_id, x.is_builtin, now(), x.phase,
+            x.ready_replicas, x.desired_replicas, x.runtime_mode, x.resources,
+            x.spec_version, x.observed_template_version, x.env_offline
        FROM jsonb_to_recordset($1::jsonb) AS x(
-         workspace_id TEXT, user_id TEXT, phase TEXT,
+         workspace_id TEXT, user_id TEXT, environment_id TEXT, is_builtin BOOLEAN, phase TEXT,
          ready_replicas INT, desired_replicas INT, runtime_mode TEXT, resources JSONB,
          spec_version INT, observed_template_version INT, env_offline BOOLEAN
        )`,
@@ -183,8 +195,8 @@ export async function closeDeletedWorkspaceIntervals(): Promise<string[]> {
        SELECT last.*
          FROM ids
          CROSS JOIN LATERAL (
-           SELECT r.workspace_id, r.user_id, r.phase, r.runtime_mode, r.resources,
-                  r.spec_version, r.observed_template_version
+           SELECT r.workspace_id, r.user_id, r.environment_id, r.is_builtin, r.phase,
+                  r.runtime_mode, r.resources, r.spec_version, r.observed_template_version
              FROM workspace_runtime_events r
             WHERE r.workspace_id = ids.workspace_id
             ORDER BY r.ts DESC, r.id DESC
@@ -193,7 +205,7 @@ export async function closeDeletedWorkspaceIntervals(): Promise<string[]> {
         WHERE ids.workspace_id IS NOT NULL
      )
      INSERT INTO workspace_runtime_events (${INSERT_COLUMNS})
-     SELECT o.workspace_id, o.user_id, now(), 'deleted', 0, 0,
+     SELECT o.workspace_id, o.user_id, o.environment_id, o.is_builtin, now(), 'deleted', 0, 0,
             o.runtime_mode, o.resources, o.spec_version, o.observed_template_version, false
        FROM open o
       WHERE o.phase <> 'deleted'

--- a/control-plane/src/services/db/workspace-usage.ts
+++ b/control-plane/src/services/db/workspace-usage.ts
@@ -50,6 +50,12 @@ function toUsageRow(r: UsageRecord): UsageRow {
  * Append usage records to the ledger. workspace_id/user_id are the attribution
  * snapshot (the pod is the workspace). Returns the number of rows actually
  * inserted (duplicates are silently skipped via ON CONFLICT).
+ *
+ * provider_id is read from the workspace's config as it stands at ingest, which
+ * is where the tokens were actually spent for all but the workspaces whose
+ * provider changed inside the sweep interval. It records which credentials paid
+ * for a turn — a user's own key is not the platform's cost — and pulling it here
+ * rather than joining later is what keeps the answer once the config is gone.
  */
 export async function insertUsageRecords(
   workspaceId: string,
@@ -63,12 +69,13 @@ export async function insertUsageRecords(
        workspace_id, user_id, session_id, source, model,
        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
        cache_creation_5m_tokens, cache_creation_1h_tokens, reasoning_output_tokens,
-       web_search_requests, speed, fields_incomplete, ts, dedup_key
+       web_search_requests, speed, fields_incomplete, ts, dedup_key, provider_id
      )
      SELECT $1, $2, x.session_id, x.source, x.model,
             x.input_tokens, x.output_tokens, x.cache_read_tokens, x.cache_creation_tokens,
             x.cache_creation_5m_tokens, x.cache_creation_1h_tokens, x.reasoning_output_tokens,
-            x.web_search_requests, x.speed, x.fields_incomplete, x.ts, x.dedup_key
+            x.web_search_requests, x.speed, x.fields_incomplete, x.ts, x.dedup_key,
+            (SELECT provider_id FROM workspace_config WHERE workspace_id = $1)
      FROM jsonb_to_recordset($3::jsonb) AS x(
        session_id TEXT, source TEXT, model TEXT,
        input_tokens BIGINT, output_tokens BIGINT, cache_read_tokens BIGINT, cache_creation_tokens BIGINT,

--- a/control-plane/src/services/runtime-meter.test.ts
+++ b/control-plane/src/services/runtime-meter.test.ts
@@ -16,6 +16,8 @@ function steady(over: Partial<RuntimeMeterRow> = {}): RuntimeMeterRow {
   return {
     workspace_id: 'ws1',
     user_id: 'u1',
+    environment_id: 'builtin',
+    is_builtin: true,
     phase: 'running',
     ready_replicas: 1,
     desired_replicas: 1,
@@ -24,6 +26,7 @@ function steady(over: Partial<RuntimeMeterRow> = {}): RuntimeMeterRow {
     spec_version: 3,
     observed_template_version: 3,
     env_offline: false,
+    last_environment_id: 'builtin',
     last_phase: 'running',
     last_ready_replicas: 1,
     last_desired_replicas: 1,
@@ -45,6 +48,7 @@ describe('stateChanged', () => {
     expect(
       stateChanged(
         steady({
+          last_environment_id: null,
           last_phase: null,
           last_ready_replicas: null,
           last_desired_replicas: null,
@@ -74,6 +78,10 @@ describe('stateChanged', () => {
     expect(stateChanged(steady({ env_offline: true }))).toBe(true)
   })
 
+  it('is true when the workspace moved to another environment — it changes who is billed', () => {
+    expect(stateChanged(steady({ environment_id: 'byoi-1', is_builtin: false }))).toBe(true)
+  })
+
   it('distinguishes "no ready set reported" from "an empty ready set"', () => {
     expect(stateChanged(steady({ ready_replicas: null, last_ready_replicas: 0 }))).toBe(true)
   })
@@ -101,6 +109,8 @@ describe('runRuntimeMeter', () => {
       {
         workspace_id: 'ws2',
         user_id: 'u1',
+        environment_id: 'builtin',
+        is_builtin: true,
         phase: 'stopped',
         ready_replicas: 0,
         desired_replicas: 1,

--- a/control-plane/src/services/runtime-meter.ts
+++ b/control-plane/src/services/runtime-meter.ts
@@ -33,6 +33,9 @@ const COVERAGE_GAP_SEC = Number(process.env.RUNTIME_METER_GAP_SEC) || 60
  * bumpWorkspaceSpec. `runtime_mode` is fixed when the workspace is created and
  * cannot change at all — it is logged so a rated row needs no join to a
  * placement that will be deleted with the workspace, not because it can move.
+ * `is_builtin` follows environment_id, which is compared: a workspace can be
+ * re-placed onto another environment, and that has to split the interval
+ * because where it ran decides who is billed for it.
  *
  * A workspace with no rows at all always counts as changed: the log needs an
  * opening anchor for it.
@@ -40,6 +43,7 @@ const COVERAGE_GAP_SEC = Number(process.env.RUNTIME_METER_GAP_SEC) || 60
 export function stateChanged(row: RuntimeMeterRow): boolean {
   return (
     row.last_phase === null ||
+    row.environment_id !== row.last_environment_id ||
     row.phase !== row.last_phase ||
     row.ready_replicas !== row.last_ready_replicas ||
     row.desired_replicas !== row.last_desired_replicas ||
@@ -52,6 +56,7 @@ export function stateChanged(row: RuntimeMeterRow): boolean {
 /** Drop the comparison columns, leaving exactly the row to append. */
 function toEvent(row: RuntimeMeterRow): RuntimeEventRow {
   const {
+    last_environment_id,
     last_phase,
     last_ready_replicas,
     last_desired_replicas,


### PR DESCRIPTION
Two attribution columns the ledgers cannot answer without. Added now because the runtime log is still empty — after the meter is rolled out, `environment_id` becomes unrecoverable for any workspace that is deleted, since the placement cascades away with it.

## Not an exclusion

Neither column exists to keep BYOI workspaces out of metering. A workspace is metered the same wherever it runs, and the meter already reads every placement regardless of environment. These columns are the dimension that lets a rating layer tell the cases apart:

- the platform's own infrastructure cost covers only the built-in environment
- a user's consumption report covers everything they ran, wherever it ran
- an environment's owner may be billing *their* users for what ran on theirs

That last one is the reason this matters beyond cost accounting: it means rating must not assume a single billing party. Platform→user, environment-owner→their users, and a self-hosted install doing pure internal chargeback all have to work in the same code. The raw log staying neutral is what keeps that open.

There is one non-built-in workspace in production today, so this is not hypothetical.

## `workspace_runtime_events` — `environment_id`, `is_builtin`

`environment_id` joins the change comparison: `placement.ts` re-places a workspace with `ON CONFLICT … SET environment_id = EXCLUDED.environment_id`, so a workspace really can move, and a move has to split the interval because where it ran decides who is billed for it.

`is_builtin` is carried rather than joined, on the same grounds `user_id` already is: the ledger has to be answerable after the rows it would join to are gone.

Both are `NOT NULL` — migration 134 ships the table empty, so there is nothing to backfill.

The covering index is rebuilt to include `environment_id`, otherwise the newest-row-per-workspace read falls back to a heap fetch per workspace every 15 seconds.

## `workspace_usage_events` — `provider_id`

Snapshotted from the workspace's config at ingest. It records which credentials paid for a turn: a user's own key is not the platform's cost, and today the ledger cannot distinguish that at all. Nullable, since rows predating it have no answer and a workspace may have no provider configured.

Provider *ownership* resolves through `model_providers` rather than being copied — it can change hands, and a stale copy would contradict the truth rather than preserve it.

One known imprecision: the usage sweep runs every 30 minutes, so a workspace whose provider changed inside that window attributes to the newer one. Capturing it per turn would need the agent to report it.

## Verification

Migration 135 was applied verbatim against a real database using session-local `TEMP` tables shadowing the affected ones, so the queries ran against the live `workspace_placements` / `workspaces` / `environments` without touching any schema or data.

- 990 placements read; environment split observed as 989 built-in + 1 BYOI
- `NOT NULL` holds on every written row
- close-out carries the attribution through to the terminal `deleted` row
- the rebuilt index does cover `environment_id`
- 461 unit tests, typecheck and knip clean

A new test covers the moved-environment case. It caught a real bug on the way: `toEvent` strips comparison columns by rest destructuring, and the newly added `last_environment_id` leaked into the written row until it was added there too.
