### PR TITLE
Collect a workspace's usage before its pod goes away

### DIFF
--- a/control-plane/src/lib/sse.ts
+++ b/control-plane/src/lib/sse.ts
@@ -972,14 +972,23 @@ function createPersistMainTurnPlugin(ctx: PersistPluginCtx): TurnPlugin {
 
           // Fresh-data token-usage pull for this workspace. Detached (not on the
           // serial queue) so the 30s-timeout fetch never delays message
-          // persistence; the periodic sweep is the completeness backstop, so a
-          // failure here is harmless.
-          void pullWorkspaceUsage(workspaceId).catch((e) =>
-            console.warn(
-              `[usage] session.ended pull ws=${workspaceId}:`,
-              e instanceof Error ? e.message : e,
-            ),
-          )
+          // persistence; nothing is lost when it fails — the transcripts keep
+          // the records and a later pull collects them — but a pull that keeps
+          // failing leaves accounts open, so say which ones did not land.
+          void pullWorkspaceUsage(workspaceId)
+            .then((o) => {
+              if (!o.drained) {
+                console.warn(
+                  `[usage] session.ended pull ws=${workspaceId} did not drain (${o.stop})`,
+                )
+              }
+            })
+            .catch((e) =>
+              console.warn(
+                `[usage] session.ended pull ws=${workspaceId}:`,
+                e instanceof Error ? e.message : e,
+              ),
+            )
 
           const reason = (evt as UniversalEvent).reason
           state.endReason = reason ?? null

--- a/control-plane/src/routes/admin/workspaces.ts
+++ b/control-plane/src/routes/admin/workspaces.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import type { AppEnv } from '../../lib/types'
 import { pool } from '../../services/db/pool'
 import { getWorkspace } from '../../services/db/workspaces'
+import { UsageNotDrained } from '../../services/usage/teardown'
 import { destroyWorkspace, stopWorkspace } from '../../services/workspace-lifecycle'
 
 const workspaces = new Hono<AppEnv>()
@@ -133,11 +134,16 @@ workspaces.delete('/:id', async (c) => {
   if (!workspace) {
     return c.json({ error: 'Workspace not found' }, 404)
   }
+  // `force=true` skips the refusal when the workspace's usage cannot be
+  // collected first — same escape hatch as the owner route, since an operator
+  // clearing out a wedged workspace needs it more, not less.
+  const force = c.req.query('force') === 'true'
   try {
-    console.log(`[Admin] Delete workspace=${id}`)
-    await destroyWorkspace(workspace)
+    console.log(`[Admin] Delete workspace=${id}${force ? ' (force)' : ''}`)
+    await destroyWorkspace(workspace, force)
     return c.json({ success: true })
   } catch (e) {
+    if (e instanceof UsageNotDrained) return c.json({ error: e.message }, 409)
     return c.json({ error: e instanceof Error ? e.message : 'Failed to delete workspace' }, 500)
   }
 })

--- a/control-plane/src/routes/workspaces/write.ts
+++ b/control-plane/src/routes/workspaces/write.ts
@@ -20,6 +20,7 @@ import { chooseEnvironment } from '../../services/placement-decision'
 import { skillRepo } from '../../services/skills-composition'
 import { materializeTemplateLayout } from '../../services/template-layout'
 import { materializeTemplateSchedules } from '../../services/template-schedules'
+import { UsageNotDrained } from '../../services/usage/teardown'
 import { applyWorkspaceConfigUpdate } from '../../services/workspace-config'
 import { destroyWorkspace } from '../../services/workspace-lifecycle'
 import { canManage, toApiWorkspace } from './_shared'
@@ -310,12 +311,34 @@ const deleteRouteDef = createRoute({
   path: '/{id}',
   tags: ['workspaces'],
   summary: 'Delete a workspace and its underlying instance',
+  description: [
+    "Collects the workspace's outstanding token usage into the ledger before",
+    'tearing it down — the volume goes with the workspace, so records left on',
+    'it cannot be recovered. This waits out the transcript settle grace, so the',
+    'call takes a few seconds longer than the teardown itself.',
+    '',
+    'A running workspace that cannot be read answers 409: that is usually',
+    'transient and worth retrying. `force=true` deletes regardless, for an agent',
+    'wedged badly enough that waiting would never help.',
+  ].join('\n'),
   security: [{ bearerAuth: [] }],
-  request: { params: WorkspaceIdParam },
+  request: {
+    params: WorkspaceIdParam,
+    query: z.object({
+      force: z
+        .enum(['true', 'false'])
+        .optional()
+        .openapi({ param: { name: 'force', in: 'query' } }),
+    }),
+  },
   responses: {
     200: { description: 'Deleted', content: { 'application/json': { schema: SuccessSchema } } },
     404: {
       description: 'Workspace not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+    409: {
+      description: 'Usage could not be collected before deleting',
       content: { 'application/json': { schema: ErrorSchema } },
     },
   },
@@ -324,12 +347,18 @@ const deleteRouteDef = createRoute({
 write.openapi(deleteRouteDef, async (c) => {
   const currentUser = c.get('user')
   const { id } = c.req.valid('param')
+  const { force } = c.req.valid('query')
   const workspace = await getWorkspace(id)
   if (!workspace || !canManage(workspace, currentUser)) {
     return c.json({ error: 'Workspace not found' }, 404)
   }
 
-  await destroyWorkspace(workspace)
+  try {
+    await destroyWorkspace(workspace, force === 'true')
+  } catch (e) {
+    if (e instanceof UsageNotDrained) return c.json({ error: e.message }, 409)
+    throw e
+  }
   return c.json({ success: true }, 200)
 })
 

--- a/control-plane/src/services/db/batch.ts
+++ b/control-plane/src/services/db/batch.ts
@@ -97,6 +97,20 @@ export async function listBatchTasks(batchRunId: string): Promise<BatchTask[]> {
   return rows
 }
 
+/**
+ * Task counts plus what the run's sessions spent.
+ *
+ * The tokens come from the usage ledger. They used to come from
+ * `sessions.last_turn_stats`, which held one turn's snapshot — summing those
+ * across tasks counted only each session's final turn, and once token
+ * accounting moved to the ledger the fields stopped being written at all, so
+ * the totals were a constant zero. The ledger has every turn, and keeps them
+ * after the session is deleted.
+ *
+ * No money: there is no pricing layer yet, and cache-read tokens (often tens of
+ * times the input volume, at a fraction of the price) make raw token counts a
+ * poor stand-in for one. They stay in their own column for whoever prices them.
+ */
 export async function getBatchRunStats(batchRunId: string): Promise<{
   total: number
   queued: number
@@ -104,9 +118,13 @@ export async function getBatchRunStats(batchRunId: string): Promise<{
   completed: number
   failed: number
   cancelled: number
-  total_cost_usd: number
-  total_duration_ms: number
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cache_read_tokens: number
+  total_cache_creation_tokens: number
 }> {
+  // LATERAL, not a join to the ledger: a task with 300 usage rows would
+  // otherwise appear 300 times and multiply every status count with it.
   const { rows } = await pool.query(
     `SELECT
        COUNT(*)::int AS total,
@@ -115,12 +133,34 @@ export async function getBatchRunStats(batchRunId: string): Promise<{
        COUNT(*) FILTER (WHERE bt.status = 'completed')::int AS completed,
        COUNT(*) FILTER (WHERE bt.status = 'failed')::int AS failed,
        COUNT(*) FILTER (WHERE bt.status = 'cancelled')::int AS cancelled,
-       COALESCE(SUM((s.last_turn_stats->>'costUsd')::numeric), 0)::float AS total_cost_usd,
-       COALESCE(SUM((s.last_turn_stats->>'durationMs')::numeric), 0)::float AS total_duration_ms
+       COALESCE(SUM(u.input_tokens), 0)::bigint          AS total_input_tokens,
+       COALESCE(SUM(u.output_tokens), 0)::bigint         AS total_output_tokens,
+       COALESCE(SUM(u.cache_read_tokens), 0)::bigint     AS total_cache_read_tokens,
+       COALESCE(SUM(u.cache_creation_tokens), 0)::bigint AS total_cache_creation_tokens
      FROM batch_tasks bt
-     LEFT JOIN sessions s ON s.id = bt.session_id
+     LEFT JOIN LATERAL (
+       SELECT SUM(e.input_tokens)          AS input_tokens,
+              SUM(e.output_tokens)         AS output_tokens,
+              SUM(e.cache_read_tokens)     AS cache_read_tokens,
+              SUM(e.cache_creation_tokens) AS cache_creation_tokens
+         FROM workspace_usage_events e
+        WHERE e.session_id = bt.session_id
+     ) u ON TRUE
      WHERE bt.batch_run_id = $1`,
     [batchRunId],
   )
-  return rows[0]
+  const r = rows[0]
+  return {
+    total: r.total,
+    queued: r.queued,
+    running: r.running,
+    completed: r.completed,
+    failed: r.failed,
+    cancelled: r.cancelled,
+    // pg returns bigint as string; the counts above are already int.
+    total_input_tokens: Number(r.total_input_tokens),
+    total_output_tokens: Number(r.total_output_tokens),
+    total_cache_read_tokens: Number(r.total_cache_read_tokens),
+    total_cache_creation_tokens: Number(r.total_cache_creation_tokens),
+  }
 }

--- a/control-plane/src/services/usage/teardown.test.ts
+++ b/control-plane/src/services/usage/teardown.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTLE_GRACE_MS } from '../../../../internal/agent-usage/src/index'
+
+vi.mock('./pull', () => ({ pullWorkspaceUsage: vi.fn() }))
+
+import { pullWorkspaceUsage } from './pull'
+import { UsageNotDrained, drainAfterStop, drainBeforeDelete } from './teardown'
+
+const RUNNING = { id: 'ws1', user_id: 'alice', status: 'running' }
+
+/** Long enough for the parser to consider the transcripts quiescent. */
+const PAST_GRACE = DEFAULT_SETTLE_GRACE_MS + 5_000
+
+function pullReturns(drained: boolean, stop = drained ? 'drained' : 'agent_unreachable') {
+  vi.mocked(pullWorkspaceUsage).mockResolvedValue({ inserted: 0, drained, stop } as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+})
+afterEach(() => vi.useRealTimers())
+
+describe('drainBeforeDelete', () => {
+  it('waits out the settle grace before reading', async () => {
+    // Reading early risks ingesting a half-written record, which would then
+    // block the finished one as a duplicate — a silent undercount.
+    pullReturns(true)
+    const p = drainBeforeDelete(RUNNING, Date.now(), false)
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_SETTLE_GRACE_MS - 1)
+    expect(pullWorkspaceUsage).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(PAST_GRACE)
+    await p
+    expect(pullWorkspaceUsage).toHaveBeenCalledWith('ws1', 'alice')
+  })
+
+  it('does not wait again for time already spent tearing down', async () => {
+    pullReturns(true)
+    const startedAt = Date.now()
+    await vi.advanceTimersByTimeAsync(PAST_GRACE)
+
+    await drainBeforeDelete(RUNNING, startedAt, false)
+    expect(pullWorkspaceUsage).toHaveBeenCalled()
+  })
+
+  it('refuses the delete when a running workspace cannot be read', async () => {
+    pullReturns(false)
+    const p = drainBeforeDelete(RUNNING, Date.now(), false)
+    const assertion = expect(p).rejects.toBeInstanceOf(UsageNotDrained)
+    await vi.advanceTimersByTimeAsync(PAST_GRACE)
+    await assertion
+  })
+
+  it('deletes anyway under force, so a wedged agent cannot pin a workspace', async () => {
+    pullReturns(false)
+    const p = drainBeforeDelete(RUNNING, Date.now(), true)
+    await vi.advanceTimersByTimeAsync(PAST_GRACE)
+    await expect(p).resolves.toBeUndefined()
+  })
+
+  it.each(['stopped', 'error', 'deleting'])(
+    'skips a %s workspace instead of demanding it be started first',
+    async (status) => {
+      await drainBeforeDelete({ ...RUNNING, status }, Date.now(), false)
+      expect(pullWorkspaceUsage).not.toHaveBeenCalled()
+    },
+  )
+})
+
+describe('drainAfterStop', () => {
+  it('reads after the grace without the caller waiting on it', async () => {
+    pullReturns(true)
+    // Returns void: a stop keeps its volume, so nothing here is worth blocking on.
+    expect(drainAfterStop('ws1', 'alice', Date.now())).toBeUndefined()
+    expect(pullWorkspaceUsage).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(PAST_GRACE)
+    expect(pullWorkspaceUsage).toHaveBeenCalledWith('ws1', 'alice')
+  })
+
+  it('swallows a failed pull', async () => {
+    // The pod is often already gone by now. Nothing is lost — the volume keeps
+    // the records — so this must not surface as an unhandled rejection.
+    vi.mocked(pullWorkspaceUsage).mockRejectedValue(new Error('pod gone'))
+    drainAfterStop('ws1', 'alice', Date.now())
+
+    await vi.advanceTimersByTimeAsync(PAST_GRACE)
+    expect(pullWorkspaceUsage).toHaveBeenCalled()
+  })
+})

--- a/control-plane/src/services/usage/teardown.ts
+++ b/control-plane/src/services/usage/teardown.ts
@@ -1,0 +1,97 @@
+import { DEFAULT_SETTLE_GRACE_MS } from '../../../../internal/agent-usage/src/index'
+import { pullWorkspaceUsage } from './pull'
+
+/**
+ * Collecting a workspace's outstanding usage before its pod goes away.
+ *
+ * Usage lives on the transcripts until a pull moves it into the ledger, and the
+ * only thing that pulls is a running pod. Deleting a workspace takes its volume
+ * with it, so anything not yet collected is gone for good — and a caller that
+ * recycles a workspace after each run is exactly the one that would lose it.
+ *
+ * The wait is what makes the collection whole rather than nearly whole. The
+ * parser withholds a transcript's trailing entry until the file has been
+ * quiescent for the settle grace, so a pull fired the instant a turn is
+ * interrupted misses the last record it was written for. Waiting is also the
+ * only safe way to get it: reading early could ingest a half-written streaming
+ * record, and since it carries the same dedup key as the finished one, the
+ * finished one would then be rejected as a duplicate — undercounting silently,
+ * which is worse than being late.
+ */
+
+/** Slack on top of the grace, so the parser's comparison is not a photo finish. */
+const SETTLE_MARGIN_MS = 1_000
+
+/** Wait until transcripts last written around `since` count as quiescent. */
+async function awaitQuiescent(since: number): Promise<void> {
+  const remaining = since + DEFAULT_SETTLE_GRACE_MS + SETTLE_MARGIN_MS - Date.now()
+  if (remaining > 0) await new Promise((r) => setTimeout(r, remaining))
+}
+
+/** Thrown when a teardown cannot account for what the workspace spent. */
+export class UsageNotDrained extends Error {
+  constructor(
+    readonly workspaceId: string,
+    readonly stop: string,
+  ) {
+    super(
+      `Could not collect usage for workspace ${workspaceId} before deleting it (${stop}). Its unread records would be destroyed with the volume. Retry, or pass force=true to delete anyway.`,
+    )
+    this.name = 'UsageNotDrained'
+  }
+}
+
+/**
+ * Collect on the way to a stop. Detached from the caller and best-effort: the
+ * volume survives a stop, so whatever this misses is still there to collect
+ * after the next start. It runs at all so that a workspace stopped right after
+ * a run still settles its account instead of leaving it open until then.
+ *
+ * Racing the scale-down is fine. The runner takes a reconcile tick to act on
+ * desired=stopped, which is usually room enough, and losing the race costs
+ * nothing that the next start will not recover.
+ */
+export function drainAfterStop(workspaceId: string, userId: string, settleFrom: number): void {
+  void awaitQuiescent(settleFrom)
+    .then(() => pullWorkspaceUsage(workspaceId, userId))
+    .then((o) => {
+      if (!o.drained) console.warn(`[usage] stop drain incomplete ws=${workspaceId} (${o.stop})`)
+    })
+    .catch((e) =>
+      console.warn(`[usage] stop drain ws=${workspaceId}:`, e instanceof Error ? e.message : e),
+    )
+}
+
+/**
+ * Collect before a delete, blocking until it is done.
+ *
+ * Throws `UsageNotDrained` if the workspace is running and cannot be read,
+ * because that is a transient failure worth retrying rather than a reason to
+ * destroy the records. `force` is the way out for a workspace whose agent is
+ * wedged — a workspace must never become undeletable.
+ *
+ * A workspace that is not running is not blocked on: nothing can read its
+ * transcripts, so refusing would only mean "start it before you may delete it".
+ * The loss is logged instead, since that is all that can honestly be done.
+ */
+export async function drainBeforeDelete(
+  workspace: { id: string; user_id: string; status: string },
+  settleFrom: number,
+  force: boolean,
+): Promise<void> {
+  if (workspace.status !== 'running') {
+    console.warn(
+      `[usage] deleting a ${workspace.status} workspace ws=${workspace.id} — any records not yet collected go with its volume`,
+    )
+    return
+  }
+
+  await awaitQuiescent(settleFrom)
+  const outcome = await pullWorkspaceUsage(workspace.id, workspace.user_id)
+  if (outcome.drained) return
+
+  if (!force) throw new UsageNotDrained(workspace.id, outcome.stop)
+  console.warn(
+    `[usage] forced delete ws=${workspace.id} with usage undrained (${outcome.stop}) — records not yet collected are lost`,
+  )
+}

--- a/control-plane/src/services/workspace-lifecycle.test.ts
+++ b/control-plane/src/services/workspace-lifecycle.test.ts
@@ -16,12 +16,17 @@ vi.mock('./db/sessions', () => ({ resetAllSessionsIdle: vi.fn() }))
 vi.mock('./db/workspaces', () => ({ deleteWorkspace: vi.fn(), updateWorkspace: vi.fn() }))
 vi.mock('./placement', () => ({ setDesiredPhase: vi.fn() }))
 vi.mock('./k8s', () => ({ destroy: vi.fn() }))
+vi.mock('./usage/teardown', () => ({
+  drainAfterStop: vi.fn(),
+  drainBeforeDelete: vi.fn(),
+}))
 
 import { getWorkspacePlacementEnv } from './db/environments'
 import { deleteWorkspace, updateWorkspace } from './db/workspaces'
 import * as k8s from './k8s'
 import { setDesiredPhase } from './placement'
-import { destroyWorkspace } from './workspace-lifecycle'
+import { drainAfterStop, drainBeforeDelete } from './usage/teardown'
+import { destroyWorkspace, stopWorkspace } from './workspace-lifecycle'
 
 const ws = { id: 'ws1' } as Workspace
 
@@ -56,5 +61,44 @@ describe('destroyWorkspace', () => {
     expect(updateWorkspace).toHaveBeenCalledWith('ws1', { status: 'deleting' })
     expect(k8s.destroy).not.toHaveBeenCalled()
     expect(deleteWorkspace).not.toHaveBeenCalled()
+  })
+
+  // Both teardown paths put the transcripts out of reach — the built-in one
+  // destroys the volume, the remote one hands the workspace to a runner that
+  // will. Collecting has to happen before either, not inside one of them.
+  it.each([true, false])('collects usage before tearing down (builtin=%s)', async (isBuiltin) => {
+    vi.mocked(getWorkspacePlacementEnv).mockResolvedValue({ isBuiltin } as never)
+    const order: string[] = []
+    vi.mocked(drainBeforeDelete).mockImplementation(async () => {
+      order.push('drain')
+    })
+    vi.mocked(k8s.destroy).mockImplementation(async () => {
+      order.push('teardown')
+    })
+    vi.mocked(setDesiredPhase).mockImplementation(async () => {
+      order.push('teardown')
+    })
+
+    await destroyWorkspace(ws)
+    expect(order).toEqual(['drain', 'teardown'])
+  })
+
+  it('passes force through, and lets a refusal stop the delete', async () => {
+    vi.mocked(getWorkspacePlacementEnv).mockResolvedValue({ isBuiltin: true } as never)
+    vi.mocked(drainBeforeDelete).mockRejectedValue(new Error('undrained'))
+
+    await expect(destroyWorkspace(ws, true)).rejects.toThrow('undrained')
+    expect(drainBeforeDelete).toHaveBeenCalledWith(ws, expect.any(Number), true)
+    expect(k8s.destroy).not.toHaveBeenCalled()
+    expect(deleteWorkspace).not.toHaveBeenCalled()
+  })
+})
+
+describe('stopWorkspace', () => {
+  it('collects usage on the way out, without waiting for it', async () => {
+    await stopWorkspace(ws)
+
+    expect(setDesiredPhase).toHaveBeenCalledWith('ws1', 'stopped')
+    expect(drainAfterStop).toHaveBeenCalledWith('ws1', ws.user_id, expect.any(Number))
   })
 })

--- a/control-plane/src/services/workspace-lifecycle.ts
+++ b/control-plane/src/services/workspace-lifecycle.ts
@@ -8,6 +8,7 @@ import type { Workspace } from './db/types'
 import { deleteWorkspace, updateWorkspace } from './db/workspaces'
 import * as k8s from './k8s'
 import { setDesiredPhase } from './placement'
+import { drainAfterStop, drainBeforeDelete } from './usage/teardown'
 
 /**
  * Stop a workspace: interrupt active sessions, record desired=stopped (the
@@ -19,9 +20,13 @@ import { setDesiredPhase } from './placement'
  */
 export async function stopWorkspace(workspace: Workspace): Promise<void> {
   await interruptAllSessions(workspace, 'Stop')
+  // Interrupting is the last thing that can add to the transcripts, so the wait
+  // for them to settle starts here. Detached — see drainAfterStop.
+  const settleFrom = Date.now()
   await setDesiredPhase(workspace.id, 'stopped')
   await resetAllSessionsIdle(workspace.id)
   await updateWorkspace(workspace.id, { status: 'stopped' })
+  drainAfterStop(workspace.id, workspace.user_id, settleFrom)
 }
 
 /**
@@ -37,16 +42,24 @@ export async function stopWorkspace(workspace: Workspace): Promise<void> {
  * projection. Built-in environments delete the k8s instance and the row
  * synchronously.
  *
+ * Its usage is collected first, because both exits below put the transcripts
+ * out of reach — see drainBeforeDelete, which is also what `force` overrides.
+ *
  * Shared by the owner delete route and the admin fleet view.
  */
-export async function destroyWorkspace(workspace: Workspace): Promise<void> {
+export async function destroyWorkspace(workspace: Workspace, force = false): Promise<void> {
   await interruptAllSessions(workspace, 'Delete')
+  const settleFrom = Date.now()
 
   for (const s of await listSchedulesByWorkspace(workspace.id)) {
     await jobs.cancelScheduleTimer(s).catch(() => {})
   }
 
   await fireDeleteHooks(workspace.id)
+
+  // Before either teardown path, and after the work above — which the settle
+  // wait absorbs rather than adds to.
+  await drainBeforeDelete(workspace, settleFrom, force)
 
   const placementEnv = await getWorkspacePlacementEnv(workspace.id)
   if (placementEnv && !placementEnv.isBuiltin) {

--- a/internal/client/src/batch-runs.ts
+++ b/internal/client/src/batch-runs.ts
@@ -36,8 +36,12 @@ export interface BatchRunStats {
   completed: number
   failed: number
   cancelled: number
-  total_cost_usd: number
-  total_duration_ms: number
+  /** Summed from the usage ledger over the run's sessions. Cache tiers stay
+   *  separate — a cache read costs a fraction of an input token. */
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cache_read_tokens: number
+  total_cache_creation_tokens: number
 }
 
 export interface BatchRunDetail extends BatchRun {


### PR DESCRIPTION
Closes the gap flagged in #229: nothing collected a workspace's outstanding token usage before teardown, so deleting one destroyed whatever the ledger had not caught up on.

## Why

Usage sits on the transcripts until a pull moves it into the ledger, and only a running pod can be pulled. Deleting a workspace takes its volume along. The only pull outside the half-hourly sweep was the detached one fired at `session.ended`, so a delete raced it — and for a caller that recycles a workspace after each run, usually won. The loss was silent.

## What

**Delete collects first, and refuses if it cannot.** A running workspace that will not answer is a transient failure worth retrying, not a reason to destroy the records, so the route answers **409**. `force=true` deletes regardless — a wedged agent must never leave a workspace undeletable. Both the owner route and the admin fleet delete take it.

A workspace that is already **stopped** is not blocked on. Its transcripts are unreadable either way, and refusing would only mean "start it before you may delete it", so the loss is logged instead. That is the honest limit of what teardown can do.

**Stop collects too, detached.** The volume survives a stop, so anything missed is still there after the next start — but without this, a workspace stopped right after a run leaves its account open until then, and the settlement verdict added in #229 would sit at `agent_unreachable` indefinitely. Racing the scale-down is fine: the runner needs a reconcile tick to act, and losing the race costs nothing.

### Why both wait

The parser withholds a transcript's trailing entry until the file has been quiescent for the settle grace, so a pull fired the instant a turn is interrupted misses the very record it was fired for.

Waiting is also the only *safe* way to get it. Reading early can ingest a half-written streaming record, and since it carries the same dedup key as the finished one, the finished one would then be rejected as a duplicate — an undercount with no trace. Bypassing the grace would have been the faster fix and the wrong one.

The wait starts when the sessions are interrupted, so cancelling schedules and firing delete hooks happen *inside* it rather than after: the added latency is the remainder, not the whole grace.

## Batch-run stats come off the ledger

Same root cause, so it travels with this. `getBatchRunStats` summed `sessions.last_turn_stats`, which held one turn's snapshot — summing those counted only each session's final turn, and once accounting moved to the ledger the fields stopped being written at all, leaving `total_cost_usd` and `total_duration_ms` pinned at zero.

Token totals from the ledger replace them, cache tiers apart. No money: there is no pricing layer, and a cache read costs a fraction of an input token, so a summed token count is not a cost.

The ledger is reached with a `LATERAL`, not a join — a task with 300 usage rows would otherwise appear 300 times and multiply every status count with it.

Also: the `session.ended` pull now logs when it does not drain, instead of only when it throws.

## Testing

- 9 tests on the teardown itself (fake timers): the grace is waited out, time already spent tearing down is not waited twice, a running workspace that cannot be read is refused, `force` gets through, a non-running one is skipped, and the stop path neither blocks nor surfaces an unhandled rejection.
- 4 more on the wiring: collection happens before *both* teardown paths (built-in destroy and remote hand-off), `force` is passed through, and a refusal stops the delete before anything is torn down.
- Full control-plane suite (498) passes; typecheck, biome, knip clean.
- The new batch query was run against production data: task counts match ground truth on three real runs (no row multiplication), and the token totals come back non-zero where the old ones were structurally zero.
