### PR TITLE
Per-session token accounting, with a completeness verdict

### DIFF
--- a/control-plane/migrations/136_usage_drain_watermark.sql
+++ b/control-plane/migrations/136_usage_drain_watermark.sql
@@ -1,0 +1,17 @@
+-- Drain watermark for the token-usage puller.
+--
+-- `updated_at` cannot answer "has this workspace's usage been read to the end?".
+-- It advances after every batch, including the batches that ran before a pull
+-- failed partway, so a cursor left halfway through a backlog still looks freshly
+-- updated. A consumer that needs a complete account of a finished session — an
+-- external harness reading what one run cost — has to tell "there is nothing
+-- left to collect" apart from "the pull never got that far".
+--
+-- drained_through is written only when a pull reaches the agent's end of data,
+-- and holds the wall-clock time of that pull. Anything the agent wrote to a
+-- transcript more than one settle grace before it is in the ledger: the parser
+-- withholds a file's trailing entry until the file has been quiescent that long,
+-- so every older entry was offered and ingested.
+
+ALTER TABLE workspace_usage_cursor
+  ADD COLUMN IF NOT EXISTS drained_through timestamptz;

--- a/control-plane/src/routes/__tests__/session-usage.test.ts
+++ b/control-plane/src/routes/__tests__/session-usage.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Route-level tests for GET /api/workspaces/:id/sessions/:sessionId/usage.
+ *
+ * Strategy: mock the db and settle layers so this exercises only what the
+ * handler itself decides — which caller may read an account, what counts as a
+ * session worth answering for, and the response shape. The completeness rule
+ * has its own tests in services/usage/settle.test.ts.
+ *
+ * The two authorisation paths are the point. Both are specific to this route:
+ * the ledger outlives the workspace, so a deleted workspace falls back to the
+ * owner stamped on its rows, and a session nobody has heard of must not read
+ * back as a settled zero.
+ */
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getWorkspace: vi.fn(),
+  getSession: vi.fn(),
+  getSessionUsage: vi.fn(),
+  getSessionUsageOwner: vi.fn(),
+  settleSessionUsage: vi.fn(),
+}))
+
+vi.mock('../../services/db/workspaces', () => ({ getWorkspace: mocks.getWorkspace }))
+vi.mock('../../services/db/workspace-usage', () => ({
+  getSessionUsage: mocks.getSessionUsage,
+  getSessionUsageOwner: mocks.getSessionUsageOwner,
+}))
+vi.mock('../../services/usage/settle', () => ({ settleSessionUsage: mocks.settleSessionUsage }))
+vi.mock('../../services/db/sessions', () => ({
+  getSession: mocks.getSession,
+  clearPendingMessage: vi.fn(),
+  deleteSession: vi.fn(),
+  renameSession: vi.fn(),
+  setPendingMessage: vi.fn(),
+  setSessionStarred: vi.fn(),
+}))
+vi.mock('../../services/db/pool', () => ({ pool: { query: vi.fn() } }))
+
+import sessionRoutes from '../workspaces/sessions'
+
+const FAKE_USER = {
+  sub: 'alice',
+  username: 'alice',
+  name: 'Alice',
+  role: 'user' as const,
+  exp: Math.floor(Date.now() / 1000) + 3600,
+}
+
+function makeApp(): OpenAPIHono {
+  const app = new OpenAPIHono()
+  app.use('*', async (c, next) => {
+    ;(c as unknown as { set: (k: string, v: unknown) => void }).set('user', FAKE_USER)
+    await next()
+  })
+  app.route('/api/workspaces', sessionRoutes as unknown as OpenAPIHono)
+  return app
+}
+
+const URL = '/api/workspaces/ws-1/sessions/sess-1/usage'
+
+const TOTALS = {
+  input_tokens: 120,
+  output_tokens: 34,
+  cache_read_tokens: 5_000,
+  cache_creation_tokens: 40,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 40,
+  reasoning_output_tokens: 7,
+  web_search_requests: 0,
+  record_count: 3,
+}
+
+const USAGE = {
+  totals: TOTALS,
+  by_model: [{ ...TOTALS, source: 'codex', model: 'gpt-5.5' }],
+  first_ts: '2026-08-10T06:00:00.000Z',
+  last_ts: '2026-08-10T06:40:44.000Z',
+}
+
+const SETTLEMENT = {
+  complete: true,
+  drained_through: '2026-08-10T06:40:55.000Z',
+  activity_at: '2026-08-10T06:40:44.000Z',
+  reason: null,
+}
+
+describe('GET /workspaces/:id/sessions/:sessionId/usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getWorkspace.mockResolvedValue({ id: 'ws-1', user_id: 'alice', is_system: false })
+    mocks.getSessionUsageOwner.mockResolvedValue('alice')
+    mocks.getSessionUsage.mockResolvedValue(USAGE)
+    mocks.settleSessionUsage.mockResolvedValue(SETTLEMENT)
+  })
+
+  it('returns the totals, the per-model split and the settlement', async () => {
+    const res = await makeApp().request(URL)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ session_id: 'sess-1', ...USAGE, settlement: SETTLEMENT })
+  })
+
+  it('reads the totals after settling, so a pull it triggered is included', async () => {
+    const order: string[] = []
+    mocks.settleSessionUsage.mockImplementation(async () => {
+      order.push('settle')
+      return SETTLEMENT
+    })
+    mocks.getSessionUsage.mockImplementation(async () => {
+      order.push('read')
+      return USAGE
+    })
+
+    await makeApp().request(URL)
+    expect(order).toEqual(['settle', 'read'])
+  })
+
+  it('reports an unsettled account as it stands', async () => {
+    const pending = { ...SETTLEMENT, complete: false, reason: 'pending_settle' }
+    mocks.settleSessionUsage.mockResolvedValue(pending)
+
+    const res = await makeApp().request(URL)
+    expect(res.status).toBe(200)
+    expect((await res.json()).settlement).toEqual(pending)
+  })
+
+  it('hides a workspace the caller does not own', async () => {
+    mocks.getWorkspace.mockResolvedValue({ id: 'ws-1', user_id: 'bob', is_system: false })
+
+    const res = await makeApp().request(URL)
+    expect(res.status).toBe(404)
+    expect(mocks.getSessionUsage).not.toHaveBeenCalled()
+  })
+
+  it('answers for a deleted workspace when the ledger names the caller', async () => {
+    // The whole point of a ledger with no foreign key: a caller that recycles
+    // its workspace after a run can still read what the run cost.
+    mocks.getWorkspace.mockResolvedValue(null)
+    mocks.getSessionUsageOwner.mockResolvedValue('alice')
+
+    const res = await makeApp().request(URL)
+    expect(res.status).toBe(200)
+    expect((await res.json()).totals).toEqual(TOTALS)
+  })
+
+  it('hides a deleted workspace whose ledger names someone else', async () => {
+    mocks.getWorkspace.mockResolvedValue(null)
+    mocks.getSessionUsageOwner.mockResolvedValue('bob')
+
+    expect((await makeApp().request(URL)).status).toBe(404)
+  })
+
+  it('hides a deleted workspace that left no ledger rows', async () => {
+    mocks.getWorkspace.mockResolvedValue(null)
+    mocks.getSessionUsageOwner.mockResolvedValue(null)
+
+    expect((await makeApp().request(URL)).status).toBe(404)
+  })
+
+  it('404s an unknown session instead of reporting a free one', async () => {
+    // A mistyped id summing to zero would read exactly like a run that cost
+    // nothing, which is the one answer a caller comparing runs must not get.
+    mocks.getSessionUsageOwner.mockResolvedValue(null)
+    mocks.getSession.mockResolvedValue(null)
+
+    const res = await makeApp().request(URL)
+    expect(res.status).toBe(404)
+    expect(mocks.getSessionUsage).not.toHaveBeenCalled()
+  })
+
+  it('404s a session belonging to another workspace', async () => {
+    mocks.getSessionUsageOwner.mockResolvedValue(null)
+    mocks.getSession.mockResolvedValue({ id: 'sess-1', workspace_id: 'ws-2' })
+
+    expect((await makeApp().request(URL)).status).toBe(404)
+  })
+
+  it('answers for a live session that has not spent anything yet', async () => {
+    mocks.getSessionUsageOwner.mockResolvedValue(null)
+    mocks.getSession.mockResolvedValue({ id: 'sess-1', workspace_id: 'ws-1' })
+
+    expect((await makeApp().request(URL)).status).toBe(200)
+  })
+})

