### PR TITLE
Ship agent-usage into the control-plane image

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -100,6 +100,11 @@ COPY internal/k8s-provider /internal/k8s-provider
 # /app/src/routes/admin/system-settings.ts (used to validate admin config and
 # list available providers; the periodic sweep itself runs in the scheduler).
 COPY internal/titlegen /internal/titlegen
+# agent-usage is imported via ../../../../internal/agent-usage/src/index from
+# /app/src/services/{usage,db}/*.ts. Long type-only (erased before the bundler
+# saw it), now also for the settle grace the parser and the completeness verdict
+# have to share, so the module has to be present to resolve.
+COPY internal/agent-usage /internal/agent-usage
 
 RUN npm run build
 


### PR DESCRIPTION
Fixes the control-plane image build, broken by #229.

The image copies each internal package it needs by name, and `internal/agent-usage` was never on that list. Nothing noticed until now because every import of it from cp was type-only — erased before esbuild went looking for the module. #229 added a value import (`DEFAULT_SETTLE_GRACE_MS`, shared so the parser withholding a trailing entry and the verdict subtracting the grace cannot drift), so the bundler had to resolve the path for the first time and stopped:

```
✘ [ERROR] Could not resolve "../../../../internal/agent-usage/src/index"
    src/services/usage/settle.ts:1:40
```

A local `npm run build` cannot catch this: outside the image that relative path lands in the repo itself, copied or not. Verified instead by building the `backend-builder` stage, which now bundles clean.

The package has no runtime dependencies and is reached by a relative path, so it bundles into `dist` — no install step and nothing added to the runtime image.
