### PR TITLE
Keep the drain watermark when a workspace is deleted

### DIFF
--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -264,8 +264,20 @@ export async function deleteWorkspace(id: string): Promise<boolean> {
     await client.query('DELETE FROM workspace_config WHERE workspace_id = $1', [id])
     await client.query('DELETE FROM workspace_skills WHERE workspace_id = $1', [id])
     await client.query('DELETE FROM workspace_tag_assignments WHERE workspace_id = $1', [id])
-    // Pure pull-optimization state; the usage *ledger* is immutable and intentionally kept.
-    await client.query('DELETE FROM workspace_usage_cursor WHERE workspace_id = $1', [id])
+    // The per-file fingerprints are pull-optimization state and go; the drain
+    // watermark stays, because it is the only evidence left that the ledger
+    // holds everything this workspace spent. Deleting it would leave a
+    // correctly-collected account indistinguishable from a lost one — for a
+    // caller that recycles workspaces, every finished run would read as
+    // unaccounted-for. A row with nothing to say is dropped outright.
+    await client.query(
+      'DELETE FROM workspace_usage_cursor WHERE workspace_id = $1 AND drained_through IS NULL',
+      [id],
+    )
+    await client.query(
+      `UPDATE workspace_usage_cursor SET cursor = '{}'::jsonb WHERE workspace_id = $1`,
+      [id],
+    )
     await client.query('DELETE FROM shares WHERE workspace_id = $1', [id])
     const result = await client.query('DELETE FROM workspaces WHERE id = $1', [id])
     await client.query('COMMIT')

--- a/control-plane/src/services/usage/settle.test.ts
+++ b/control-plane/src/services/usage/settle.test.ts
@@ -74,6 +74,25 @@ describe('evaluateSettlement', () => {
     })
   })
 
+  it('settles a deleted workspace whose final drain outlived it', () => {
+    // Deleting collects first, and the watermark is kept for exactly this: the
+    // account is closed and provably whole, so it must not read as lost.
+    const deleted = facts({ workspace_status: null, chat_status: null })
+    expect(evaluateSettlement(deleted)).toMatchObject({ complete: true, reason: null })
+  })
+
+  it('still refuses a deleted workspace that was force-deleted undrained', () => {
+    const forced = facts({
+      workspace_status: null,
+      chat_status: null,
+      drained_through: drainedAfter(-60_000),
+    })
+    expect(evaluateSettlement(forced)).toMatchObject({
+      complete: false,
+      reason: 'workspace_gone',
+    })
+  })
+
   it('does not settle an empty session before any drain', () => {
     expect(evaluateSettlement(facts({ activity_at: null, drained_through: null })).complete).toBe(
       false,


### PR DESCRIPTION
Found while testing #232 against production: create a workspace, run a turn, delete it, then read the session's account.

```jsonc
// after the delete
{ "totals": { "input_tokens": 26351, "output_tokens": 21, "record_count": 1 },
  "settlement": { "drained_through": null, "complete": false, "reason": "workspace_gone" } }
```

The tokens are all there — the delete collected them first, as #232 intends. But the verdict says the account is not whole, and always will.

## Why

Deleting a workspace drops its `workspace_usage_cursor` row, which was correct when the row held nothing but per-file fingerprints. #229 added `drained_through` to it, and that column is the only evidence left that the ledger holds everything the workspace spent. Deleting it makes a correctly-collected account read exactly like a lost one.

For the caller this whole feature exists for — one that recycles a workspace after every run — that is every run, permanently unaccounted-for.

## Fix

The fingerprints still go. The watermark stays, and a row that never recorded a drain is dropped outright rather than kept as an empty shell.

The verdict stays honest in both directions:

- a normal delete collects first, so the watermark lands past the last activity → the account settles
- a `force=true` delete that could not collect leaves the watermark behind the activity → the account still reads incomplete

Retaining one narrow row per deleted workspace is the same bargain the ledger itself already makes: an account has to outlive its subject.

## Testing

- Two verdict tests: a deleted workspace whose final drain outlived it settles; one force-deleted undrained still refuses.
- The cleanup SQL was run against production data inside `BEGIN … ROLLBACK`, covering all three shapes: a row with a watermark keeps it and loses its cursor, a row that never drained is removed, and a workspace with no row at all is a no-op.
- Full control-plane suite (500) passes; typecheck, biome, knip clean.

## Note

Neither half was wrong on its own, and nothing in the unit tests or the SQL checks could see the seam between them — it took deleting a real workspace end to end. Worth remembering when weighing the e2e coverage still outstanding for this feature.
