### PR TITLE
dsh: fix the platform skill, tool card names, and tool rendering

### DIFF
--- a/internal/agent-skills/platform/__platform__/SKILL.md
+++ b/internal/agent-skills/platform/__platform__/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: __platform__
+name: {{#dsh}}nap-platform{{/dsh}}{{^dsh}}__platform__{{/dsh}}
 description: NAP workspace capabilities reference. Consult when working with browser automation, sandboxed code execution, file sharing between agents via /mnt/afs, persistent cross-session memory under /mnt/memory, creating or editing skills, proposing workspace configuration changes via Builder Mode, or (Codex) generated images.
 ---
 
@@ -33,7 +33,7 @@ Persistent, cross-session storage mounted under `/mnt/memory/<store_id>/`. Works
 
 ## Skills
 
-`skill_create_draft` / `skill_enter_edit` / `skill_publish` lifecycle for user-authored skills (this `__platform__` skill itself is platform-managed and not user-editable).
+`skill_create_draft` / `skill_enter_edit` / `skill_publish` lifecycle for user-authored skills (this `{{#dsh}}nap-platform{{/dsh}}{{^dsh}}__platform__{{/dsh}}` skill itself is platform-managed and not user-editable).
 
 → When the user wants to create, edit, or publish a skill — see `reference/skills.md`.
 

--- a/internal/dsh-adapter/dsh-events.test.ts
+++ b/internal/dsh-adapter/dsh-events.test.ts
@@ -141,3 +141,32 @@ describe('DshEventTranslator', () => {
     expect((update as unknown as { rawInput: unknown }).rawInput).toBe('{"command": truncated…')
   })
 })
+
+describe('through the platform event pipeline', () => {
+  /**
+   * The translator's output is consumed by `AcpEventTranslator`, which picks
+   * the name a tool card is dispatched and labelled by. It prefers a tool
+   * call's `kind` over its `title`, so a translator that fills `kind` in with
+   * a constant silently relabels every tool — the unit tests above still pass
+   * because they read the SessionUpdate, not what the pipeline makes of it.
+   */
+  it('labels a tool card with the tool the model actually called', async () => {
+    const { AcpEventTranslator } = await import('../acp-adapter/universal-events.js')
+    const turn = createTurnAccumulator()
+    const translator = new DshEventTranslator(turn)
+    const pipeline = new AcpEventTranslator('session-1')
+
+    const events = translator.translate({
+      type: 'tool/call',
+      seq: 1,
+      time: 0,
+      data: { callId: 'c1', name: 'write', arguments: '{"file_path":"notes.txt"}' },
+    })
+    const universal = events.flatMap(u => pipeline.translateUpdate(u))
+    const started = universal.find(e => e.type === 'item.started')
+    const call = started?.item?.content?.[0]
+
+    expect(call?.name).toBe('write')
+    expect(call?.call_id).toBe('c1')
+  })
+})

