### PR TITLE
fix: keep template-backed config fields from resolving to null

### DIFF
--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -306,10 +306,14 @@ export async function getWorkspaceConfig(workspaceId: string): Promise<Workspace
             ELSE wc.small_model END AS small_model,
        CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.system_prompt, ''), tv.system_prompt)
             ELSE wc.system_prompt END AS system_prompt,
-       CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.mcp_config, '{}'), tv.mcp_config::text)
-            ELSE wc.mcp_config END AS mcp_config,
-       CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.agent_settings, '{}'), tv.agent_settings::text)
-            ELSE wc.agent_settings END AS agent_settings,
+       -- The outer COALESCE guards a template_id that resolves to no
+       -- template_versions row: the inner NULLIF turns an empty '{}' into NULL,
+       -- and tv.* is NULL from the LEFT JOIN, so both arms would be NULL and
+       -- the string-typed field would reach clients as null.
+       COALESCE(CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.mcp_config, '{}'), tv.mcp_config::text)
+            ELSE wc.mcp_config END, '{}') AS mcp_config,
+       COALESCE(CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.agent_settings, '{}'), tv.agent_settings::text)
+            ELSE wc.agent_settings END, '{}') AS agent_settings,
        CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(wc.compute_resources, tv.compute_resources)
             ELSE wc.compute_resources END AS compute_resources,
        wc.auto_start,

--- a/web/src/components/dialogs/CreateWorkspaceDialog.tsx
+++ b/web/src/components/dialogs/CreateWorkspaceDialog.tsx
@@ -34,7 +34,7 @@ import { api } from '@/lib/api/client'
 import type { ApiTemplate } from '@/lib/api/types'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronsUpDown, Globe, Lock, Users } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
@@ -190,7 +190,13 @@ export default function CreateWorkspaceDialog({ open, onOpenChange }: DialogProp
   const navigate = useNavigate()
   const { user } = useAuth()
   const createMutation = useCreateWorkspace()
-  const { templates } = useTemplates()
+  const { templates: allTemplates } = useTemplates()
+  // A template without a published version carries no config to seed from, so
+  // creating off it yields a workspace with an empty model, prompt and MCP set.
+  const templates = useMemo(
+    () => allTemplates?.filter((tpl) => tpl.latest_version > 0),
+    [allTemplates],
+  )
   const { data: environments = [] } = useEnvironments()
   const [form, setForm] = useState<FormState>(INITIAL_FORM)
   const [visibleSections, setVisibleSections] = useState<AgentConfigSection[]>(['model'])

--- a/web/src/components/workspace/McpConfigEditor.tsx
+++ b/web/src/components/workspace/McpConfigEditor.tsx
@@ -167,7 +167,10 @@ function emptyDraft(): StructuredDraft {
 
 function parseMcp(raw: string): McpConfig {
   try {
-    return JSON.parse(raw)
+    // `JSON.parse` succeeds on `null` and on scalars, so a bare try/catch is
+    // not enough — only an object shape can be read for `mcpServers`.
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : {}
   } catch {
     return {}
   }


### PR DESCRIPTION
## What breaks

Opening a workspace whose settings panel is parked on the **MCP** page renders a blank screen. The console shows:

```
TypeError: Cannot read properties of null (reading 'mcpServers')
```

It reproduces on every reload, because the settings panel persists its active section — the user cannot navigate away from the page that crashes.

## Root cause

`getWorkspaceConfig` resolves template-backed fields with:

```sql
CASE WHEN wc.template_id IS NOT NULL
     THEN COALESCE(NULLIF(wc.mcp_config, '{}'), tv.mcp_config::text)
     ELSE wc.mcp_config END AS mcp_config
```

`tv` comes from `LEFT JOIN template_versions ... AND wc.template_version = tv.version`. When a workspace points at a template that has **no published version**, the join misses, so `tv.mcp_config` is NULL — and the workspace's own value is the default `'{}'`, which `NULLIF` also turns into NULL. Both COALESCE arms are empty, and a field typed `string` on the API reaches the client as `null`. `agent_settings` has the identical shape one line below.

The MCP editor's parse guard then lets it through:

```ts
function parseMcp(raw: string) {
  try { return JSON.parse(raw) } catch { return {} }
}
```

`JSON.parse(null)` is `JSON.parse("null")` — it returns `null` instead of throwing, so the `catch` never fires and `parsed.mcpServers` throws during render, taking down the tree.

## Fix

1. **control-plane** — wrap both resolved fields in an outer `COALESCE(..., '{}')`, so a string-typed field is never NULL regardless of template state.
2. **web** — make `parseMcp` require an object shape, not merely a successful parse.
3. **web** — hide versionless templates in the create-workspace picker. A template with no published version seeds nothing, so workspaces created from it come up with no model, no prompt and no MCP config — the state that triggered this in the first place.

Layers 1 and 2 are independent: either alone stops the blank screen, and both are worth having (the API contract and the render guard).

## Verification

- Ran the patched query against a live database for an affected workspace: `mcp_config` now returns `'{}'` instead of `null`, and unaffected workspaces (own config, and template-backed with a real version) return byte-identical values to before.
- `tsc --noEmit` clean in `web` and `control-plane`.
- `control-plane`: 39 files / 498 tests pass. `web`: 9 files / 159 tests pass.