### PR TITLE
fix(chart): point env-runner default images at the published registry

### DIFF
--- a/charts/env-runner-k8s/values.yaml
+++ b/charts/env-runner-k8s/values.yaml
@@ -4,7 +4,7 @@
 # existingSecret), and the agent image settings for your cluster.
 
 image:
-  repository: ghcr.io/neutree-ai/env-runner-k8s
+  repository: ghcr.io/neutree-ai/agent-platform/nap-env-runner-k8s
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -32,10 +32,12 @@ envToken:
 # memoryFuseImage is set (memory tunnels back to the control plane).
 provider:
   namespace: default
-  agentImagePrefix: ghcr.io/neutree-ai/agent
+  # The provider builds each workspace image as <prefix>-<agentType>:<tag>, so
+  # the prefix ends at `nap-agent` — e.g. nap-agent-claude-code, nap-agent-codex.
+  agentImagePrefix: ghcr.io/neutree-ai/agent-platform/nap-agent
   agentImageTag: latest
   storageClass: ""
-  memoryFuseImage: ghcr.io/neutree-ai/memory-fuse:latest
+  memoryFuseImage: ghcr.io/neutree-ai/agent-platform/nap-memory-fuse:latest
   # "" → no nodeSelector; "k=v,k2=v2" → that selector (matches provider parsing).
   nodeSelector: ""
 


### PR DESCRIPTION
The remote runner chart shipped image names that are not published anywhere. CI pushes to `ghcr.io/neutree-ai/agent-platform` with a `nap-` prefix, but the chart defaulted to:

| value | was | now |
| --- | --- | --- |
| `image.repository` | `ghcr.io/neutree-ai/env-runner-k8s` | `ghcr.io/neutree-ai/agent-platform/nap-env-runner-k8s` |
| `provider.agentImagePrefix` | `ghcr.io/neutree-ai/agent` | `ghcr.io/neutree-ai/agent-platform/nap-agent` |
| `provider.memoryFuseImage` | `ghcr.io/neutree-ai/memory-fuse:latest` | `ghcr.io/neutree-ai/agent-platform/nap-memory-fuse:latest` |

Following the chart README as written could not pull any of them.

`agentImagePrefix` also gained a comment: the provider composes `<prefix>-<agentType>:<tag>` (`internal/k8s-provider/config.ts:107`), so the prefix must stop at `nap-agent` to resolve to `nap-agent-claude-code` and friends.

`afs.image` is deliberately untouched — afs is not built by this repo's CI, so its correct public name is still an open question.

Verified with `helm template`: the runner image renders as `ghcr.io/neutree-ai/agent-platform/nap-env-runner-k8s:latest`.