### PR TITLE
fix(channel-gateway): keep the catch-all route with the connector owner

### DIFF
--- a/channel-gateway/src/routes/routes.test.ts
+++ b/channel-gateway/src/routes/routes.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppEnv, JwtPayload } from '../lib/types'
 import * as db from '../services/db'
 import routesApp from './routes'
 
@@ -15,9 +16,9 @@ vi.mock('../services/db', () => ({
 const mocked = vi.mocked(db)
 
 function appAs(userId: string) {
-  const app = new Hono()
+  const app = new Hono<AppEnv>()
   app.use('*', async (c, next) => {
-    c.set('user', { sub: userId })
+    c.set('user', { sub: userId } as JwtPayload)
     await next()
   })
   app.route('/routes', routesApp)

--- a/channel-gateway/src/routes/routes.test.ts
+++ b/channel-gateway/src/routes/routes.test.ts
@@ -1,0 +1,79 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as db from '../services/db'
+import routesApp from './routes'
+
+vi.mock('../services/db', () => ({
+  getConnector: vi.fn(),
+  createRoute: vi.fn(),
+  listRoutes: vi.fn(),
+  getRoute: vi.fn(),
+  updateRoute: vi.fn(),
+  deleteRoute: vi.fn(),
+}))
+
+const mocked = vi.mocked(db)
+
+function appAs(userId: string) {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    c.set('user', { sub: userId })
+    await next()
+  })
+  app.route('/routes', routesApp)
+  return app
+}
+
+function post(userId: string, body: Record<string, unknown>) {
+  return appAs(userId).request('/routes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /routes catch-all ownership', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocked.createRoute.mockImplementation(async (data) => ({ id: 'r1', ...data }) as never)
+  })
+
+  it('lets the connector owner claim the catch-all', async () => {
+    mocked.getConnector.mockResolvedValue({ id: 'c1', user_id: 'owner' } as never)
+
+    const res = await post('owner', {
+      connector_id: 'c1',
+      external_id: '*',
+      workspace_id: 'w1',
+    })
+
+    expect(res.status).toBe(201)
+    expect(mocked.createRoute).toHaveBeenCalled()
+  })
+
+  it('rejects the catch-all on a connector owned by someone else', async () => {
+    mocked.getConnector.mockResolvedValue({ id: 'c1', user_id: 'owner' } as never)
+
+    const res = await post('borrower', {
+      connector_id: 'c1',
+      external_id: '*',
+      workspace_id: 'w1',
+    })
+
+    expect(res.status).toBe(403)
+    expect(mocked.createRoute).not.toHaveBeenCalled()
+  })
+
+  it('still lets a borrower route a specific channel', async () => {
+    mocked.getConnector.mockResolvedValue({ id: 'c1', user_id: 'owner' } as never)
+
+    const res = await post('borrower', {
+      connector_id: 'c1',
+      external_id: 'C0123456789',
+      workspace_id: 'w1',
+    })
+
+    expect(res.status).toBe(201)
+    expect(mocked.createRoute).toHaveBeenCalled()
+  })
+})

--- a/channel-gateway/src/routes/routes.ts
+++ b/channel-gateway/src/routes/routes.ts
@@ -37,7 +37,14 @@ app.post('/', async (c) => {
     return c.json({ error: 'only the connector owner can create a catch-all route' }, 403)
   }
 
-  const route = await db.createRoute({ user_id: userId, connector_id, external_id, workspace_id, name, config })
+  const route = await db.createRoute({
+    user_id: userId,
+    connector_id,
+    external_id,
+    workspace_id,
+    name,
+    config,
+  })
   return c.json(route, 201)
 })
 

