### PR TITLE
feat(skills): accept zip uploads alongside tar.gz

### DIFF
--- a/control-plane/src/routes/skills.ts
+++ b/control-plane/src/routes/skills.ts
@@ -351,7 +351,7 @@ const scanTarballRoute = createRoute({
   method: 'post',
   path: '/scan-tarball',
   tags: ['skills'],
-  summary: 'List skill candidates inside an uploaded tarball without persisting',
+  summary: 'List skill candidates inside an uploaded archive (tar.gz or zip) without persisting',
   security: [{ bearerAuth: [] }],
   responses: {
     200: {
@@ -361,7 +361,7 @@ const scanTarballRoute = createRoute({
       },
     },
     400: {
-      description: 'Empty body or invalid tarball',
+      description: 'Empty body or unreadable archive',
       content: { 'application/json': { schema: ErrorSchema } },
     },
     413: {
@@ -416,7 +416,7 @@ const uploadRoute = createRoute({
   method: 'post',
   path: '/',
   tags: ['skills'],
-  summary: 'Upload a skill package (tar.gz). Metadata goes in query params.',
+  summary: 'Upload a skill package (tar.gz or zip). Metadata goes in query params.',
   security: [{ bearerAuth: [] }],
   request: { query: uploadQuery },
   responses: {

--- a/skills-content-service/package-lock.json
+++ b/skills-content-service/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "tos-skills-content-service",
+  "name": "@neutree-ai/skills-content-service",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tos-skills-content-service",
+      "name": "@neutree-ai/skills-content-service",
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.19.14",
         "@hono/zod-openapi": "^1.2.4",
         "@scalar/hono-api-reference": "^0.10.7",
+        "fflate": "^0.8.3",
         "hono": "^4.7.0",
         "pg": "^8.21.0",
         "tar-stream": "^3.2.0",
@@ -1500,6 +1501,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",

--- a/skills-content-service/package.json
+++ b/skills-content-service/package.json
@@ -15,6 +15,7 @@
     "@hono/node-server": "^1.19.14",
     "@hono/zod-openapi": "^1.2.4",
     "@scalar/hono-api-reference": "^0.10.7",
+    "fflate": "^0.8.3",
     "hono": "^4.7.0",
     "pg": "^8.21.0",
     "tar-stream": "^3.2.0",

--- a/skills-content-service/src/index.ts
+++ b/skills-content-service/src/index.ts
@@ -50,6 +50,7 @@ import { DUFS_ORIGIN, startDufs } from './dufs'
 import { importFromGit, scanGit, scanTarballBytes, switchSourceToGit, syncSource } from './from-git'
 import { startLruSweep } from './lru'
 import { packageStream } from './package-stream'
+import { normalizeUploadToTarGz } from './skill-tar'
 
 const MAX_SKILL_PACKAGE_BYTES = Number(process.env.MAX_SKILL_PACKAGE_BYTES || 50 * 1024 * 1024)
 
@@ -212,8 +213,15 @@ const scanTarballRoute = createRoute({
   method: 'post',
   path: '/scan-tarball',
   tags: ['scan'],
-  summary: 'Scan an uploaded tarball for skill candidates',
-  request: { body: { content: { 'application/gzip': { schema: BinarySchema } } } },
+  summary: 'Scan an uploaded archive (tar.gz or zip) for skill candidates',
+  request: {
+    body: {
+      content: {
+        'application/gzip': { schema: BinarySchema },
+        'application/zip': { schema: BinarySchema },
+      },
+    },
+  },
   responses: {
     200: {
       description: 'Scan result',
@@ -856,10 +864,15 @@ const uploadRoute = createRoute({
   method: 'post',
   path: '/skills/upload',
   tags: ['skills'],
-  summary: 'Upload a packaged skill (creates native source + skill + version)',
+  summary: 'Upload a packaged skill, tar.gz or zip (creates native source + skill + version)',
   request: {
     query: UploadQuery,
-    body: { content: { 'application/gzip': { schema: BinarySchema } } },
+    body: {
+      content: {
+        'application/gzip': { schema: BinarySchema },
+        'application/zip': { schema: BinarySchema },
+      },
+    },
   },
   responses: {
     200: {
@@ -890,10 +903,20 @@ app.openapi(uploadRoute, async (c) => {
   if (declared > MAX_SKILL_PACKAGE_BYTES) {
     return c.json({ error: `Package exceeds limit (${declared} bytes)` }, 413)
   }
-  const body = await readBoundedBody(c.req.raw)
-  if ('error' in body) {
-    if (body.error === 'empty') return c.json({ error: 'Empty body' }, 400)
+  const raw = await readBoundedBody(c.req.raw)
+  if ('error' in raw) {
+    if (raw.error === 'empty') return c.json({ error: 'Empty body' }, 400)
     return c.json({ error: 'Package exceeds size limit' }, 413)
+  }
+
+  // A zip is rewritten as tar.gz here rather than downstream: these bytes are
+  // stored verbatim and later served to agents / gunzipped by the draft cache,
+  // both of which only speak tar.gz.
+  let body: Buffer
+  try {
+    body = await normalizeUploadToTarGz(raw)
+  } catch {
+    return c.json({ error: 'Unreadable package: expected a .tar.gz or .zip archive' }, 400)
   }
 
   // p3: upload is upsert on (user_id, name). Re-uploading an existing skill

--- a/skills-content-service/src/skill-tar.test.ts
+++ b/skills-content-service/src/skill-tar.test.ts
@@ -4,10 +4,12 @@ import {
   filterSubpath,
   findSkillMd,
   listNestedSkillDirs,
+  normalizeUploadToTarGz,
   repack,
   stripPrefix,
 } from './skill-tar'
 import { buildTarGz } from './tar-fixtures'
+import { buildZip } from './zip-fixtures'
 
 describe('extractEntries', () => {
   it('round-trips a multi-entry tarball', async () => {
@@ -23,6 +25,65 @@ describe('extractEntries', () => {
 
   it('rejects on malformed bytes', async () => {
     await expect(extractEntries(Buffer.from('not a tarball'))).rejects.toBeTruthy()
+  })
+
+  it('round-trips a multi-entry zip', async () => {
+    const entries = await extractEntries(
+      buildZip([
+        { name: 'a.txt', content: 'A' },
+        { name: 'sub/b.txt', content: 'BB' },
+      ]),
+    )
+    expect(entries.map((e) => e.header.name).sort()).toEqual(['a.txt', 'sub/b.txt'])
+    const byName = new Map(entries.map((e) => [e.header.name, e]))
+    expect(byName.get('a.txt')?.data.toString()).toBe('A')
+    expect(byName.get('sub/b.txt')?.data.toString()).toBe('BB')
+    expect(byName.get('a.txt')?.header.type).toBe('file')
+  })
+
+  it('keeps zip directory entries as directories', async () => {
+    const entries = await extractEntries(
+      buildZip([
+        { name: 'empty-dir', type: 'directory' },
+        { name: 'SKILL.md', content: 'hi' },
+      ]),
+    )
+    const dir = entries.find((e) => e.header.name === 'empty-dir/')
+    expect(dir?.header.type).toBe('directory')
+    expect(dir?.data.length).toBe(0)
+  })
+
+  it('drops macOS archiver noise from a zip', async () => {
+    const entries = await extractEntries(
+      buildZip([
+        { name: 'SKILL.md', content: 'hi' },
+        { name: '__MACOSX/._SKILL.md', content: 'resource fork' },
+        { name: '.DS_Store', content: 'junk' },
+        { name: 'sub/._x.txt', content: 'resource fork' },
+      ]),
+    )
+    expect(entries.map((e) => e.header.name)).toEqual(['SKILL.md'])
+  })
+
+  it('rejects a truncated zip', async () => {
+    const zip = buildZip([{ name: 'a.txt', content: 'A' }])
+    await expect(extractEntries(zip.subarray(0, zip.length - 8))).rejects.toBeTruthy()
+  })
+
+  it('feeds the same pipeline from either format', async () => {
+    const fromZip = await extractEntries(
+      buildZip([
+        { name: 'pkg/SKILL.md', content: 'hi' },
+        { name: 'pkg/sub/x.txt', content: 'x' },
+      ]),
+    )
+    const stripped = stripPrefix(fromZip).sort((a, b) => a.header.name.localeCompare(b.header.name))
+    expect(stripped.map((e) => e.header.name)).toEqual(['SKILL.md', 'sub/x.txt'])
+    expect(findSkillMd(stripped)?.data.toString()).toBe('hi')
+    // Whatever came in, what gets stored is a tar.gz.
+    const repacked = await repack(stripped)
+    const roundTripped = await extractEntries(repacked)
+    expect(roundTripped.map((e) => e.header.name).sort()).toEqual(['SKILL.md', 'sub/x.txt'])
   })
 })
 
@@ -182,5 +243,69 @@ describe('repack', () => {
     const out = await repack(entries)
     const reparsed = await extractEntries(out)
     expect(reparsed.map((e) => e.header.name)).toEqual(['real.txt'])
+  })
+})
+
+describe('normalizeUploadToTarGz', () => {
+  it('passes tar.gz through byte-for-byte', async () => {
+    const bytes = await buildTarGz([{ name: 'SKILL.md', content: 'hi' }])
+    const out = await normalizeUploadToTarGz(bytes)
+    expect(out).toBe(bytes)
+  })
+
+  it('converts a zip into a tar.gz the rest of the pipeline can read', async () => {
+    const out = await normalizeUploadToTarGz(
+      buildZip([
+        { name: 'SKILL.md', content: '---\nname: r\n---\n' },
+        { name: 'sub/x.txt', content: 'x' },
+      ]),
+    )
+    const entries = await extractEntries(out)
+    expect(entries.map((e) => e.header.name).sort()).toEqual(['SKILL.md', 'sub/x.txt'])
+    expect(findSkillMd(entries)?.data.toString()).toBe('---\nname: r\n---\n')
+  })
+
+  it('strips the wrapping dir a folder-compressed zip carries', async () => {
+    const out = await normalizeUploadToTarGz(
+      buildZip([
+        { name: 'my-skill/SKILL.md', content: 'hi' },
+        { name: 'my-skill/refs/a.md', content: 'a' },
+      ]),
+    )
+    const entries = await extractEntries(out)
+    expect(entries.map((e) => e.header.name).sort()).toEqual(['SKILL.md', 'refs/a.md'])
+  })
+
+  it('keeps a root SKILL.md even when a sibling dir exists', async () => {
+    const out = await normalizeUploadToTarGz(
+      buildZip([
+        { name: 'SKILL.md', content: 'hi' },
+        { name: 'refs/a.md', content: 'a' },
+      ]),
+    )
+    const entries = await extractEntries(out)
+    expect(entries.map((e) => e.header.name).sort()).toEqual(['SKILL.md', 'refs/a.md'])
+  })
+
+  it('leaves multiple top-level dirs alone', async () => {
+    const out = await normalizeUploadToTarGz(
+      buildZip([
+        { name: 'a/SKILL.md', content: 'a' },
+        { name: 'b/SKILL.md', content: 'b' },
+      ]),
+    )
+    const entries = await extractEntries(out)
+    expect(entries.map((e) => e.header.name).sort()).toEqual(['a/SKILL.md', 'b/SKILL.md'])
+  })
+
+  it('rejects a zip it cannot read', async () => {
+    const zip = buildZip([{ name: 'SKILL.md', content: 'hi' }])
+    await expect(normalizeUploadToTarGz(zip.subarray(0, zip.length - 8))).rejects.toBeTruthy()
+  })
+
+  it('leaves non-zip bytes to the existing tar.gz path', async () => {
+    // Validation of tarball bytes has always happened downstream, not here.
+    const junk = Buffer.from('PK nope')
+    expect(await normalizeUploadToTarGz(junk)).toBe(junk)
   })
 })

--- a/skills-content-service/src/skill-tar.ts
+++ b/skills-content-service/src/skill-tar.ts
@@ -1,5 +1,5 @@
 /**
- * Pure tarball operations for skill packages.
+ * Pure archive operations for skill packages.
  *
  * Pipeline (composed by the service):
  *   bytes
@@ -8,11 +8,16 @@
  *     → filterSubpath  → entries scoped to a subpath (optional)
  *     → repack         → clean tar.gz buffer
  *
+ * Uploads arrive as either tar.gz or zip; `extractEntries` normalizes both to
+ * the same entry list, so everything downstream — and the stored package,
+ * which `repack` always writes as tar.gz — is archive-format agnostic.
+ *
  * I/O lives outside (the GitSourceClient fetches the bytes; the service
  * orchestrates these steps). Tar/gzip streams are still asynchronous via
  * Node streams, but no network or filesystem touch happens here.
  */
 import { createGunzip, createGzip } from 'node:zlib'
+import { unzipSync } from 'fflate'
 import { type Headers, extract, pack } from 'tar-stream'
 
 export interface TarEntry {
@@ -20,8 +25,24 @@ export interface TarEntry {
   data: Buffer
 }
 
+/** Local file header signature — the first bytes of any non-empty zip. */
+const ZIP_MAGIC = [0x50, 0x4b, 0x03, 0x04]
+
+function isZip(bytes: Buffer): boolean {
+  return bytes.length >= 4 && ZIP_MAGIC.every((b, i) => bytes[i] === b)
+}
+
+/**
+ * Parse a tar.gz or zip buffer into entries, dispatching on the magic bytes
+ * rather than on a filename or a client-supplied content type — neither is
+ * trustworthy, and both are absent on the git-import path.
+ */
+export function extractEntries(archiveBytes: Buffer): Promise<TarEntry[]> {
+  return isZip(archiveBytes) ? extractZipEntries(archiveBytes) : extractTarGzEntries(archiveBytes)
+}
+
 /** Parse a tar.gz buffer into entries. Streams gunzip + tar-extract in-memory. */
-export function extractEntries(tarballBytes: Buffer): Promise<TarEntry[]> {
+function extractTarGzEntries(tarballBytes: Buffer): Promise<TarEntry[]> {
   return new Promise<TarEntry[]>((resolve, reject) => {
     const entries: TarEntry[] = []
     const ex = extract()
@@ -43,6 +64,86 @@ export function extractEntries(tarballBytes: Buffer): Promise<TarEntry[]> {
     gunzip.pipe(ex)
     gunzip.end(tarballBytes)
   })
+}
+
+/**
+ * Names a zip carries that are archiver bookkeeping, not skill content.
+ * macOS Finder's "Compress" writes an `__MACOSX/` tree of `._name` resource
+ * forks alongside every file; keeping them would put junk in the skill and let
+ * `__MACOSX/._SKILL.md` masquerade as a skill entry point.
+ */
+function isArchiverNoise(name: string): boolean {
+  const parts = name.split('/')
+  return parts.some((p) => p === '__MACOSX' || p === '.DS_Store' || p.startsWith('._'))
+}
+
+/**
+ * Parse a zip buffer into the same shape `extractTarGzEntries` produces.
+ *
+ * Zip carries no unix mode we can rely on across the writers users actually
+ * use (Finder, Explorer, `zip`), so entries take the same defaults `repack`
+ * would apply anyway. Directory entries are recognized by the trailing slash
+ * that the format mandates for them.
+ */
+function extractZipEntries(zipBytes: Buffer): Promise<TarEntry[]> {
+  return new Promise<TarEntry[]>((resolve, reject) => {
+    let files: Record<string, Uint8Array>
+    try {
+      files = unzipSync(zipBytes)
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+    const entries: TarEntry[] = []
+    for (const [name, data] of Object.entries(files)) {
+      if (!name || isArchiverNoise(name)) continue
+      if (name.endsWith('/')) {
+        entries.push({
+          header: { name, type: 'directory', mode: 0o755 },
+          data: Buffer.alloc(0),
+        })
+      } else {
+        const buf = Buffer.from(data)
+        entries.push({
+          header: { name, type: 'file', size: buf.length, mode: 0o644 },
+          data: buf,
+        })
+      }
+    }
+    resolve(entries)
+  })
+}
+
+/**
+ * Convert an uploaded package to the tar.gz that everything downstream
+ * assumes: the stored `skill_versions.package` bytes are served verbatim to
+ * agents and gunzipped by the draft cache, so a zip has to be rewritten before
+ * it is persisted, not merely readable.
+ *
+ * tar.gz input is returned untouched — byte-identical, no repack — so the
+ * existing upload path keeps behaving exactly as before.
+ *
+ * Zip input additionally loses a single wrapping directory when the archive
+ * has one and no SKILL.md at its root. Compressing a skill folder in Finder or
+ * Explorer always produces `skill-name/SKILL.md`, whereas the documented tar
+ * invocation (`tar -czf … -C skill-dir .`) produces a root-level SKILL.md;
+ * stripping reconciles the two so the obvious way to make a zip works.
+ */
+export async function normalizeUploadToTarGz(bytes: Buffer): Promise<Buffer> {
+  if (!isZip(bytes)) return bytes
+  const entries = await extractZipEntries(bytes)
+  return repack(hasSingleWrappingDir(entries) ? stripPrefix(entries) : entries)
+}
+
+/** True when every entry sits under one shared top-level dir and no root SKILL.md exists. */
+function hasSingleWrappingDir(entries: TarEntry[]): boolean {
+  if (entries.length === 0) return false
+  if (findSkillMd(entries)) return false
+  const first = entries[0].header.name
+  const slashIdx = first.indexOf('/')
+  if (slashIdx <= 0) return false
+  const prefix = first.slice(0, slashIdx + 1)
+  return entries.every((e) => e.header.name.startsWith(prefix))
 }
 
 /**

--- a/skills-content-service/src/zip-fixtures.ts
+++ b/skills-content-service/src/zip-fixtures.ts
@@ -1,0 +1,31 @@
+/**
+ * Test helper: build a zip buffer in-memory from a declarative entry list.
+ * Mirrors `tar-fixtures.ts` so the same pipeline can be exercised with either
+ * archive format without committing binary fixtures.
+ */
+import { zipSync } from 'fflate'
+
+interface FixtureEntry {
+  name: string
+  content?: string | Buffer
+  type?: 'file' | 'directory'
+}
+
+export function buildZip(entries: FixtureEntry[]): Buffer {
+  const files: Record<string, Uint8Array> = {}
+  for (const e of entries) {
+    if ((e.type ?? 'file') === 'directory') {
+      // Zip marks directories with a trailing slash and no payload.
+      files[e.name.endsWith('/') ? e.name : `${e.name}/`] = new Uint8Array(0)
+    } else {
+      const body =
+        e.content === undefined
+          ? Buffer.alloc(0)
+          : typeof e.content === 'string'
+            ? Buffer.from(e.content, 'utf-8')
+            : e.content
+      files[e.name] = new Uint8Array(body)
+    }
+  }
+  return Buffer.from(zipSync(files))
+}

--- a/web/src/components/dialogs/SkillFormFields.tsx
+++ b/web/src/components/dialogs/SkillFormFields.tsx
@@ -200,12 +200,18 @@ export function SkillFormFields({
   }, [form.gitUrl, form.gitType, setForm])
 
   // Drag-and-drop state for upload mode. We accept the first dropped file
-  // matching .tar.gz / .tgz, drop everything else with a quiet error so the
-  // dropzone stays unobtrusive (the user can still try again).
+  // matching .tar.gz / .tgz / .zip, drop everything else with a quiet error so
+  // the dropzone stays unobtrusive (the user can still try again).
   const [isDraggingFile, setIsDraggingFile] = useState(false)
-  function isAcceptableTarball(file: File): boolean {
+  function isAcceptablePackage(file: File): boolean {
     const n = file.name.toLowerCase()
-    return n.endsWith('.tar.gz') || n.endsWith('.tgz') || file.type === 'application/gzip'
+    return (
+      n.endsWith('.tar.gz') ||
+      n.endsWith('.tgz') ||
+      n.endsWith('.zip') ||
+      file.type === 'application/gzip' ||
+      file.type === 'application/zip'
+    )
   }
   function applyChosenFile(file: File | null) {
     // Selecting a new file invalidates any prior scan output.
@@ -217,7 +223,7 @@ export function SkillFormFields({
     setIsDraggingFile(false)
     const file = e.dataTransfer.files?.[0]
     if (!file) return
-    if (!isAcceptableTarball(file)) {
+    if (!isAcceptablePackage(file)) {
       setScanError(t('components.library.skills.errors.invalidFileType'))
       return
     }
@@ -614,7 +620,7 @@ export function SkillFormFields({
           >
             {/*
              * Dropzone wraps the click-to-pick controls so the whole row
-             * accepts a dragged .tar.gz file. Dashed-border highlight is
+             * accepts a dragged package file. Dashed-border highlight is
              * only visible while a file is actively being dragged over —
              * empty-state copy gets a subtle hint underneath.
              */}
@@ -700,7 +706,7 @@ export function SkillFormFields({
               <input
                 id={`${idPrefix}-file`}
                 type="file"
-                accept=".tar.gz,.tgz,application/gzip"
+                accept=".tar.gz,.tgz,.zip,application/gzip,application/zip"
                 className="hidden"
                 onChange={(e) => applyChosenFile(e.target.files?.[0] ?? null)}
               />

--- a/web/src/docs/inline-help/en-US/skill-upload.md
+++ b/web/src/docs/inline-help/en-US/skill-upload.md
@@ -1,4 +1,4 @@
-Upload a packaged Skill directory (`.tar.gz`).
+Upload a packaged Skill directory (`.tar.gz` or `.zip`).
 
 ## Packaging
 
@@ -11,6 +11,10 @@ linux: |
 windows: |
   tar -czf skill.tar.gz -C C:\path\to\skill-dir .
 </platform-cmd>
+
+Zipping the folder works too — right-click it and choose Compress (macOS) or
+Send to → Compressed folder (Windows). The wrapping folder the archive picks up
+is unwrapped on upload, and macOS resource-fork files are discarded.
 
 The directory must contain a `SKILL.md` file as the Skill entry description.
 

--- a/web/src/docs/inline-help/zh-CN/skill-upload.md
+++ b/web/src/docs/inline-help/zh-CN/skill-upload.md
@@ -1,4 +1,4 @@
-上传一个打包好的 skill 目录（`.tar.gz`）。
+上传一个打包好的 skill 目录（`.tar.gz` 或 `.zip`）。
 
 ## 打包方式
 
@@ -11,6 +11,8 @@ linux: |
 windows: |
   tar -czf skill.tar.gz -C C:\path\to\skill-dir .
 </platform-cmd>
+
+也可以直接压缩成 zip：macOS 上右键「压缩」，Windows 上右键「发送到 → 压缩文件夹」。压缩包外层多出的那层目录会在上传时自动去掉，macOS 附带的资源分叉文件也会被丢弃。
 
 目录内需要包含 `SKILL.md` 文件作为 skill 的入口描述。
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -159,6 +159,19 @@ export class ApiClientError extends Error {
   }
 }
 
+/**
+ * Skill packages upload as either tar.gz or zip. The server dispatches on the
+ * archive's magic bytes, so deriving the header from the same bytes keeps the
+ * two from ever disagreeing — a filename or a browser-supplied `File.type`
+ * can.
+ */
+function archiveContentType(file: ArrayBuffer): string {
+  const head = new Uint8Array(file, 0, Math.min(4, file.byteLength))
+  const isZip =
+    head.length >= 4 && head[0] === 0x50 && head[1] === 0x4b && head[2] === 0x03 && head[3] === 0x04
+  return isZip ? 'application/zip' : 'application/gzip'
+}
+
 class ApiClient {
   private baseUrl = '/api'
 
@@ -770,9 +783,9 @@ class ApiClient {
   }
 
   /**
-   * One-shot tarball upload. The cp endpoint creates an implicit native
-   * source + skill + initial version in one call. For native source
-   * authoring (where you want a draft cycle) use `createNativeSource` +
+   * One-shot package upload (tar.gz or zip). The cp endpoint creates an
+   * implicit native source + skill + initial version in one call. For native
+   * source authoring (where you want a draft cycle) use `createNativeSource` +
    * `saveSkillDraft` + `publishSkill` instead.
    */
   async uploadSkill(
@@ -785,7 +798,7 @@ class ApiClient {
     return this.request<ApiSkill>(`/skills?${params}`, {
       method: 'POST',
       body: file,
-      headers: { 'Content-Type': 'application/gzip' },
+      headers: { 'Content-Type': archiveContentType(file) },
     })
   }
 
@@ -930,7 +943,7 @@ class ApiClient {
     return this.request('/skills/scan-tarball', {
       method: 'POST',
       body: file,
-      headers: { 'Content-Type': 'application/gzip' },
+      headers: { 'Content-Type': archiveContentType(file) },
     })
   }
 

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -816,8 +816,8 @@
           "nameOptional": "Name (optional)",
           "description": "Description",
           "descriptionOptional": "Description (optional)",
-          "package": "Package (.tar.gz)",
-          "packageKeepCurrent": "Package (.tar.gz) (leave empty to keep current)",
+          "package": "Package (.tar.gz / .zip)",
+          "packageKeepCurrent": "Package (.tar.gz / .zip) (leave empty to keep current)",
           "publicVisible": "Public (visible to all users)",
           "visibility": "Visibility",
           "teams": "Teams",
@@ -854,7 +854,7 @@
         "help": {
           "repositoryUrl": "Supports GitHub, GitLab, and self-hosted. Append /tree/branch/subpath to import a subdirectory.",
           "category": "Used as a filter chip in the library. Optional.",
-          "dropHint": "or drop a .tar.gz here",
+          "dropHint": "or drop a .tar.gz / .zip here",
           "dropActive": "Release to use this file"
         },
         "tokenSources": {
@@ -957,7 +957,7 @@
           "deleteFailed": "Failed to delete",
           "scanFailed": "Failed to scan repo",
           "multipleCandidatesPickOne": "Multiple skills found in this repo — pick one below.",
-          "invalidFileType": "Only .tar.gz / .tgz files are accepted."
+          "invalidFileType": "Only .tar.gz / .tgz / .zip files are accepted."
         },
         "switchHint": "Switching this native skill to a Git source keeps the skill and all its mounts, but its version history will be deleted — only the version fetched from Git remains.",
         "switchDialog": {
@@ -2169,7 +2169,7 @@
         "nameOptional": "Name (optional)",
         "description": "Description",
         "descriptionOptional": "Description (optional)",
-        "package": "Package (.tar.gz)",
+        "package": "Package (.tar.gz / .zip)",
         "public": "Public (visible to all users)",
         "gitType": "Provider Type"
       },

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -846,8 +846,8 @@
           "nameOptional": "名称（选填）",
           "description": "描述",
           "descriptionOptional": "描述（选填）",
-          "package": "安装包（.tar.gz）",
-          "packageKeepCurrent": "安装包（.tar.gz）（留空则保留当前文件）",
+          "package": "安装包（.tar.gz / .zip）",
+          "packageKeepCurrent": "安装包（.tar.gz / .zip）（留空则保留当前文件）",
           "publicVisible": "公开（所有用户可见）",
           "visibility": "可见性",
           "teams": "团队",
@@ -884,7 +884,7 @@
         "help": {
           "repositoryUrl": "支持 GitHub、GitLab 和自托管仓库。可在末尾追加 /tree/branch/subpath 以导入子目录。",
           "category": "用于资源库的筛选 chip。选填。",
-          "dropHint": "或将 .tar.gz 拖到这里",
+          "dropHint": "或将 .tar.gz / .zip 拖到这里",
           "dropActive": "松开以使用此文件"
         },
         "tokenSources": {
@@ -987,7 +987,7 @@
           "deleteFailed": "删除失败",
           "scanFailed": "扫描仓库失败",
           "multipleCandidatesPickOne": "该仓库内有多个 skill，请在下方选择一个。",
-          "invalidFileType": "仅支持 .tar.gz / .tgz 文件。"
+          "invalidFileType": "仅支持 .tar.gz / .tgz / .zip 文件。"
         },
         "switchHint": "把这个本地编写的 skill 切换到 Git 来源后，skill 本身和它的所有挂载都会保留，但版本历史会被删除——只留下从 Git 拉取的版本。",
         "switchDialog": {
@@ -2194,7 +2194,7 @@
         "nameOptional": "名称（可选）",
         "description": "描述",
         "descriptionOptional": "描述（可选）",
-        "package": "安装包（.tar.gz）",
+        "package": "安装包（.tar.gz / .zip）",
         "public": "公开（对所有用户可见）",
         "gitType": "服务类型"
       },


### PR DESCRIPTION
Skill authors asked to upload `.zip`. Packaging a skill currently means producing a `.tar.gz`, which is an awkward thing to ask for on the desktops most authors work from — right-click "Compress" is the obvious gesture there, and it makes a zip.

## Why parsing zip is not enough

`POST /skills/upload` does not unpack anything: it stores the posted bytes verbatim in `skill_versions.package`. Those same bytes are later

- served as-is to agents, which `tar -xzf` them, and
- gunzipped by the draft cache to build the file tree.

So a stored zip breaks both. Uploads are therefore **rewritten to tar.gz before they are persisted** — the stored format never changes, and nothing downstream had to be touched.

## What changed

**skills-content-service**

- `extractEntries` dispatches on the archive's **magic bytes** (`PK\x03\x04`), not a filename or a client-supplied content type — neither is trustworthy, and the git-import path has neither.
- New `normalizeUploadToTarGz`: converts zip, and returns tar.gz **byte-identical and unrepacked**, so the existing upload path behaves exactly as before.
- Two zip-specific hazards handled:
  - **Archiver noise** — Finder's "Compress" writes a `__MACOSX/` tree of `._name` resource forks plus `.DS_Store`. Left in, they pollute the skill and let `__MACOSX/._SKILL.md` pose as a skill entry point.
  - **Wrapping directory** — compressing a folder always yields `my-skill/SKILL.md`, whereas the documented `tar -czf … -C skill-dir .` yields a root-level `SKILL.md`. A zip with a single enclosing dir and no root SKILL.md is unwrapped, so the obvious way to make a zip produces a valid skill. Multiple top-level dirs are left alone.
- Adds `fflate` (dependency-free, pure-JS zip).

**control-plane** — OpenAPI copy only (`summary` on upload / scan-tarball, and a 400 description). No logic change; it proxies the body untouched.

**web** — `.zip` in the file picker and the dropzone's accept check; the upload's `Content-Type` is derived from the same magic bytes so the header can't disagree with the payload; copy and inline help updated in both locales.

## Verification

- 12 new cases in `skill-tar.test.ts`: zip round-trip, directory entries, noise filtering, truncated-zip rejection, wrapping-dir unwrap, multi-top-level left alone, root SKILL.md preserved, tar.gz passthrough identity.
- Full suites green: skills-content-service 87, web 159, control-plane 498. `tsc --noEmit` clean in all three.
- **End-to-end**: built a Finder-style zip (wrapping dir + `__MACOSX/._SKILL.md` + `.DS_Store`), ran it through the conversion, wrote the result to disk — `file(1)` reports gzip, system `tar -tzf` lists exactly `SKILL.md` and `refs/a.md`, and `tar -xzf` extracts the right content.

## Known boundary (pre-existing, not widened)

A zip holding several sibling skill dirs (`a/SKILL.md`, `b/SKILL.md`) still uploads as an invalid package, because the upload endpoint takes no subpath — a multi-skill tar.gz has always behaved the same way. The scan dialog lists the candidates but has nowhere to send the choice. Fixing that means giving upload a subpath parameter, which is a separate change.