--- a/control-plane/src/routes/workspaces/sessions.ts
+++ b/control-plane/src/routes/workspaces/sessions.ts
@@ -13,7 +13,7 @@ import {
 } from '../../services/db/sessions'
 import { getSessionUsage, getSessionUsageOwner } from '../../services/db/workspace-usage'
 import { getWorkspace } from '../../services/db/workspaces'
-import { MAX_WAIT_SEC, settleSessionUsage } from '../../services/usage/settle'
+import { settleSessionUsage } from '../../services/usage/settle'
 import { canManage, interruptAgentSession } from './_shared'
 
 const sessions = new OpenAPIHono<AppEnv>()
@@ -377,22 +377,13 @@ const getSessionUsageRoute = createRoute({
     '',
     '`settlement` says whether the ledger already holds everything the session',
     'spent. Usage arrives by pulling the agent transcripts and the pull fired at',
-    'the end of a turn is detached, so a read taken immediately can be short.',
-    'Pass `wait` (seconds, max 60) to pull and block until the account settles;',
-    'a timeout returns the real verdict rather than a false success.',
+    'the end of a turn is detached, so a read taken immediately can be short —',
+    'poll until `complete`, which for a session that just ended takes about as',
+    "long as the parser's settle grace. `reason` distinguishes an account that",
+    'is still converging from one nothing will advance.',
   ].join('\n'),
   security: [{ bearerAuth: [] }],
-  request: {
-    params: SessionScopedParam,
-    query: z.object({
-      wait: z.coerce
-        .number()
-        .min(0)
-        .max(MAX_WAIT_SEC)
-        .optional()
-        .openapi({ param: { name: 'wait', in: 'query' } }),
-    }),
-  },
+  request: { params: SessionScopedParam },
   responses: {
     200: {
       description: 'Session usage',
@@ -408,7 +399,6 @@ const getSessionUsageRoute = createRoute({
 sessions.openapi(getSessionUsageRoute, async (c) => {
   const currentUser = c.get('user')
   const { id, sessionId } = c.req.valid('param')
-  const { wait } = c.req.valid('query')
 
   // The ledger has no foreign key and outlives both the session and the
   // workspace, on purpose: a harness that recycles a workspace after a run must
@@ -433,9 +423,7 @@ sessions.openapi(getSessionUsageRoute, async (c) => {
     }
   }
 
-  // Settle first: with `wait` this is what pulls the outstanding records, so
-  // reading the totals before it would return the account it just completed.
-  const settlement = await settleSessionUsage(id, sessionId, wait ?? 0)
+  const settlement = await settleSessionUsage(id, sessionId)
   const usage = await getSessionUsage(id, sessionId)
   return c.json({ session_id: sessionId, ...usage, settlement }, 200)
 })

--- a/control-plane/src/routes/workspaces/sessions.ts
+++ b/control-plane/src/routes/workspaces/sessions.ts
@@ -11,7 +11,9 @@ import {
   setPendingMessage,
   setSessionStarred,
 } from '../../services/db/sessions'
+import { getSessionUsage, getSessionUsageOwner } from '../../services/db/workspace-usage'
 import { getWorkspace } from '../../services/db/workspaces'
+import { MAX_WAIT_SEC, settleSessionUsage } from '../../services/usage/settle'
 import { canManage, interruptAgentSession } from './_shared'
 
 const sessions = new OpenAPIHono<AppEnv>()
@@ -332,6 +334,110 @@ sessions.openapi(deletePendingRoute, async (c) => {
 
   await clearPendingMessage(sessionId)
   return c.json({ success: true }, 200)
+})
+
+// ── GET /:id/sessions/:sessionId/usage ─────────────────────────────────────
+const UsageTotalsSchema = z.object({
+  input_tokens: z.number(),
+  output_tokens: z.number(),
+  cache_read_tokens: z.number(),
+  cache_creation_tokens: z.number(),
+  cache_creation_5m_tokens: z.number(),
+  cache_creation_1h_tokens: z.number(),
+  reasoning_output_tokens: z.number(),
+  web_search_requests: z.number(),
+  record_count: z.number(),
+})
+
+const SessionUsageSchema = z.object({
+  session_id: z.string(),
+  totals: UsageTotalsSchema,
+  by_model: z.array(UsageTotalsSchema.extend({ source: z.string(), model: z.string() })),
+  first_ts: z.string().nullable(),
+  last_ts: z.string().nullable(),
+  settlement: z.object({
+    complete: z.boolean(),
+    drained_through: z.string().nullable(),
+    activity_at: z.string().nullable(),
+    reason: z
+      .enum(['turn_in_progress', 'pending_settle', 'agent_unreachable', 'workspace_gone'])
+      .nullable(),
+  }),
+})
+
+const getSessionUsageRoute = createRoute({
+  method: 'get',
+  path: '/{id}/sessions/{sessionId}/usage',
+  tags: ['workspaces'],
+  summary: 'Get token usage for one session',
+  description: [
+    'Sums the usage ledger for a single session, split by the model that spent',
+    'it. Cache tiers stay in their own columns — cache reads routinely dwarf',
+    'input volume at a fraction of the price, so a combined number misranks cost.',
+    '',
+    '`settlement` says whether the ledger already holds everything the session',
+    'spent. Usage arrives by pulling the agent transcripts and the pull fired at',
+    'the end of a turn is detached, so a read taken immediately can be short.',
+    'Pass `wait` (seconds, max 60) to pull and block until the account settles;',
+    'a timeout returns the real verdict rather than a false success.',
+  ].join('\n'),
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: SessionScopedParam,
+    query: z.object({
+      wait: z.coerce
+        .number()
+        .min(0)
+        .max(MAX_WAIT_SEC)
+        .optional()
+        .openapi({ param: { name: 'wait', in: 'query' } }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Session usage',
+      content: { 'application/json': { schema: SessionUsageSchema } },
+    },
+    404: {
+      description: 'Workspace or session not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
+sessions.openapi(getSessionUsageRoute, async (c) => {
+  const currentUser = c.get('user')
+  const { id, sessionId } = c.req.valid('param')
+  const { wait } = c.req.valid('query')
+
+  // The ledger has no foreign key and outlives both the session and the
+  // workspace, on purpose: a harness that recycles a workspace after a run must
+  // still be able to read what the run cost. So the workspace row is the
+  // preferred authorisation anchor, and when it is gone the owner stamped on
+  // the ledger rows stands in — narrower, since it admits only that user.
+  const workspace = await getWorkspace(id)
+  const ledgerOwner = await getSessionUsageOwner(id, sessionId)
+  if (workspace) {
+    if (!canManage(workspace, currentUser)) return c.json({ error: 'Workspace not found' }, 404)
+  } else if (!ledgerOwner || ledgerOwner !== currentUser.sub) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+
+  // A session cp has never heard of must not read back as a clean zero-cost
+  // account — for a caller comparing runs, a mistyped id would look like a free
+  // one. Ledger rows or a live session row; either is enough to answer for.
+  if (!ledgerOwner) {
+    const session = await getSession(sessionId)
+    if (!session || session.workspace_id !== id) {
+      return c.json({ error: 'Session not found' }, 404)
+    }
+  }
+
+  // Settle first: with `wait` this is what pulls the outstanding records, so
+  // reading the totals before it would return the account it just completed.
+  const settlement = await settleSessionUsage(id, sessionId, wait ?? 0)
+  const usage = await getSessionUsage(id, sessionId)
+  return c.json({ session_id: sessionId, ...usage, settlement }, 200)
 })
 
 export default sessions

--- a/control-plane/src/services/db/workspace-usage.ts
+++ b/control-plane/src/services/db/workspace-usage.ts
@@ -235,6 +235,8 @@ export interface SessionSettlementFacts {
   drained_through: string | null
   /** 'agent' while a turn runs. Null when the session row is gone. */
   chat_status: string | null
+  /** Null when the workspace is gone. Only a running one can still be pulled. */
+  workspace_status: string | null
 }
 
 export async function getSessionSettlementFacts(
@@ -251,7 +253,8 @@ export async function getSessionSettlementFacts(
          (SELECT MAX(created_at) FROM messages WHERE session_id = $2 AND workspace_id = $1),
          (SELECT MAX(ts) FROM workspace_usage_events WHERE workspace_id = $1 AND session_id = $2)
        ) AS activity_at,
-       (SELECT drained_through FROM workspace_usage_cursor WHERE workspace_id = $1) AS drained_through`,
+       (SELECT drained_through FROM workspace_usage_cursor WHERE workspace_id = $1) AS drained_through,
+       (SELECT status FROM workspaces WHERE id = $1) AS workspace_status`,
     [workspaceId, sessionId],
   )
   const r = rows[0]
@@ -259,6 +262,7 @@ export async function getSessionSettlementFacts(
     activity_at: r?.activity_at ?? null,
     drained_through: r?.drained_through ?? null,
     chat_status: r?.chat_status ?? null,
+    workspace_status: r?.workspace_status ?? null,
   }
 }
 

--- a/control-plane/src/services/db/workspace-usage.ts
+++ b/control-plane/src/services/db/workspace-usage.ts
@@ -131,6 +131,153 @@ export async function getWorkspaceUsageTotals(workspaceId: string): Promise<Work
   }
 }
 
+/** Token totals over a set of ledger rows. snake_case = the API response shape. */
+interface UsageTotals {
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  cache_creation_5m_tokens: number
+  cache_creation_1h_tokens: number
+  reasoning_output_tokens: number
+  web_search_requests: number
+  /** Number of usage records (ledger rows), not conversation turns. */
+  record_count: number
+}
+
+interface UsageByModel extends UsageTotals {
+  source: string
+  model: string
+}
+
+interface SessionUsage {
+  totals: UsageTotals
+  by_model: UsageByModel[]
+  first_ts: string | null
+  last_ts: string | null
+}
+
+const EMPTY_TOTALS: UsageTotals = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 0,
+  reasoning_output_tokens: 0,
+  web_search_requests: 0,
+  record_count: 0,
+}
+
+const TOTAL_KEYS = Object.keys(EMPTY_TOTALS) as (keyof UsageTotals)[]
+
+/**
+ * One session's usage, split by the model that spent it and summed across.
+ *
+ * Split rather than one number because a session is not bound to one model —
+ * it survives a core switch, and a fallback can serve part of a run. Comparing
+ * what two configurations cost only works if each model's tokens stay
+ * separable, and cache reads (routinely tens of times the input volume, at a
+ * fraction of the price) have to stay in their own column for the same reason.
+ *
+ * Scoped by workspace as well as session: the ledger keeps no foreign key, so
+ * the workspace is what the caller was authorised against.
+ */
+export async function getSessionUsage(
+  workspaceId: string,
+  sessionId: string,
+): Promise<SessionUsage> {
+  const { rows } = await pool.query(
+    `SELECT source, model,
+            COALESCE(SUM(input_tokens), 0)::bigint             AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)::bigint            AS output_tokens,
+            COALESCE(SUM(cache_read_tokens), 0)::bigint        AS cache_read_tokens,
+            COALESCE(SUM(cache_creation_tokens), 0)::bigint    AS cache_creation_tokens,
+            COALESCE(SUM(cache_creation_5m_tokens), 0)::bigint AS cache_creation_5m_tokens,
+            COALESCE(SUM(cache_creation_1h_tokens), 0)::bigint AS cache_creation_1h_tokens,
+            COALESCE(SUM(reasoning_output_tokens), 0)::bigint  AS reasoning_output_tokens,
+            COALESCE(SUM(web_search_requests), 0)::bigint      AS web_search_requests,
+            COUNT(*)::bigint                                   AS record_count,
+            MIN(ts) AS first_ts, MAX(ts) AS last_ts
+       FROM workspace_usage_events
+      WHERE workspace_id = $1 AND session_id = $2
+      GROUP BY source, model
+      ORDER BY SUM(${ALL_IN}) DESC`,
+    [workspaceId, sessionId],
+  )
+
+  const totals = { ...EMPTY_TOTALS }
+  const by_model: UsageByModel[] = []
+  let first: string | null = null
+  let last: string | null = null
+  for (const r of rows) {
+    const bucket = { source: r.source, model: r.model } as UsageByModel
+    for (const k of TOTAL_KEYS) {
+      const v = Number(r[k])
+      bucket[k] = v
+      totals[k] += v
+    }
+    by_model.push(bucket)
+    if (r.first_ts && (!first || r.first_ts < first)) first = r.first_ts
+    if (r.last_ts && (!last || r.last_ts > last)) last = r.last_ts
+  }
+  return { totals, by_model, first_ts: first, last_ts: last }
+}
+
+/** The raw inputs a completeness verdict is derived from; see services/usage/settle.ts. */
+export interface SessionSettlementFacts {
+  /**
+   * The latest moment cp has any evidence the session was active — its own
+   * row, its messages, or its ledger entries. Null when all three are silent.
+   */
+  activity_at: string | null
+  /** When a pull last read this workspace to the end; null if none ever did. */
+  drained_through: string | null
+  /** 'agent' while a turn runs. Null when the session row is gone. */
+  chat_status: string | null
+}
+
+export async function getSessionSettlementFacts(
+  workspaceId: string,
+  sessionId: string,
+): Promise<SessionSettlementFacts> {
+  // GREATEST ignores NULL arguments in Postgres, so a session with no messages
+  // or no ledger rows yet still yields the newest of whatever does exist.
+  const { rows } = await pool.query(
+    `SELECT
+       (SELECT chat_status FROM sessions WHERE id = $2 AND workspace_id = $1) AS chat_status,
+       GREATEST(
+         (SELECT last_active_at FROM sessions WHERE id = $2 AND workspace_id = $1),
+         (SELECT MAX(created_at) FROM messages WHERE session_id = $2 AND workspace_id = $1),
+         (SELECT MAX(ts) FROM workspace_usage_events WHERE workspace_id = $1 AND session_id = $2)
+       ) AS activity_at,
+       (SELECT drained_through FROM workspace_usage_cursor WHERE workspace_id = $1) AS drained_through`,
+    [workspaceId, sessionId],
+  )
+  const r = rows[0]
+  return {
+    activity_at: r?.activity_at ?? null,
+    drained_through: r?.drained_through ?? null,
+    chat_status: r?.chat_status ?? null,
+  }
+}
+
+/**
+ * Owner recorded on a session's ledger rows, or null if it has none. Lets a
+ * caller reach the account of a workspace that has since been deleted, which
+ * the ledger deliberately outlives.
+ */
+export async function getSessionUsageOwner(
+  workspaceId: string,
+  sessionId: string,
+): Promise<string | null> {
+  const { rows } = await pool.query(
+    'SELECT user_id FROM workspace_usage_events WHERE workspace_id = $1 AND session_id = $2 LIMIT 1',
+    [workspaceId, sessionId],
+  )
+  return rows[0]?.user_id ?? null
+}
+
 export async function getUsageCursor(workspaceId: string): Promise<SweepCursors> {
   const { rows } = await pool.query(
     'SELECT cursor FROM workspace_usage_cursor WHERE workspace_id = $1',
@@ -145,6 +292,19 @@ export async function setUsageCursor(workspaceId: string, cursor: SweepCursors):
      VALUES ($1, $2::jsonb, NOW())
      ON CONFLICT (workspace_id) DO UPDATE SET cursor = EXCLUDED.cursor, updated_at = NOW()`,
     [workspaceId, JSON.stringify(cursor)],
+  )
+}
+
+/**
+ * Record that a pull read this workspace's transcripts to the end. Separate
+ * from setUsageCursor, which runs per batch and therefore also runs on the
+ * batches leading up to a failure — see migration 136 for why the difference
+ * matters.
+ */
+export async function markUsageDrained(workspaceId: string): Promise<void> {
+  await pool.query(
+    'UPDATE workspace_usage_cursor SET drained_through = NOW() WHERE workspace_id = $1',
+    [workspaceId],
   )
 }
 

--- a/control-plane/src/services/usage/pull.ts
+++ b/control-plane/src/services/usage/pull.ts
@@ -37,12 +37,7 @@ const PULL_BATCH_FILES = 50
 const MAX_BATCHES_PER_PULL = 40
 
 /** Why a pull stopped. Only `drained` means the agent had nothing left to give. */
-export type PullStop =
-  | 'drained'
-  | 'workspace_gone'
-  | 'agent_unreachable'
-  | 'agent_error'
-  | 'batch_cap'
+type PullStop = 'drained' | 'workspace_gone' | 'agent_unreachable' | 'agent_error' | 'batch_cap'
 
 interface PullOutcome {
   /** Ledger rows actually appended (duplicates already excluded). */

--- a/control-plane/src/services/usage/pull.ts
+++ b/control-plane/src/services/usage/pull.ts
@@ -1,6 +1,11 @@
 import type { UsageSweepResponse } from '../../../../internal/agent-usage/src/index'
 import { postToAgent } from '../../lib/workspace-address'
-import { getUsageCursor, insertUsageRecords, setUsageCursor } from '../db/workspace-usage'
+import {
+  getUsageCursor,
+  insertUsageRecords,
+  markUsageDrained,
+  setUsageCursor,
+} from '../db/workspace-usage'
 import { getWorkspace, listRunningWorkspaces } from '../db/workspaces'
 
 /**
@@ -31,22 +36,47 @@ const PULL_BATCH_FILES = 50
 // resumes next tick. Per call: up to 50 * 40 = 2000 files.
 const MAX_BATCHES_PER_PULL = 40
 
+/** Why a pull stopped. Only `drained` means the agent had nothing left to give. */
+export type PullStop =
+  | 'drained'
+  | 'workspace_gone'
+  | 'agent_unreachable'
+  | 'agent_error'
+  | 'batch_cap'
+
+interface PullOutcome {
+  /** Ledger rows actually appended (duplicates already excluded). */
+  inserted: number
+  /** True only for `stop === 'drained'`. */
+  drained: boolean
+  stop: PullStop
+}
+
 /**
  * Pull one workspace's new usage into the ledger, draining in bounded batches
  * until the agent reports no more (or the per-call batch cap is hit; the rest
  * resumes on the next pull). Pass `userId` when known (the sweep already has it)
- * to skip a workspace lookup. Returns total rows inserted.
+ * to skip a workspace lookup.
+ *
+ * The outcome distinguishes an empty pull from a failed one. Both append zero
+ * rows, but only the first proves the ledger holds everything the agent had —
+ * which is what `markUsageDrained` records and what a consumer asking whether a
+ * session's account is complete depends on.
  */
-export async function pullWorkspaceUsage(workspaceId: string, userId?: string): Promise<number> {
+export async function pullWorkspaceUsage(
+  workspaceId: string,
+  userId?: string,
+): Promise<PullOutcome> {
   let owner = userId
   if (!owner) {
     const ws = await getWorkspace(workspaceId)
-    if (!ws) return 0
+    if (!ws) return { inserted: 0, drained: false, stop: 'workspace_gone' }
     owner = ws.user_id
   }
 
   let inserted = 0
   let pulled = 0
+  let stop: PullStop = 'batch_cap'
   for (let batch = 0; batch < MAX_BATCHES_PER_PULL; batch++) {
     const cursor = await getUsageCursor(workspaceId)
     const resp = await postToAgent(
@@ -58,10 +88,12 @@ export async function pullWorkspaceUsage(workspaceId: string, userId?: string): 
     if (!resp) {
       // Agent not reachable (stopped / starting / mid-restart) — pull again later.
       console.warn(`[usage] pull fetch failed ws=${workspaceId}`)
+      stop = 'agent_unreachable'
       break
     }
     if (!resp.ok) {
       console.warn(`[usage] pull non-ok ws=${workspaceId} status=${resp.status}`)
+      stop = 'agent_error'
       break
     }
 
@@ -70,13 +102,20 @@ export async function pullWorkspaceUsage(workspaceId: string, userId?: string): 
     pulled += records.length
     // Persist the cursor after each batch so progress survives a later failure.
     await setUsageCursor(workspaceId, cursors)
-    if (!hasMore) break
+    if (!hasMore) {
+      stop = 'drained'
+      break
+    }
   }
+
+  // Stamped after the last cursor write, so the watermark can never claim to
+  // cover a batch that is not in the ledger yet.
+  if (stop === 'drained') await markUsageDrained(workspaceId)
 
   if (inserted > 0) {
     console.log(`[usage] ws=${workspaceId} +${inserted} records (pulled ${pulled})`)
   }
-  return inserted
+  return { inserted, drained: stop === 'drained', stop }
 }
 
 /** Sweep all running workspaces, pulling usage with bounded concurrency. */

--- a/control-plane/src/services/usage/settle.test.ts
+++ b/control-plane/src/services/usage/settle.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SETTLE_GRACE_MS } from '../../../../internal/agent-usage/src/index'
+import type { SessionSettlementFacts } from '../db/workspace-usage'
+import { evaluateSettlement } from './settle'
+
+const ACTIVITY = '2026-08-10T06:40:44.000Z'
+
+/** A drain that happened `ms` after the session's last activity. */
+function drainedAfter(ms: number): string {
+  return new Date(Date.parse(ACTIVITY) + ms).toISOString()
+}
+
+function facts(over: Partial<SessionSettlementFacts> = {}): SessionSettlementFacts {
+  return {
+    activity_at: ACTIVITY,
+    drained_through: drainedAfter(DEFAULT_SETTLE_GRACE_MS + 1_000),
+    chat_status: 'human',
+    ...over,
+  }
+}
+
+describe('evaluateSettlement', () => {
+  it('settles once a drain clears the activity by more than the settle grace', () => {
+    expect(evaluateSettlement(facts(), 'drained')).toMatchObject({
+      complete: true,
+      reason: null,
+    })
+  })
+
+  it('withholds a drain that landed inside the grace', () => {
+    // The parser holds back a file's trailing entry until it has been quiescent
+    // for the grace, so this drain cannot have seen the session's last record.
+    const inside = facts({ drained_through: drainedAfter(DEFAULT_SETTLE_GRACE_MS - 1_000) })
+    expect(evaluateSettlement(inside, 'drained')).toMatchObject({
+      complete: false,
+      reason: 'pending_settle',
+    })
+  })
+
+  it('withholds a drain that predates the activity', () => {
+    const before = facts({ drained_through: drainedAfter(-60_000) })
+    expect(evaluateSettlement(before, 'drained').complete).toBe(false)
+  })
+
+  it('never settles while a turn is running, however old the drain', () => {
+    const running = facts({
+      chat_status: 'agent',
+      drained_through: drainedAfter(3_600_000),
+    })
+    expect(evaluateSettlement(running, 'drained')).toMatchObject({
+      complete: false,
+      reason: 'turn_in_progress',
+    })
+  })
+
+  it('reports a running turn ahead of a failed pull', () => {
+    const running = facts({ chat_status: 'agent' })
+    expect(evaluateSettlement(running, 'agent_unreachable').reason).toBe('turn_in_progress')
+  })
+
+  it('does not settle a workspace that was never drained', () => {
+    expect(evaluateSettlement(facts({ drained_through: null }), null)).toMatchObject({
+      complete: false,
+      reason: 'pending_settle',
+    })
+  })
+
+  it('settles an empty session once the workspace has been drained', () => {
+    // Nothing to account for, and a drain proved the agent had nothing to give.
+    expect(evaluateSettlement(facts({ activity_at: null }), 'drained')).toMatchObject({
+      complete: true,
+      reason: null,
+    })
+  })
+
+  it('does not settle an empty session before any drain', () => {
+    expect(
+      evaluateSettlement(facts({ activity_at: null, drained_through: null }), null).complete,
+    ).toBe(false)
+  })
+
+  it.each([
+    ['agent_unreachable', 'agent_unreachable'],
+    ['agent_error', 'agent_unreachable'],
+    ['workspace_gone', 'workspace_gone'],
+    // A capped drain made real progress; it just has more to read.
+    ['batch_cap', 'pending_settle'],
+  ] as const)('maps a %s stop to reason %s', (stop, reason) => {
+    const stale = facts({ drained_through: drainedAfter(-60_000) })
+    expect(evaluateSettlement(stale, stop).reason).toBe(reason)
+  })
+
+  it('echoes the facts the verdict was drawn from', () => {
+    const f = facts()
+    expect(evaluateSettlement(f, 'drained')).toMatchObject({
+      drained_through: f.drained_through,
+      activity_at: f.activity_at,
+    })
+  })
+})

--- a/control-plane/src/services/usage/settle.test.ts
+++ b/control-plane/src/services/usage/settle.test.ts
@@ -15,13 +15,14 @@ function facts(over: Partial<SessionSettlementFacts> = {}): SessionSettlementFac
     activity_at: ACTIVITY,
     drained_through: drainedAfter(DEFAULT_SETTLE_GRACE_MS + 1_000),
     chat_status: 'human',
+    workspace_status: 'running',
     ...over,
   }
 }
 
 describe('evaluateSettlement', () => {
   it('settles once a drain clears the activity by more than the settle grace', () => {
-    expect(evaluateSettlement(facts(), 'drained')).toMatchObject({
+    expect(evaluateSettlement(facts())).toMatchObject({
       complete: true,
       reason: null,
     })
@@ -31,7 +32,7 @@ describe('evaluateSettlement', () => {
     // The parser holds back a file's trailing entry until it has been quiescent
     // for the grace, so this drain cannot have seen the session's last record.
     const inside = facts({ drained_through: drainedAfter(DEFAULT_SETTLE_GRACE_MS - 1_000) })
-    expect(evaluateSettlement(inside, 'drained')).toMatchObject({
+    expect(evaluateSettlement(inside)).toMatchObject({
       complete: false,
       reason: 'pending_settle',
     })
@@ -39,7 +40,7 @@ describe('evaluateSettlement', () => {
 
   it('withholds a drain that predates the activity', () => {
     const before = facts({ drained_through: drainedAfter(-60_000) })
-    expect(evaluateSettlement(before, 'drained').complete).toBe(false)
+    expect(evaluateSettlement(before).complete).toBe(false)
   })
 
   it('never settles while a turn is running, however old the drain', () => {
@@ -47,19 +48,19 @@ describe('evaluateSettlement', () => {
       chat_status: 'agent',
       drained_through: drainedAfter(3_600_000),
     })
-    expect(evaluateSettlement(running, 'drained')).toMatchObject({
+    expect(evaluateSettlement(running)).toMatchObject({
       complete: false,
       reason: 'turn_in_progress',
     })
   })
 
-  it('reports a running turn ahead of a failed pull', () => {
-    const running = facts({ chat_status: 'agent' })
-    expect(evaluateSettlement(running, 'agent_unreachable').reason).toBe('turn_in_progress')
+  it('reports a running turn ahead of an unreachable workspace', () => {
+    const running = facts({ chat_status: 'agent', workspace_status: 'stopped' })
+    expect(evaluateSettlement(running).reason).toBe('turn_in_progress')
   })
 
   it('does not settle a workspace that was never drained', () => {
-    expect(evaluateSettlement(facts({ drained_through: null }), null)).toMatchObject({
+    expect(evaluateSettlement(facts({ drained_through: null }))).toMatchObject({
       complete: false,
       reason: 'pending_settle',
     })
@@ -67,32 +68,34 @@ describe('evaluateSettlement', () => {
 
   it('settles an empty session once the workspace has been drained', () => {
     // Nothing to account for, and a drain proved the agent had nothing to give.
-    expect(evaluateSettlement(facts({ activity_at: null }), 'drained')).toMatchObject({
+    expect(evaluateSettlement(facts({ activity_at: null }))).toMatchObject({
       complete: true,
       reason: null,
     })
   })
 
   it('does not settle an empty session before any drain', () => {
-    expect(
-      evaluateSettlement(facts({ activity_at: null, drained_through: null }), null).complete,
-    ).toBe(false)
+    expect(evaluateSettlement(facts({ activity_at: null, drained_through: null })).complete).toBe(
+      false,
+    )
   })
 
   it.each([
-    ['agent_unreachable', 'agent_unreachable'],
-    ['agent_error', 'agent_unreachable'],
-    ['workspace_gone', 'workspace_gone'],
-    // A capped drain made real progress; it just has more to read.
-    ['batch_cap', 'pending_settle'],
-  ] as const)('maps a %s stop to reason %s', (stop, reason) => {
-    const stale = facts({ drained_through: drainedAfter(-60_000) })
-    expect(evaluateSettlement(stale, stop).reason).toBe(reason)
+    // Transcripts are read out of the running pod, so anything else is a wait
+    // that polling alone will not end.
+    ['running', 'pending_settle'],
+    ['stopped', 'agent_unreachable'],
+    ['error', 'agent_unreachable'],
+    ['starting', 'agent_unreachable'],
+    [null, 'workspace_gone'],
+  ] as const)('reads workspace status %s as reason %s', (workspace_status, reason) => {
+    const stale = facts({ drained_through: drainedAfter(-60_000), workspace_status })
+    expect(evaluateSettlement(stale).reason).toBe(reason)
   })
 
   it('echoes the facts the verdict was drawn from', () => {
     const f = facts()
-    expect(evaluateSettlement(f, 'drained')).toMatchObject({
+    expect(evaluateSettlement(f)).toMatchObject({
       drained_through: f.drained_through,
       activity_at: f.activity_at,
     })

--- a/control-plane/src/services/usage/settle.ts
+++ b/control-plane/src/services/usage/settle.ts
@@ -1,0 +1,130 @@
+import { DEFAULT_SETTLE_GRACE_MS } from '../../../../internal/agent-usage/src/index'
+import { type SessionSettlementFacts, getSessionSettlementFacts } from '../db/workspace-usage'
+import { type PullStop, pullWorkspaceUsage } from './pull'
+
+/**
+ * Whether the ledger holds everything a session spent.
+ *
+ * Usage reaches the ledger by pulling the agent's transcripts, and the pull on
+ * `session.ended` is detached — so a caller reading straight after a run has no
+ * way to tell a cheap run from an account that has not arrived. Rather than
+ * have every consumer guess at a delay, the answer is derived and reported.
+ *
+ * The account is complete when a pull read the workspace to the end at a moment
+ * far enough past the session's last activity that the parser was no longer
+ * withholding anything. Both halves are load-bearing: draining alone proves the
+ * agent had nothing more to give *at that moment*, and the grace is what makes
+ * "that moment" cover the entry the parser was still holding back.
+ */
+
+/** Why an account is not complete. Null when it is. */
+type SettlementReason =
+  | 'turn_in_progress'
+  | 'pending_settle'
+  | 'agent_unreachable'
+  | 'workspace_gone'
+
+interface Settlement {
+  complete: boolean
+  /** When a pull last read this workspace to the end. */
+  drained_through: string | null
+  /** Latest activity cp can see for the session; the grace is measured from here. */
+  activity_at: string | null
+  reason: SettlementReason | null
+}
+
+/** Stops that no amount of retrying will get past. */
+const TERMINAL: PullStop[] = ['workspace_gone']
+
+/** How long a `wait` request sleeps between attempts. */
+const POLL_INTERVAL_MS = 3_000
+
+/** Upper bound on `wait`, so a caller cannot pin a request open indefinitely. */
+export const MAX_WAIT_SEC = 60
+
+function reasonFor(facts: SessionSettlementFacts, stop: PullStop | null): SettlementReason {
+  if (facts.chat_status === 'agent') return 'turn_in_progress'
+  if (stop === 'workspace_gone') return 'workspace_gone'
+  if (stop === 'agent_unreachable' || stop === 'agent_error') return 'agent_unreachable'
+  // 'batch_cap' included: the drain is real progress, just unfinished.
+  return 'pending_settle'
+}
+
+/**
+ * Decide a verdict from already-gathered facts. Pure, so the rule can be tested
+ * against the clock skews it exists to handle without a database or an agent.
+ */
+export function evaluateSettlement(
+  facts: SessionSettlementFacts,
+  stop: PullStop | null,
+): Settlement {
+  const base = {
+    drained_through: facts.drained_through,
+    activity_at: facts.activity_at,
+  }
+  // A turn still running will write more; nothing observed so far can be final.
+  const settled =
+    facts.chat_status !== 'agent' &&
+    facts.drained_through !== null &&
+    // No activity at all: the drain found the session had nothing to account for.
+    (facts.activity_at === null ||
+      new Date(facts.drained_through).getTime() - DEFAULT_SETTLE_GRACE_MS >
+        new Date(facts.activity_at).getTime())
+
+  return settled
+    ? { ...base, complete: true, reason: null }
+    : { ...base, complete: false, reason: reasonFor(facts, stop) }
+}
+
+// Collapses concurrent pulls of the same workspace onto one round trip. Several
+// clients waiting on sibling sessions of one workspace is the expected shape,
+// and each pull is a full drain — without this they would multiply into
+// redundant load on the agent for an answer they all share.
+const inFlight = new Map<string, Promise<PullStop>>()
+
+function pullOnce(workspaceId: string): Promise<PullStop> {
+  const existing = inFlight.get(workspaceId)
+  if (existing) return existing
+  const p = pullWorkspaceUsage(workspaceId)
+    .then((o) => o.stop)
+    .catch((e): PullStop => {
+      console.warn(`[usage] settle pull ws=${workspaceId}:`, e instanceof Error ? e.message : e)
+      return 'agent_error'
+    })
+    .finally(() => inFlight.delete(workspaceId))
+  inFlight.set(workspaceId, p)
+  return p
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * Report whether a session's account is complete, optionally pulling and
+ * waiting for it to become so.
+ *
+ * With `waitSec` unset this only reads what is already known — no round trip to
+ * the agent. With it set, the wait ends the moment the account settles, at the
+ * deadline, or on a stop that retrying cannot fix; a timeout returns the real
+ * verdict rather than pretending to have succeeded.
+ */
+export async function settleSessionUsage(
+  workspaceId: string,
+  sessionId: string,
+  waitSec = 0,
+): Promise<Settlement> {
+  if (waitSec <= 0) {
+    return evaluateSettlement(await getSessionSettlementFacts(workspaceId, sessionId), null)
+  }
+
+  const deadline = Date.now() + Math.min(waitSec, MAX_WAIT_SEC) * 1000
+  let stop: PullStop | null = null
+  while (true) {
+    stop = await pullOnce(workspaceId)
+    const result = evaluateSettlement(await getSessionSettlementFacts(workspaceId, sessionId), stop)
+    if (result.complete || TERMINAL.includes(stop)) return result
+
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) return result
+    await sleep(Math.min(POLL_INTERVAL_MS, remaining))
+  }
+}

--- a/control-plane/src/services/usage/settle.ts
+++ b/control-plane/src/services/usage/settle.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SETTLE_GRACE_MS } from '../../../../internal/agent-usage/src/index'
 import { type SessionSettlementFacts, getSessionSettlementFacts } from '../db/workspace-usage'
-import { type PullStop, pullWorkspaceUsage } from './pull'
+import { pullWorkspaceUsage } from './pull'
 
 /**
  * Whether the ledger holds everything a session spent.
@@ -33,20 +33,22 @@ interface Settlement {
   reason: SettlementReason | null
 }
 
-/** Stops that no amount of retrying will get past. */
-const TERMINAL: PullStop[] = ['workspace_gone']
+/** Shortest gap between two background pulls of one workspace. */
+const PULL_MIN_INTERVAL_MS = 2_000
 
-/** How long a `wait` request sleeps between attempts. */
-const POLL_INTERVAL_MS = 3_000
-
-/** Upper bound on `wait`, so a caller cannot pin a request open indefinitely. */
-export const MAX_WAIT_SEC = 60
-
-function reasonFor(facts: SessionSettlementFacts, stop: PullStop | null): SettlementReason {
+/**
+ * Why an incomplete account is incomplete — read off the same facts as the
+ * verdict rather than off the last pull's outcome, so it means the same thing
+ * on every cp replica and survives a restart. It separates "wait, this is
+ * converging" from "waiting will not help", which is all a polling caller
+ * needs to decide whether to keep going.
+ */
+function reasonFor(facts: SessionSettlementFacts): SettlementReason {
   if (facts.chat_status === 'agent') return 'turn_in_progress'
-  if (stop === 'workspace_gone') return 'workspace_gone'
-  if (stop === 'agent_unreachable' || stop === 'agent_error') return 'agent_unreachable'
-  // 'batch_cap' included: the drain is real progress, just unfinished.
+  if (facts.workspace_status === null) return 'workspace_gone'
+  // Transcripts are read out of the running pod; a stopped workspace keeps them
+  // on its volume, but nothing can collect them until it runs again.
+  if (facts.workspace_status !== 'running') return 'agent_unreachable'
   return 'pending_settle'
 }
 
@@ -54,10 +56,7 @@ function reasonFor(facts: SessionSettlementFacts, stop: PullStop | null): Settle
  * Decide a verdict from already-gathered facts. Pure, so the rule can be tested
  * against the clock skews it exists to handle without a database or an agent.
  */
-export function evaluateSettlement(
-  facts: SessionSettlementFacts,
-  stop: PullStop | null,
-): Settlement {
+export function evaluateSettlement(facts: SessionSettlementFacts): Settlement {
   const base = {
     drained_through: facts.drained_through,
     activity_at: facts.activity_at,
@@ -73,58 +72,56 @@ export function evaluateSettlement(
 
   return settled
     ? { ...base, complete: true, reason: null }
-    : { ...base, complete: false, reason: reasonFor(facts, stop) }
+    : { ...base, complete: false, reason: reasonFor(facts) }
 }
 
-// Collapses concurrent pulls of the same workspace onto one round trip. Several
-// clients waiting on sibling sessions of one workspace is the expected shape,
-// and each pull is a full drain — without this they would multiply into
-// redundant load on the agent for an answer they all share.
-const inFlight = new Map<string, Promise<PullStop>>()
-
-function pullOnce(workspaceId: string): Promise<PullStop> {
-  const existing = inFlight.get(workspaceId)
-  if (existing) return existing
-  const p = pullWorkspaceUsage(workspaceId)
-    .then((o) => o.stop)
-    .catch((e): PullStop => {
-      console.warn(`[usage] settle pull ws=${workspaceId}:`, e instanceof Error ? e.message : e)
-      return 'agent_error'
-    })
-    .finally(() => inFlight.delete(workspaceId))
-  inFlight.set(workspaceId, p)
-  return p
-}
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+// Last time a background pull was started per workspace. Together with the
+// in-flight map this bounds how much agent traffic a polling client can cause:
+// concurrent reads share one round trip, and a fast poll cannot start a new one
+// more often than PULL_MIN_INTERVAL_MS.
+const inFlight = new Map<string, Promise<unknown>>()
+const lastPullAt = new Map<string, number>()
 
 /**
- * Report whether a session's account is complete, optionally pulling and
- * waiting for it to become so.
+ * Nudge a workspace's usage forward without making the caller wait for it.
  *
- * With `waitSec` unset this only reads what is already known — no round trip to
- * the agent. With it set, the wait ends the moment the account settles, at the
- * deadline, or on a stop that retrying cannot fix; a timeout returns the real
- * verdict rather than pretending to have succeeded.
+ * The pull on `session.ended` fires while the transcript is still inside its
+ * settle grace, so it drains but cannot cover the entry the parser is holding
+ * back. Nothing else pulls until the half-hourly sweep — a client polling a
+ * purely passive read would sit at `complete: false` for that long. Reading an
+ * unsettled account is therefore what schedules the next pull, which makes a
+ * poll loop converge in seconds while keeping the read itself a database query.
+ */
+function schedulePull(workspaceId: string, workspaceStatus: string | null): void {
+  const now = Date.now()
+  // Only a running workspace can be read; anything else already says so in the
+  // verdict's reason, and pulling it would just burn a request to find out.
+  if (workspaceStatus !== 'running') return
+  if (inFlight.has(workspaceId)) return
+  if (now - (lastPullAt.get(workspaceId) ?? 0) < PULL_MIN_INTERVAL_MS) return
+
+  lastPullAt.set(workspaceId, now)
+  const p = pullWorkspaceUsage(workspaceId)
+    .catch((e) =>
+      console.warn(`[usage] settle pull ws=${workspaceId}:`, e instanceof Error ? e.message : e),
+    )
+    .finally(() => inFlight.delete(workspaceId))
+  inFlight.set(workspaceId, p)
+}
+
+/**
+ * Report whether a session's account is complete.
+ *
+ * Always a plain read — the verdict describes what the ledger holds right now,
+ * never what a pull might be about to add. An incomplete answer schedules a
+ * pull in the background so the next read can differ; poll until `complete`.
  */
 export async function settleSessionUsage(
   workspaceId: string,
   sessionId: string,
-  waitSec = 0,
 ): Promise<Settlement> {
-  if (waitSec <= 0) {
-    return evaluateSettlement(await getSessionSettlementFacts(workspaceId, sessionId), null)
-  }
-
-  const deadline = Date.now() + Math.min(waitSec, MAX_WAIT_SEC) * 1000
-  let stop: PullStop | null = null
-  while (true) {
-    stop = await pullOnce(workspaceId)
-    const result = evaluateSettlement(await getSessionSettlementFacts(workspaceId, sessionId), stop)
-    if (result.complete || TERMINAL.includes(stop)) return result
-
-    const remaining = deadline - Date.now()
-    if (remaining <= 0) return result
-    await sleep(Math.min(POLL_INTERVAL_MS, remaining))
-  }
+  const facts = await getSessionSettlementFacts(workspaceId, sessionId)
+  const result = evaluateSettlement(facts)
+  if (!result.complete) schedulePull(workspaceId, facts.workspace_status)
+  return result
 }

--- a/internal/agent-usage/src/index.ts
+++ b/internal/agent-usage/src/index.ts
@@ -71,6 +71,18 @@ export interface FileFingerprint {
 /** Cursor = fingerprint per transcript path; control-plane owns and persists it. */
 export type SweepCursors = Record<string, FileFingerprint>
 
+/**
+ * How long a transcript must sit untouched before its trailing entry counts as
+ * settled and gets emitted.
+ *
+ * Shared rather than local to the sweep because it is half of the answer to
+ * "does the ledger hold everything this session spent?": a pull that drained
+ * the agent covers only what was written this long before it ran. The consumer
+ * deciding whether an account is complete has to subtract the same grace the
+ * parser applied, so both sides read it from here.
+ */
+export const DEFAULT_SETTLE_GRACE_MS = 10_000
+
 /** Wire shape of the agent's `POST /usage` response. */
 export interface UsageSweepResponse {
   records: UsageRecord[]

--- a/internal/agent-usage/src/node.ts
+++ b/internal/agent-usage/src/node.ts
@@ -21,6 +21,7 @@ import {
   type UsageRecord,
   type UsageSweepResponse,
   type WarnFn,
+  DEFAULT_SETTLE_GRACE_MS,
   parseAcpUsageLog,
   parseClaudeTranscript,
   parseCodexRollout,
@@ -113,7 +114,7 @@ function listCodexRollouts(sessionsDir: string): string[] {
 export function sweepUsage(opts: SweepOpts): UsageSweepResponse {
   const warn = opts.onWarn
   const now = opts.now ?? Date.now()
-  const settleGraceMs = opts.settleGraceMs ?? 10_000
+  const settleGraceMs = opts.settleGraceMs ?? DEFAULT_SETTLE_GRACE_MS
   const prev = opts.cursors ?? {}
   const cursors: SweepCursors = {}
   const records: UsageRecord[] = []


### PR DESCRIPTION
Adds a per-session read of the token ledger, and makes "is this account complete?" something the API answers instead of something the caller guesses.

## Why

Token accounting was moved out of `sessions.last_turn_stats` and into the ledger, but only the write side landed. There is no per-session read at all, and the sync chat response's `stats` carries context gauges only — no tokens.

The gap matters most to a consumer that records what a single run cost. Usage reaches the ledger by pulling agent transcripts, and the pull fired at `session.ended` is detached, so a read taken right after a run can be short. Nothing in the response distinguished that from a genuinely cheap run.

## What

`GET /api/workspaces/{id}/sessions/{sessionId}/usage`

```jsonc
{
  "session_id": "...",
  "totals": { "input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
              "cache_creation_5m_tokens": 0, "cache_creation_1h_tokens": 0, "...": "" },
  "by_model": [ { "source": "codex", "model": "gpt-5.5", "...": "same fields" } ],
  "first_ts": "...", "last_ts": "...",
  "settlement": {
    "complete": true,
    "drained_through": "2026-08-10T06:40:55Z",
    "activity_at": "2026-08-10T06:40:44Z",
    "reason": null   // turn_in_progress | pending_settle | agent_unreachable | workspace_gone
  }
}
```

Tokens are split by the model that spent them: a session survives a core switch, and cache reads routinely run tens of times the input volume at a fraction of the price, so a single combined number misranks cost.

### How completeness is decided

An account is complete when a pull read the workspace **to the end** at a moment far enough past the session's last activity that the parser was no longer withholding a trailing entry.

Both halves are load-bearing, so both had to become observable:

- `pullWorkspaceUsage` now reports **why** it stopped. It used to return a row count that read identically for an empty pull and a failed one, which is exactly the distinction a watermark needs.
- Only a full drain stamps the new `workspace_usage_cursor.drained_through` (migration 136). `updated_at` cannot stand in: it advances on the batches that precede a failure, so a cursor abandoned halfway still looks fresh.
- The settle grace becomes a shared constant. The parser applies it when withholding a trailing entry and the verdict subtracts it when judging coverage; they have to be the same number.

### Reading is what drives it forward

The endpoint is a plain read — the verdict describes what the ledger holds now, never what a pull might be about to add. Callers poll until `complete`.

A purely passive read would not have converged, though: the `session.ended` pull fires while the transcript is still inside its settle grace, so it drains without covering the entry the parser is holding back, and nothing else pulls until the half-hourly sweep. So an *incomplete* read schedules a pull in the background. Concurrent reads share one round trip and a fast poll cannot start pulls closer than 2s apart, so agent traffic stays bounded however eagerly a client polls. For a session that just ended, a poll loop settles in about the length of the settle grace.

`reason` is derived from the workspace's status rather than from the last pull's outcome, so it means the same thing on every cp replica and survives a restart. It separates an account that is converging from one that polling will never advance — a stopped workspace still holds its transcripts on its volume, but nothing can collect them until it runs again.

### Two edges worth flagging

- **Deleted workspace.** The route falls back to the owner stamped on the ledger rows, which is the point of a ledger that keeps no foreign key — a caller that recycles a workspace after a run can still read what it cost. Narrower than the normal path: only the owner.
- **Unknown session.** 404, not zeros. For a caller comparing runs, a mistyped id must not read back as a free one.

`activity_at` is `GREATEST(sessions.last_active_at, MAX(messages.created_at), MAX(ledger.ts))`. There is no "turn ended" timestamp in the schema — `transitionSessionStatus` does not touch `last_active_at` — so the verdict uses the latest activity that can be seen.

## Testing

- 14 unit tests over the verdict, which is a pure function: inside/outside the grace, a drain predating the activity, a turn still running outranking an unreachable workspace, never-drained, empty session, and every workspace status mapped to its reason.
- Full control-plane suite (475) and agent-usage suite (25) pass; typecheck, biome and knip clean.
- Queries validated against production data inside `BEGIN … ROLLBACK`: a 3168-record session aggregates in 145ms, the settlement facts query in ~100ms. Also confirmed Postgres `GREATEST` ignores NULL arguments, which the activity fallback relies on.

## Not in this PR

Draining before a workspace is stopped or deleted. Today neither path collects first, so a workspace removed right after a run can take unpulled records to the grave with its volume. That is a lifecycle change and gets its own PR.