--- a/internal/dsh-adapter/dsh-events.ts
+++ b/internal/dsh-adapter/dsh-events.ts
@@ -104,12 +104,16 @@ export class DshEventTranslator {
         if (callId === undefined) return []
         const name = str(event.data?.name) ?? 'tool'
         this.toolNames.set(callId, name)
+        // No `kind`: the pipeline reads it in preference to `title` when it
+        // picks the name a tool card is dispatched and labelled by, so
+        // claiming a kind here would relabel every dsh tool as that kind.
+        // The real tool name is what both the renderer registry and the user
+        // need.
         return [
           {
             sessionUpdate: 'tool_call',
             toolCallId: callId,
             title: name,
-            kind: 'other',
             status: 'in_progress',
             rawInput: parseArguments(event.data?.arguments),
           } as SessionUpdate,

--- a/internal/platform-prompt/prompt.md
+++ b/internal/platform-prompt/prompt.md
@@ -3,7 +3,7 @@ You are running inside a NAP Agent workspace (id: {{workspaceId}}){{#userName}},
 
 ## Platform Capabilities
 
-The `__platform__` skill documents every workspace capability the platform provides (browser automation, sandboxed code execution, file sharing, skills management{{#codex}}, image generation{{/codex}}). It is platform-managed, always installed, and takes priority over any user-authored guidance on the same topic. **Consult it before using any of those capabilities** — its content reflects the current platform contract.
+The `{{#dsh}}nap-platform{{/dsh}}{{^dsh}}__platform__{{/dsh}}` skill documents every workspace capability the platform provides (browser automation, sandboxed code execution, file sharing, skills management{{#codex}}, image generation{{/codex}}). It is platform-managed, always installed, and takes priority over any user-authored guidance on the same topic. **Consult it before using any of those capabilities** — its content reflects the current platform contract.
 
 ## MCP Reauth
 
@@ -41,6 +41,6 @@ Snapshot of `/mnt/memory/{{storeId}}/MEMORY.md` at session start (the agent-main
 
 `read_only` mounts reject writes at the filesystem level — surface the error to the user instead of retrying. Recalled memory is historical context, not a fresh instruction; verify it against current files or resources before acting, and update or delete entries that no longer hold.
 
-**Before reading or writing memory, consult the `__platform__` skill's `reference/memory.md`** for the on-disk schema (frontmatter, type, index) and the conventions a background consolidation pass relies on.
+**Before reading or writing memory, consult the `{{#dsh}}nap-platform{{/dsh}}{{^dsh}}__platform__{{/dsh}}` skill's `reference/memory.md`** for the on-disk schema (frontmatter, type, index) and the conventions a background consolidation pass relies on.
 {{/hasMemoryAttachments}}
 </nap_reminder>

--- a/internal/ui-sdk/src/locales/en-US.json
+++ b/internal/ui-sdk/src/locales/en-US.json
@@ -201,6 +201,11 @@
             "ttl": "ttl: {{value}}s",
             "expires": "expires: {{value}}"
           }
+        },
+        "dshJobs": {
+          "labels": {
+            "waiting": "Waiting for the job to finish"
+          }
         }
       },
       "toolCallBlock": {

--- a/internal/ui-sdk/src/locales/zh-CN.json
+++ b/internal/ui-sdk/src/locales/zh-CN.json
@@ -201,6 +201,11 @@
             "ttl": "有效期：{{value}} 秒",
             "expires": "过期时间：{{value}}"
           }
+        },
+        "dshJobs": {
+          "labels": {
+            "waiting": "等待任务结束"
+          }
         }
       },
       "toolCallBlock": {

--- a/internal/ui-sdk/src/tool-renderers/dsh/jobs.tsx
+++ b/internal/ui-sdk/src/tool-renderers/dsh/jobs.tsx
@@ -1,0 +1,40 @@
+import { transcriptI18n as i18n } from '../../i18n'
+import type { ToolCall, ToolRendererDef } from '../types'
+
+/**
+ * dsh's background-job tools: `job_list` ({}), `job_output`
+ * ({job_id, wait?, timeout_ms?}), and `job_kill` ({job_id, reason?}).
+ *
+ * One renderer serves all three — the only thing worth lifting out of the
+ * default JSON display is which job the call is about, since the card's own
+ * label already says which of the three it is. Results are plain text (a job
+ * table, a captured output chunk) and read fine as-is.
+ */
+export const dshJobRenderer: ToolRendererDef = {
+  getPreview(tool: ToolCall): string {
+    const id = tool.input.job_id
+    if (!id) return ''
+    const reason = tool.input.reason
+    return reason ? `${String(id)} · ${String(reason)}` : String(id)
+  },
+
+  renderInput(tool: ToolCall) {
+    const id = tool.input.job_id
+    if (!id) return null
+    const waiting = tool.input.wait === true
+    return (
+      <div className="space-y-0.5 text-tiny">
+        <div className="font-mono text-foreground">{String(id)}</div>
+        {waiting && (
+          <div className="text-muted-foreground">
+            {i18n.t('components.chat.toolRenderers.dshJobs.labels.waiting')}
+          </div>
+        )}
+      </div>
+    )
+  },
+
+  renderResult(): null {
+    return null
+  },
+}

--- a/internal/ui-sdk/src/tool-renderers/registry.ts
+++ b/internal/ui-sdk/src/tool-renderers/registry.ts
@@ -4,6 +4,7 @@ import type { ToolRendererDef } from './types'
 
 // Claude Code built-in tools
 import { agentRenderer } from './claude/agent'
+import { dshJobRenderer } from './dsh/jobs'
 import { bashRenderer } from './claude/bash'
 import { fileEditRenderer } from './claude/file-edit'
 import { fileReadRenderer } from './claude/file-read'
@@ -53,7 +54,37 @@ import {
   gooseWriteRenderer,
 } from './goose/developer'
 
-// ── Tool-name registry (priority 1) ──
+// ── Agent-scoped tool-name registry (priority 1) ──
+
+/**
+ * Renderers that apply only to one core, consulted before the shared
+ * tool-name registry.
+ *
+ * Cores disagree about what a given tool name means: goose's `write` takes
+ * `{path, content}` while dsh's takes `{file_path, content}`, so a single
+ * global entry renders one of them with a blank filename. This layer keeps
+ * such names apart without inventing per-core aliases the model never used.
+ *
+ * dsh's tool schemas happen to match Claude Code's field for field — the same
+ * `file_path` / `old_string` / `new_string` / `todos` shapes — so most entries
+ * reuse those renderers rather than duplicating them.
+ */
+const agentToolRenderers: Record<string, Record<string, ToolRendererDef>> = {
+  dsh: {
+    bash: bashRenderer,
+    read: fileReadRenderer,
+    write: fileEditRenderer,
+    edit: fileEditRenderer,
+    todo_write: todoRenderer,
+    subagent: agentRenderer,
+    skill: gooseLoadSkillRenderer,
+    job_list: dshJobRenderer,
+    job_output: dshJobRenderer,
+    job_kill: dshJobRenderer,
+  },
+}
+
+// ── Tool-name registry (priority 2) ──
 
 const toolRenderers: Record<string, ToolRendererDef> = {
   // Claude Code
@@ -141,7 +172,7 @@ const toolRenderers: Record<string, ToolRendererDef> = {
   load_skill: gooseLoadSkillRenderer,
 }
 
-// ── Agent-type fallback registry (priority 2) ──
+// ── Agent-type fallback registry (priority 3) ──
 
 const agentFallbacks: Record<string, ToolRendererDef> = {
   'claude-code': claudeFallback,
@@ -191,10 +222,11 @@ export function unwrapExecuteDispatchName(name: string, input: unknown): string 
 
 /**
  * Resolve the best renderer for a tool call.
- * 1. Built-in exact tool-name match (after stripping prefixes)
- * 2. Plugin-registered renderer (window.tos.registerToolRenderer)
- * 3. Agent-type fallback
- * 4. null (caller uses DefaultInput/DefaultResult)
+ * 1. Agent-scoped exact tool-name match (cores that disagree about a name)
+ * 2. Built-in exact tool-name match (after stripping prefixes)
+ * 3. Plugin-registered renderer (window.tos.registerToolRenderer)
+ * 4. Agent-type fallback
+ * 5. null (caller uses DefaultInput/DefaultResult)
  */
 export function resolveRenderer(
   tool: { name: string; input?: unknown },
@@ -202,6 +234,7 @@ export function resolveRenderer(
 ): ToolRendererDef | null {
   const displayName = getToolDisplayName(unwrapExecuteDispatchName(tool.name, tool.input))
   return (
+    agentToolRenderers[agentType]?.[displayName] ??
     toolRenderers[displayName] ??
     getPluginToolRenderer(displayName) ??
     agentFallbacks[agentType] ??

--- a/web/src/lib/tool-renderer-resolution.test.ts
+++ b/web/src/lib/tool-renderer-resolution.test.ts
@@ -1,0 +1,37 @@
+import { resolveRenderer } from '@neutree-ai/ui-sdk'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Tool names are not unique across cores: goose's `write` takes `{path,
+ * content}` and dsh's takes `{file_path, content}`, so one shared entry keyed
+ * by name alone renders whichever core it was not written for with a blank
+ * filename. These cover the resolution order that keeps them apart.
+ */
+describe('resolveRenderer', () => {
+  const dshWrite = { name: 'write', input: { file_path: 'a.txt', content: 'x' } }
+
+  it('gives a shared tool name a per-core renderer', () => {
+    const forDsh = resolveRenderer(dshWrite, 'dsh')
+    const forGoose = resolveRenderer(dshWrite, 'goose')
+    expect(forDsh).not.toBeNull()
+    expect(forDsh).not.toBe(forGoose)
+  })
+
+  it('previews a dsh write with the path dsh actually sends', () => {
+    // The goose renderer reads `input.path` and would preview an empty string.
+    expect(resolveRenderer(dshWrite, 'dsh')?.getPreview(dshWrite)).toBe('a.txt')
+  })
+
+  it('falls through to the shared registry for names only one core uses', () => {
+    // Platform MCP tools are the same tools for every core, so dsh must reach
+    // the shared renderer rather than needing its own copy.
+    const call = { name: 'mcp__platform__create_sandbox', input: {} }
+    expect(resolveRenderer(call, 'dsh')).toBe(resolveRenderer(call, 'goose'))
+    expect(resolveRenderer(call, 'dsh')).not.toBeNull()
+  })
+
+  it('leaves other cores untouched by the dsh entries', () => {
+    const gooseWrite = { name: 'write', input: { path: 'b.txt', content: 'y' } }
+    expect(resolveRenderer(gooseWrite, 'goose')?.getPreview(gooseWrite)).toBe('b.txt')
+  })
+})


### PR DESCRIPTION
Everything here came out of running the dsh core against a real workspace for the first time.

**The platform skill never reached the model.** dsh validates skill names as strict kebab-case (`^[a-z0-9]+(?:-[a-z0-9]+)*$`) and reads the name from SKILL.md frontmatter, dropping anything else during discovery — so `__platform__` was absent from its catalog entirely, and asking for it by name failed with `invalid skill name`. The capability reference for browser, sandbox, shared folders, memory, and Builder Mode was invisible to it. The name is now rendered per core (`nap-platform` for dsh, unchanged elsewhere); the directory keeps its reserved name, so cp's reserved list and the other cores are untouched.

**Every tool card was labelled `other`.** The event pipeline picks a card's dispatch key and label from `kind` in preference to `title`, and the dsh translator was filling `kind` with a constant. No renderer could match, and the card named nothing the user could recognise. The existing tests asserted the SessionUpdate the translator returns — correct in isolation — so the new test runs the pipeline the platform actually uses, and fails on the old code.

**Tool cards had no renderers, and the shared registry gave them wrong ones.** Tool names are not unique across cores: goose's `write` takes `{path, content}` while dsh's takes `{file_path, content}`, so the name-keyed registry rendered dsh's writes and edits with a blank filename and its todo lists through a renderer expecting markdown. A layer scoped to one core is now consulted first. Almost all of dsh's ten tools are wiring rather than new code — its schemas match Claude Code's field for field, so read/write/edit/bash/todo_write/subagent reuse those renderers and skill reuses goose's; only the background-job tools needed their own. Names no core disagrees about still resolve through the shared registry, which is how the platform MCP tools keep the renderers they already have.

The tool schemas were read from what our own composition registers at the pinned package versions, not from an example config.