### PR TITLE
Let a multi-select question return more than one option

### DIFF
--- a/web/src/components/workspace/AskUserQuestionPanel.tsx
+++ b/web/src/components/workspace/AskUserQuestionPanel.tsx
@@ -1,7 +1,13 @@
 import { Button } from '@/components/ui/button'
 import type { AskUserRequest } from '@/lib/api/types'
+import { Check } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+// The agent looks each answer up by the question's full text, and reads a
+// multi-select answer as its option labels joined by ", ". Keeping selections
+// as a list per question covers both cases without widening the wire shape.
+const ANSWER_SEPARATOR = ', '
 
 export function AskUserQuestionPanel({
   request,
@@ -11,17 +17,34 @@ export function AskUserQuestionPanel({
   onRespond: (answers: Record<string, string>) => void
 }) {
   const { t } = useTranslation()
-  const [selections, setSelections] = useState<Record<string, string>>({})
+  const [selections, setSelections] = useState<Record<string, string[]>>({})
   const [customInputs, setCustomInputs] = useState<Record<string, string>>({})
 
+  const selected = (question: string) => selections[question] ?? []
+
+  const toggle = (question: string, label: string, multiSelect: boolean) => {
+    setSelections((prev) => {
+      const current = prev[question] ?? []
+      if (!multiSelect) return { ...prev, [question]: [label] }
+      return {
+        ...prev,
+        [question]: current.includes(label)
+          ? current.filter((l) => l !== label)
+          : [...current, label],
+      }
+    })
+    setCustomInputs((prev) => ({ ...prev, [question]: '' }))
+  }
+
   const allAnswered = request.questions.every(
-    (q) => selections[q.question] || customInputs[q.question]?.trim(),
+    (q) => selected(q.question).length > 0 || customInputs[q.question]?.trim(),
   )
 
   const buildAnswers = () => {
     const answers: Record<string, string> = {}
     for (const q of request.questions) {
-      answers[q.question] = customInputs[q.question]?.trim() || selections[q.question] || ''
+      answers[q.question] =
+        customInputs[q.question]?.trim() || selected(q.question).join(ANSWER_SEPARATOR)
     }
     return answers
   }
@@ -36,27 +59,45 @@ export function AskUserQuestionPanel({
             </span>
           )}
           <div className="text-xs font-medium">{q.question}</div>
+          {q.multiSelect && (
+            <div className="text-mini text-muted-foreground">
+              {t('components.askUserQuestion.hints.selectAllThatApply')}
+            </div>
+          )}
           <div className="space-y-1">
-            {q.options.map((opt) => (
-              <button
-                key={opt.label}
-                type="button"
-                onClick={() => {
-                  setSelections((prev) => ({ ...prev, [q.question]: opt.label }))
-                  setCustomInputs((prev) => ({ ...prev, [q.question]: '' }))
-                }}
-                className={`w-full rounded border p-2 text-left text-xs transition-colors ${
-                  selections[q.question] === opt.label && !customInputs[q.question]?.trim()
-                    ? 'border-primary bg-primary/10'
-                    : 'border-border hover:border-muted-foreground/40'
-                }`}
-              >
-                <div className="font-medium">{opt.label}</div>
-                {opt.description && (
-                  <div className="mt-0.5 text-muted-foreground">{opt.description}</div>
-                )}
-              </button>
-            ))}
+            {q.options.map((opt) => {
+              const isSelected =
+                selected(q.question).includes(opt.label) && !customInputs[q.question]?.trim()
+              return (
+                <button
+                  key={opt.label}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => toggle(q.question, opt.label, q.multiSelect)}
+                  className={`w-full rounded border p-2 text-left text-xs transition-colors ${
+                    isSelected
+                      ? 'border-primary bg-primary/10'
+                      : 'border-border hover:border-muted-foreground/40'
+                  }`}
+                >
+                  <div className="flex items-start gap-1.5">
+                    {q.multiSelect && (
+                      <Check
+                        className={`mt-0.5 size-3 shrink-0 ${
+                          isSelected ? 'text-primary' : 'text-transparent'
+                        }`}
+                      />
+                    )}
+                    <div>
+                      <div className="font-medium">{opt.label}</div>
+                      {opt.description && (
+                        <div className="mt-0.5 text-muted-foreground">{opt.description}</div>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
             <input
               type="text"
               placeholder={t('components.askUserQuestion.actions.customReplyPlaceholder')}
@@ -64,7 +105,7 @@ export function AskUserQuestionPanel({
               onChange={(e) => {
                 setCustomInputs((prev) => ({ ...prev, [q.question]: e.target.value }))
                 if (e.target.value.trim()) {
-                  setSelections((prev) => ({ ...prev, [q.question]: '' }))
+                  setSelections((prev) => ({ ...prev, [q.question]: [] }))
                 }
               }}
               className="w-full rounded border border-border bg-transparent p-2 text-xs placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3472,6 +3472,9 @@
       "actions": {
         "customReplyPlaceholder": "Or type a custom reply...",
         "confirm": "Confirm"
+      },
+      "hints": {
+        "selectAllThatApply": "Select all that apply"
       }
     },
     "sessions": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3496,6 +3496,9 @@
       "actions": {
         "customReplyPlaceholder": "或者输入自定义回复...",
         "confirm": "确认"
+      },
+      "hints": {
+        "selectAllThatApply": "可多选"
       }
     },
     "sessions": {


### PR DESCRIPTION
Closes #238.

## Problem

`multiSelect` was declared on the question type and never read anywhere in the repository. Every question rendered as single-select — picking an option replaced the previous choice rather than adding to it — so a model that asked the user to pick all that apply got back exactly one label.

## Change

Selection state becomes a list per question. A single-select question replaces the list; a multi-select one toggles into it. The answer submitted is the selected labels joined by `", "`.

That separator is not arbitrary: it is the form the CLI already reads a multi-select answer in. Verified against `claude-agent-sdk@0.3.228` by answering a `multiSelect: true` question three ways through `canUseTool`:

| Answer sent | Tool result | Model's reading |
| --- | --- | --- |
| `"Rust, Go"` | `Your questions have been answered: …="Rust, Go"` | "You picked: **Rust, Go**" |
| `["Rust", "Go"]` | `…="Rust,Go"` | "You picked: **Rust** and **Go**" |
| `"Rust"` | `…="Rust"` | "You picked: **Rust**" |

Both the joined string and the array are accepted. The joined string is the one that keeps the wire shape a `string` per question, so `agent-session-store`, the API client, the agent's respond route, and the agent itself are all untouched — the change is contained to the panel.

Custom free-text still clears the selection and takes precedence, unchanged.

## UI

Options on a multi-select question carry a check mark when selected, and the question is captioned "select all that apply" (`en-US` and `zh-CN`) so the affordance is visible before the user has clicked a second option — otherwise nothing on screen distinguishes it from a single-select question.

## Checks

`tsc --noEmit` and `biome check` pass. The new i18n key sits in the app bundle, which is the instance this panel renders under.