--- a/channel-gateway/src/routes/routes.ts
+++ b/channel-gateway/src/routes/routes.ts
@@ -28,6 +28,15 @@ app.post('/', async (c) => {
     return c.json({ error: 'connector not found' }, 404)
   }
 
+  // A public connector lets anyone build routes on it, but the '*' catch-all is
+  // different: it claims every channel nobody else routed explicitly, and the
+  // job then runs as the route owner. Left open, the first user to take the slot
+  // captures their colleagues' channels into their own workspace — invisibly, as
+  // route listings are scoped per owner. Only the connector owner may set it.
+  if (external_id === '*' && connector.user_id !== userId) {
+    return c.json({ error: 'only the connector owner can create a catch-all route' }, 403)
+  }
+
   const route = await db.createRoute({ user_id: userId, connector_id, external_id, workspace_id, name, config })
   return c.json(route, 201)
 })

--- a/web/src/components/IntegrationPage.tsx
+++ b/web/src/components/IntegrationPage.tsx
@@ -23,6 +23,7 @@ import {
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { PromptField } from '@/components/workspace/PromptField'
+import { useAuth } from '@/contexts/AuthContext'
 import {
   type ConnectorType as PresetConnectorType,
   listPromptPresets,
@@ -546,10 +547,12 @@ export function RouteForm({
   onConnectorTypeChange?: (type: string) => void
 }) {
   const { t } = useTranslation()
+  const { user } = useAuth()
   const [connectorId, setConnectorId] = useState(initial?.connector_id ?? '')
-  const initConnectorType = connectors.find((c) => c.id === initial?.connector_id)?.type
+  const initConnector = connectors.find((c) => c.id === initial?.connector_id)
   const [externalId, setExternalId] = useState(
-    initial?.external_id ?? (initConnectorType === 'wecom' ? '*' : ''),
+    initial?.external_id ??
+      (initConnector?.type === 'wecom' && initConnector.user_id === user?.id ? '*' : ''),
   )
   const [workspaceId, setWorkspaceId] = useState(initial?.workspace_id ?? '')
   const [name, setName] = useState(initial?.name ?? '')
@@ -590,6 +593,13 @@ export function RouteForm({
   const isEdit = !!initial?.id
   const selectedConnector = connectors.find((c) => c.id === connectorId)
   const connectorType = selectedConnector?.type ?? ''
+  // The '*' catch-all takes every channel nobody routed explicitly, so it stays
+  // with the connector owner — a borrower on a public connector would otherwise
+  // pull their colleagues' channels into their own workspace. Rejected server-side
+  // too; kept visible here only when editing a route that already holds the slot.
+  const canUseCatchAll =
+    (!!selectedConnector && selectedConnector.user_id === user?.id) ||
+    (isEdit && initial?.external_id === '*')
 
   const selectedConnectorPresetType: PresetConnectorType | null =
     connectorType === 'slack' || connectorType === 'wecom'
@@ -625,7 +635,9 @@ export function RouteForm({
     retry: 1,
   })
   const slackChannelItems = [
-    { value: '*', label: t('components.integration.route.labels.allChannels') },
+    ...(canUseCatchAll
+      ? [{ value: '*', label: t('components.integration.route.labels.allChannels') }]
+      : []),
     ...(channels || []).map((ch) => ({ value: ch.id, label: `#${ch.name}` })),
   ]
   if (

--- a/web/src/docs/inline-help/en-US/route-slack.md
+++ b/web/src/docs/inline-help/en-US/route-slack.md
@@ -3,7 +3,7 @@ Route @mention events in a Slack Channel to a specified Workspace for execution.
 ## Field descriptions
 
 - **Connector** — Select a created Slack Connector
-- **Channel** — Select a Channel the bot has joined (only channels where the bot is present are listed)
+- **Channel** — Select a Channel the bot has joined (only channels where the bot is present are listed). Picking **All channels** turns the route into the connector's fallback: every channel without a route of its own is handled here, so a newly created channel works without adding anything. A fallback takes in channels other people may be using, so only the connector's owner can set one — on a connector shared with you, the option is not offered
 - **Workspace** — Which Workspace executes the task after the event is triggered
 
 ## Prompt template

--- a/web/src/docs/inline-help/en-US/route-wecom.md
+++ b/web/src/docs/inline-help/en-US/route-wecom.md
@@ -3,7 +3,7 @@ Route @Bot messages in WeCom group chats to a specified Workspace for execution.
 ## Field descriptions
 
 - **Connector** — Select a created WeCom Connector
-- **Group chat ID** — WeCom group chat ID (format `wrXXX...`), available from the `chatid` field in test script logs
+- **Group chat ID** — WeCom group chat ID (format `wrXXX...`), available from the `chatid` field in test script logs. Entering `*` turns the route into the connector's fallback: every group chat without a route of its own is handled here. A fallback takes in group chats other people may be using, so only the connector's owner can set one
 - **Workspace** — Which Workspace executes the task after the event is triggered
 
 ## Prompt template

--- a/web/src/docs/inline-help/zh-CN/route-slack.md
+++ b/web/src/docs/inline-help/zh-CN/route-slack.md
@@ -3,7 +3,7 @@
 ## 字段说明
 
 - **Connector** — 选择已创建的 Slack connector
-- **Channel** — 选择 bot 已加入的频道（仅列出 bot 所在频道）
+- **Channel** — 选择 bot 已加入的频道（仅列出 bot 所在频道）。选 **All channels** 就是给这个 connector 配兜底路由：凡是没单独建过路由的频道都走这条，新建频道不用再加规则。兜底会接管别人可能正在用的频道，所以只有 connector 的创建者能配；别人分享给你的 connector 上不出现这个选项
 - **Workspace** — 事件触发后在哪个 workspace 执行任务
 
 ## Prompt 模板

--- a/web/src/docs/inline-help/zh-CN/route-wecom.md
+++ b/web/src/docs/inline-help/zh-CN/route-wecom.md
@@ -3,7 +3,7 @@
 ## 字段说明
 
 - **Connector** — 选择已创建的企业微信 connector
-- **群聊 ID** — 企业微信群聊 ID（格式 `wrXXX...`），可从测试脚本日志的 `chatid` 字段获取
+- **群聊 ID** — 企业微信群聊 ID（格式 `wrXXX...`），可从测试脚本日志的 `chatid` 字段获取。填 `*` 就是给这个 connector 配兜底路由：凡是没单独建过路由的群聊都走这条。兜底会接管别人可能正在用的群聊，所以只有 connector 的创建者能配
 - **Workspace** — 事件触发后在哪个 workspace 执行任务
 
 ## Prompt 模板

--- a/web/src/lib/api/channel-gateway.ts
+++ b/web/src/lib/api/channel-gateway.ts
@@ -133,9 +133,10 @@ export const cgApi = {
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify(data),
-    }).then((r) => {
-      if (!r.ok) throw new Error(i18n.t('integration.errors.requestFailed'))
-      return r.json() as Promise<CgRoute>
+    }).then(async (r) => {
+      const body = await r.json()
+      if (!r.ok) throw new Error(body.error || i18n.t('integration.errors.requestFailed'))
+      return body as CgRoute
     }),
 
   updateRoute: (


### PR DESCRIPTION
## Problem

A connector can be made public, and that is deliberate: one user owns it, others build routes on top (`getConnector` admits any user when `is_public = true`).

The `'*'` catch-all does not fit that sharing model. Slack and WeCom both fall back to it when no exact route matches, the lookup filters on `connector_id` alone, and `resolveRouteClient` then runs the job as the *route* owner. So on a public connector, whoever takes the `'*'` slot receives every channel nobody routed explicitly — messages land in their workspace, under their token.

It is also invisible: `listRoutes` is scoped to `r.user_id`, so the connector owner never sees the route, and the users whose channels got captured have nothing to look at. The slot is global per connector (`UNIQUE (connector_id, external_id)`), so it is first-come-first-served.

## Change

- Reject `external_id = '*'` with 403 when the caller does not own the connector. Specific channels are unaffected — borrowers keep building routes as before.
- Drop "All channels" from the route form unless the selected connector is yours; it stays visible when editing a route that already holds the slot, so existing rows still render. The WeCom form no longer defaults a borrowed connector's route to `'*'`.
- `createRoute` in the API client now surfaces the server's error text instead of a generic "request failed", so the refusal is readable.

Tests cover the three cases: owner may claim `'*'`, a borrower may not, and a borrower can still route a specific channel.
