### PR TITLE
Stop killing background sub-agents at end of turn, and move to SDK 0.3.228

### DIFF
--- a/agents/claude-code/package-lock.json
+++ b/agents/claude-code/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@neutree-ai/agent-claude-code",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.203",
+        "@anthropic-ai/claude-agent-sdk": "0.3.228",
         "@anthropic-ai/sdk": "^0.100.1",
         "@hono/node-server": "^1.19.9",
         "@hono/node-ws": "^1.3.0",
@@ -28,22 +28,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.203.tgz",
-      "integrity": "sha512-K/GMQlB3IpLtvqjI+/9Xcu//4wDRSxO2JimHMOM3zxHBKJA0EIb6U+4Ea0RSrxe+SHwFHT23XATL6U/9JggxXw==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.228.tgz",
+      "integrity": "sha512-OOaME54VCoBLjKMqWqFmHkZGyL/x/FHUA0snhyolmyEhVoeBM0Ub5mrnV2Gx3d5/RcVlk2BnEVvPqu0SpZ9VFw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.203",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.203"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.228",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.228"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.203.tgz",
-      "integrity": "sha512-9uG6wp3reCtiWXA1H7NWZV5HFO6WgmedcpRCMpw0iyborLdw3MEZonJVlfRh93eQEVpflfnTOARTqtt7NzgHqg==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.228.tgz",
+      "integrity": "sha512-HuCsV3/5XuYYaWuCbksX+e0JkDDUG/AlFJ8wKhDL3PBW/3hHNd6xBYx88kEWk1Z6B1GLxwHht9624lcmscpsyw==",
       "cpu": [
         "arm64"
       ],
@@ -65,9 +65,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.203.tgz",
-      "integrity": "sha512-iP2cg+VovTYeU9f/l32Cq4cESNrgBvjZn/NipyhQ7RD468vBUjn22ii9cnGF7g9TepNrY3/IdkCPmwSea9besA==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.228.tgz",
+      "integrity": "sha512-jSUYY5Nd3efvbLZPU+i0tRBaFXskHu8M+4LMGBEw6A0PaklZ3YfGvKlTOWtJGRw6vMc6LzfOFts024xPNm6OrQ==",
       "cpu": [
         "x64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.203.tgz",
-      "integrity": "sha512-p8wTbvWbQUscQBSefTdjwGbeVE6lYoEmMMdoNSOI8uR8jBr5YXoSwnSjBwmGDjz15WI4AIIdiWwyrf6sqrvqPA==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.228.tgz",
+      "integrity": "sha512-0Wjv6TiWwGlBZINAmNJX07jN359jKwB/4Sr/uWgQkdjuVIOhe/M8ydk7JL2EPqCsbiW1lc15NjE5MWpZiYqooA==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.203.tgz",
-      "integrity": "sha512-uQNRpgHKuavsEyvY3SnDRZuCxf1z2pjGI4Q73Q0GuIEapwXrY2UM0ucAj0b7KtS6hpu//CGhnBra2kKOXsDQAw==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.228.tgz",
+      "integrity": "sha512-4PgfisC3kHKlzJvy3rrm4Oh26g+D78h4ahHjni9fvSKHuJgrvHu9Qgo6aaYmzWdc7v9drL+pgiCk5Ge4Y2ANPA==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.203.tgz",
-      "integrity": "sha512-YTW0+njIC61fZP3Qa9uzH9fOlEmApHG6SSxwyNxAQ8U3XX+yviL5/MyqLsauuUTVbyI9K7IqYOaE6xcDVDXIGg==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.228.tgz",
+      "integrity": "sha512-LmGplObceqMOu5mlrlhTZL/VSrEWdZagF0Bl8awglMu6WeQcNe7StORYkCznZ0BuzV4CwuC3ipV4q8Jrs66wSg==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.203.tgz",
-      "integrity": "sha512-Hw2NNW8crM7ENR8peWZ+hG3ehUl9IYPzNxyqc1VM+odznB6squaki2xQeCcIatHbQImeW+DzrUFIDJLLz4pltg==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.228.tgz",
+      "integrity": "sha512-dnXxyiwGCZj27HVk6clYRqGMgrs3KVLVp0vvWYLjkPGBiKbI83qJiDpOfaekEXG2I4elX0M4XikggV1LGWjimg==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.203.tgz",
-      "integrity": "sha512-EF2BPCSElFS9y76b/4TVU7RDw9xCr8DtxSUXAxYhcGsreo1gmJbMVdZ9tvLIvG6Ufquas4nrGmWh1ePLP2ol+g==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.228.tgz",
+      "integrity": "sha512-mNS5yIMz/OXSQiDErb84jA8AKBFSlS9RSZ0qn2qyGkxplUx7kVmIDg/KnwOwHmygpzmH4UmR6OCaLXGohupqNA==",
       "cpu": [
         "arm64"
       ],
@@ -143,9 +143,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.203",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.203.tgz",
-      "integrity": "sha512-sYf4UokyYhYO6Nke99o+gtgCakoaohB+Q/71i+4hEq0FYqVf31WoJ6lUTTTUPeEGVp6Ju6BblzmAX2MpvlWwCw==",
+      "version": "0.3.228",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.228.tgz",
+      "integrity": "sha512-DYT3HvdS64Pq0IRvgW3RDO31yjYp5yiUKoKaZolTpLKfALpG5LI/osfnKlya68PZ/bSST1FNAfW9I0EtCnaQ4w==",
       "cpu": [
         "x64"
       ],

--- a/agents/claude-code/package.json
+++ b/agents/claude-code/package.json
@@ -11,7 +11,7 @@
     "format": "biome format --write ."
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.203",
+    "@anthropic-ai/claude-agent-sdk": "0.3.228",
     "@anthropic-ai/sdk": "^0.100.1",
     "@hono/node-server": "^1.19.9",
     "@hono/node-ws": "^1.3.0",

--- a/agents/claude-code/src/agent.ts
+++ b/agents/claude-code/src/agent.ts
@@ -66,8 +66,20 @@ process.env.MCP_CONNECTION_NONBLOCKING ??= '0'
 
 export type { AskUserRequest, TurnStats }
 
-// Active abort controllers for interruption support
-const activeControllers = new Map<string, AbortController>()
+// Active turns, keyed by session (or a temporary key before the SDK hands us a
+// session id). `done` settles when the turn's consumer loop has fully unwound,
+// so a superseding turn can wait for the previous CLI process to exit before
+// starting one with the same `resume` id — two processes writing one transcript
+// corrupts it.
+interface ActiveTurn {
+  controller: AbortController
+  done: Promise<void>
+}
+const activeControllers = new Map<string, ActiveTurn>()
+
+// How long a superseding turn waits for the previous one to unwind before
+// starting anyway. A wedged consumer must not block new user messages forever.
+const SUPERSEDE_TIMEOUT_MS = 10_000
 
 // Pending canUseTool responses for AskUserQuestion (keyed by requestId)
 const pendingResponses = new Map<
@@ -125,9 +137,9 @@ export function interruptSession(sessionId: string): boolean {
   console.log(
     `[agent] interruptSession called session=${sessionId} active=${activeControllers.has(sessionId)}`,
   )
-  const controller = activeControllers.get(sessionId)
-  if (controller) {
-    controller.abort()
+  const turn = activeControllers.get(sessionId)
+  if (turn) {
+    turn.controller.abort()
     activeControllers.delete(sessionId)
     console.log(`[agent] interruptSession succeeded session=${sessionId}`)
     return true
@@ -159,9 +171,35 @@ export async function chat(
   let resultSessionId = sessionId || ''
   const abortController = new AbortController()
 
+  // A turn now outlives its first `result` (see the consumer loop below), so a
+  // background sub-agent can still be running when the next user message lands.
+  // Tear the previous turn down and wait for it before resuming the same
+  // session — two CLI processes sharing one transcript corrupt it.
+  if (sessionId) {
+    const prev = activeControllers.get(sessionId)
+    if (prev) {
+      console.log(`[chat] Superseding still-running turn session=${sessionId}`)
+      prev.controller.abort()
+      await Promise.race([prev.done, new Promise<void>((r) => setTimeout(r, SUPERSEDE_TIMEOUT_MS))])
+      if (activeControllers.get(sessionId) === prev) {
+        console.warn(
+          `[chat] Previous turn did not unwind within ${SUPERSEDE_TIMEOUT_MS}ms session=${sessionId}, proceeding`,
+        )
+        activeControllers.delete(sessionId)
+      }
+    }
+  }
+
   // Register for interruption (use existing sessionId or a unique temporary key)
   const queryKey = sessionId || `pending-${crypto.randomUUID()}`
-  activeControllers.set(queryKey, abortController)
+  let doneResolve!: () => void
+  const activeTurn: ActiveTurn = {
+    controller: abortController,
+    done: new Promise<void>((r) => {
+      doneResolve = r
+    }),
+  }
+  activeControllers.set(queryKey, activeTurn)
 
   // Build prompt: plain string if no images, SDKUserMessage async generator if images
   let prompt: string | AsyncIterable<SDKUserMessage>
@@ -304,6 +342,7 @@ export async function chat(
     let lastContextTokens = 0
 
     let messageCount = 0
+    let resultCount = 0
     let firstMessageAt: number | null = null
     let firstAssistantAt: number | null = null
     for await (const message of messageStream) {
@@ -328,7 +367,7 @@ export async function chat(
         // Update the controller key for interruption
         if (queryKey !== resultSessionId) {
           activeControllers.delete(queryKey)
-          activeControllers.set(resultSessionId, abortController)
+          activeControllers.set(resultSessionId, activeTurn)
         }
       }
 
@@ -361,14 +400,27 @@ export async function chat(
         }
       }
 
+      // A compaction turn reports no usage of its own, so the context size would
+      // otherwise fall back to 0 and blank the UI gauge until the next turn.
+      // The boundary message carries the post-compaction size — use it.
+      if (message.type === 'system' && (message as any).subtype === 'compact_boundary') {
+        const postTokens = (message as any).compact_metadata?.post_tokens
+        if (typeof postTokens === 'number' && postTokens > 0) {
+          lastContextTokens = postTokens
+        }
+      }
+
       // Track first assistant output
       if (!firstAssistantAt && message.type === 'assistant') {
         firstAssistantAt = Date.now()
         console.log(`[chat] First assistant output, ttfa=${firstAssistantAt - chatStartedAt}ms`)
       }
 
-      // Extract stats from result message
+      // Extract stats from the result message. A turn can produce more than one
+      // (the main agent's, then one per background sub-agent completion); the
+      // last one wins because its cost and usage cover the whole run.
       if (message.type === 'result') {
+        resultCount++
         const r = message as SDKMessage & {
           subtype?: string
           total_cost_usd?: number
@@ -427,18 +479,23 @@ export async function chat(
           contextWindow,
         }
         console.log(
-          `[chat] Result: turns=${stats.numTurns} cost=$${stats.costUsd.toFixed(4)} duration=${stats.durationMs}ms context=${stats.contextTokens}/${contextWindow} terminal_reason=${r.terminal_reason ?? 'unknown'} stop_reason=${r.stop_reason ?? 'unknown'}`,
+          `[chat] Result #${resultCount}: turns=${stats.numTurns} cost=$${stats.costUsd.toFixed(4)} duration=${stats.durationMs}ms context=${stats.contextTokens}/${contextWindow} terminal_reason=${r.terminal_reason ?? 'unknown'} stop_reason=${r.stop_reason ?? 'unknown'}`,
         )
       }
 
       await callbacks.onMessage(message)
 
-      if (message.type === 'result') {
-        break
-      }
+      // Deliberately no `break` on `result`. A background sub-agent keeps
+      // running after the main agent ends its turn, and the CLI delivers its
+      // completion as a further turn on this same stream — breaking here
+      // returns the generator, which tears down the transport and kills that
+      // work mid-flight. Consume until the stream ends on its own; `stats` then
+      // reflects the last result, whose cost is cumulative over the whole run.
     }
 
-    console.log(`[chat] Query completed, total=${Date.now() - chatStartedAt}ms`)
+    console.log(
+      `[chat] Query completed, total=${Date.now() - chatStartedAt}ms results=${resultCount}`,
+    )
     await callbacks.onComplete(stats)
   } catch (error) {
     // A user interrupt (interruptSession → controller.abort()) can surface in
@@ -460,7 +517,12 @@ export async function chat(
       await callbacks.onError(error instanceof Error ? error : new Error(String(error)))
     }
   } finally {
-    activeControllers.delete(resultSessionId || queryKey)
+    const key = resultSessionId || queryKey
+    // Only drop our own entry — a superseding turn may already own this key.
+    if (activeControllers.get(key) === activeTurn) {
+      activeControllers.delete(key)
+    }
+    doneResolve()
   }
 
   return { sessionId: resultSessionId }


### PR DESCRIPTION
## Problem

The message loop breaks on the first `result`. Breaking returns the SDK's async generator, which runs its cleanup: abort the controller, close the transport, kill the CLI process.

That is fine when the turn's work really is done. It is not fine once a sub-agent has been launched with `run_in_background`, which the CLI does by default — the sub-agent is still working when the main agent ends its turn, and killing the process aborts its in-flight model request mid-stream. The request dies as a client disconnect, and the sub-agent's findings never come back. The session settles with the main agent having announced work that was silently discarded.

## What was actually verified

Measured against `claude-agent-sdk@0.3.228`, one prompt, the only variable being the `break`. The background task sleeps 40s and then writes a marker file.

| | Behaviour | Outcome |
| --- | --- | --- |
| break on first result | stream ends at +13.1s | marker never written — the sub-agent was killed 1.7s after launch, before it ran a single tool |
| no break | sub-agent finishes at +56s, parent emits a completion turn at +63.7s, stream ends on its own at +64.3s | marker written |

Two things fall out of this that are worth stating, because they shaped the fix:

- The SDK closing stdin at the first result (single-turn mode) does **not** end the run. The CLI keeps going and exits when its background work is done. The teardown was ours.
- The background completion arrives as a further turn **on the same stream**, so its output reaches the client over the existing SSE. No change to the turn contract, no separate delivery path.

For a turn with no background work the added latency is the gap between the result and the stream ending: 0.6–0.7s measured.

## Changes

**Consume until the stream ends.** No `break` on `result`. `stats` comes from the last result rather than the first — within one run `total_cost_usd` is cumulative, so taking the first undercounts everything the background work spent.

**Supersede turns per session.** A turn can now outlive its first result, so a new message can arrive while the previous turn's background work is still running. Starting a second CLI process against the same `resume` id means two processes writing one transcript. Turns are tracked per session; a new turn aborts the previous one and waits for it to unwind, bounded at 10s so a wedged consumer cannot block new messages. Verified that aborting mid-turn and immediately resuming the same session preserves the transcript.

**Fill context size from `compact_boundary`.** A compaction turn carries no usage of its own, so the context size fell back to zero and blanked the gauge until the next turn. `compact_metadata.post_tokens` is the post-compaction size; use it.

**Move to SDK 0.3.228.** This does not fix the bug above — the measurements were taken on it — but it carries the CLI past the window where the main agent could report a background sub-agent's findings before that sub-agent had produced any. The pin stays exact: the package resolves a per-platform native binary, so the CLI version has to be reproducible from the lockfile alone.

The workarounds this package carries were re-checked against 0.3.228: the per-platform optional dependency names are unchanged, so resolving the executable ourselves still finds the glibc build first; `MCP_CONNECTION_NONBLOCKING` is still read; an aborted run still surfaces as `Claude Code process aborted by user`, which the interrupt path matches on; and the `SDKMessage` union has grown, but the event translator matches on the shapes it knows and ignores the rest.

`canUseTool` still receives the `AskUserQuestion` input as `{questions}`, and answering it still requires each answer keyed by the question's full text — which is what the client already sends. Keying by `header` is rejected identically on 0.3.203 and 0.3.228, so nothing changed here.

## Behavioural change to be aware of

A turn now stays running until its background work finishes, where previously it ended immediately — at the cost of that work. This is the intended semantics, and the existing SSE keepalive and request timeout bound it.

## Checks

`tsc --noEmit`, `tsc` build, and `biome check` all pass on 0.3.228. Slash commands were exercised against the same build (`/compact`, `/goal`, `/context`, `/clear`) — each emits exactly one result and is unaffected; `/compact` was confirmed to actually compact (25,907 → 2,327 tokens) and to carry the post-compaction size this PR now reads.
