### PR TITLE
Let a provider declare the models it serves

### DIFF
--- a/agents/codex/src/codex-config.ts
+++ b/agents/codex/src/codex-config.ts
@@ -1,0 +1,142 @@
+/**
+ * Assembling what codex reads at startup: the provider's model profile on disk,
+ * and the pieces of `config.toml` that have to be reconciled with whatever the
+ * user put in agent_settings.
+ *
+ * Everything here is best-effort by design. codex treats an unreadable
+ * `model_catalog_json` as fatal — it exits instead of starting — so a profile
+ * that cp accepted but this codex build rejects would take the workspace down
+ * with it. cp validates the shape it acts on; this module is the second gate,
+ * and it fails by writing no catalog at all: the session goes back to codex's
+ * fallback metadata and its warning, which is where every workspace was before
+ * the profile existed.
+ */
+
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** What the caller writes into `config.toml`; absent keys are simply not written. */
+export interface CodexProfileConfig {
+  /** Absolute path of the catalog file, once it is on disk and re-readable. */
+  catalogPath?: string
+  /** Only set when the catalog says this model supports the level. */
+  reasoningEffort?: string
+  /** Overrides the wire protocol inferred from the provider type. */
+  wireApi?: 'responses' | 'chat'
+}
+
+interface CatalogModel {
+  slug?: unknown
+  supported_reasoning_levels?: unknown
+}
+
+/** Levels the catalog declares for one model, empty when it declares none. */
+function declaredLevels(model: CatalogModel): string[] {
+  const levels = model.supported_reasoning_levels
+  if (!Array.isArray(levels)) return []
+  return levels
+    .map((l) => (l as { effort?: unknown })?.effort)
+    .filter((e): e is string => typeof e === 'string')
+}
+
+export function applyModelProfile(
+  codexDir: string,
+  profile: unknown,
+  model: string,
+): CodexProfileConfig {
+  // Drop any catalog from a previous config first: config.toml only points at
+  // the file when this run wrote one, and a leftover on disk reads as current.
+  const catalogPath = join(codexDir, 'models.json')
+  rmSync(catalogPath, { force: true })
+
+  const codex = (profile as { codex?: Record<string, unknown> } | null | undefined)?.codex
+  if (!codex || typeof codex !== 'object') return {}
+
+  const result: CodexProfileConfig = {}
+
+  const wireApi = codex.wire_api
+  if (wireApi === 'responses' || wireApi === 'chat') {
+    result.wireApi = wireApi
+  }
+
+  const catalog = codex.model_catalog as { models?: CatalogModel[] } | undefined
+  if (!catalog || !Array.isArray(catalog.models) || catalog.models.length === 0) {
+    if (catalog) console.error('[agent] Model catalog ignored: no models array')
+    return result
+  }
+
+  try {
+    writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`)
+    // Read it back rather than trusting the write: a truncated file is the one
+    // failure mode that would reach codex as a fatal parse error.
+    JSON.parse(readFileSync(catalogPath, 'utf-8'))
+    result.catalogPath = catalogPath
+  } catch (e) {
+    console.error(`[agent] Model catalog not applied: ${(e as Error).message}`)
+    return result
+  }
+
+  const entry = catalog.models.find((m) => m.slug === model)
+  if (!entry) {
+    // Not an error: a provider's catalog covers the models it serves, and the
+    // workspace may be pointed at another one. codex falls back to its own
+    // metadata for this model, exactly as it does with no catalog at all.
+    console.log(
+      `[agent] Model catalog has no entry for "${model}" (covers: ${catalog.models
+        .map((m) => String(m.slug))
+        .join(', ')})`,
+    )
+    return result
+  }
+
+  const effort = codex.reasoning_effort
+  if (typeof effort === 'string') {
+    const levels = declaredLevels(entry)
+    if (levels.length === 0 || levels.includes(effort)) {
+      result.reasoningEffort = effort
+    } else {
+      console.error(
+        `[agent] reasoning_effort "${effort}" dropped: ${model} declares ${levels.join(', ')}`,
+      )
+    }
+  }
+
+  return result
+}
+
+/**
+ * Top-level TOML keys the user set in agent_settings.
+ *
+ * Only the region before the first table header counts: a key inside
+ * `[mcp_servers.x]` belongs to that table, and treating it as an override would
+ * silently drop a platform default the user never touched. Duplicating a
+ * top-level key is a TOML parse error, so this is what decides whether the
+ * platform writes its own copy.
+ */
+export function userTopLevelKeys(agentSettings: string): Set<string> {
+  const keys = new Set<string>()
+  for (const line of agentSettings.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('[')) break
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const match = /^([A-Za-z0-9_-]+)\s*=/.exec(trimmed)
+    if (match) keys.add(match[1])
+  }
+  return keys
+}
+
+/**
+ * Table headers the user declared in agent_settings.
+ *
+ * TOML rejects a table defined twice, and codex treats that as a fatal config
+ * error — so a platform table the user already wrote has to be dropped rather
+ * than emitted alongside theirs.
+ */
+export function userTables(agentSettings: string): Set<string> {
+  const tables = new Set<string>()
+  for (const line of agentSettings.split('\n')) {
+    const match = /^\s*\[\[?([^\]]+)\]\]?/.exec(line)
+    if (match) tables.add(match[1].trim())
+  }
+  return tables
+}

--- a/agents/codex/src/config.ts
+++ b/agents/codex/src/config.ts
@@ -14,6 +14,7 @@ import { nodeFetch, nodeFs, nodeShell } from '../../../internal/agent-skills/src
 import { renderPlatformSkillFiles } from '../../../internal/agent-skills/src/platform.js'
 import { writePlatformPrompt } from '../../../internal/platform-prompt/src/index.js'
 import { captureWorkspaceToken } from '../../../internal/types/workspace-token.js'
+import { applyModelProfile, userTables, userTopLevelKeys } from './codex-config.js'
 
 export const CP_URL = process.env.CP_URL
 export const WORKSPACE_ID = process.env.WORKSPACE_ID
@@ -175,26 +176,55 @@ export async function loadConfig(): Promise<boolean> {
   const agentSettings = (config.agent_settings || '').trim()
   const isTomlAgentSettings =
     agentSettings && agentSettings !== '{}' && !agentSettings.startsWith('{')
-  const userHasKey = (key: string) =>
-    isTomlAgentSettings && new RegExp(`^\\s*${key}\\s*=`, 'm').test(agentSettings)
+  const userKeys = isTomlAgentSettings ? userTopLevelKeys(agentSettings) : new Set<string>()
+  const userTableNames = isTomlAgentSettings ? userTables(agentSettings) : new Set<string>()
 
-  const tomlLines = [
-    `model_provider = "${providerName}"`,
-    `model = "${model}"`,
-    'disable_response_storage = true',
+  // The provider's declaration about the models it serves. Without it codex
+  // warns once per session that it has no metadata for the model and falls back
+  // to defaults that misstate the context window and reasoning levels.
+  const profile = applyModelProfile(codexDir, config.model_profile, model)
+
+  // Platform-owned top-level keys. A key the user set at the top level of
+  // agent_settings wins: their line is emitted verbatim below, and writing both
+  // would be a duplicate-key TOML error that stops codex from starting.
+  const topLevel: [string, string][] = [
+    ['model_provider', `"${providerName}"`],
+    ['model', `"${model}"`],
+    ['disable_response_storage', 'true'],
     // Workspace pod is isolated; grant full access up front so codex skips
     // the sandbox-then-escalate dance that surfaces a spurious first-call failure.
-    // Skipped if user overrode either key in agent_settings.
-    ...(userHasKey('sandbox_mode') ? [] : ['sandbox_mode = "danger-full-access"']),
-    ...(userHasKey('approval_policy') ? [] : ['approval_policy = "never"']),
-    ...(hasHttpMcp ? ['experimental_use_rmcp_client = true'] : []),
+    ['sandbox_mode', '"danger-full-access"'],
+    ['approval_policy', '"never"'],
+    ...(hasHttpMcp ? ([['experimental_use_rmcp_client', 'true']] as [string, string][]) : []),
+    // Must be a top-level key: written after a table header it parses as that
+    // table's field and codex silently keeps warning about missing metadata.
+    ...(profile.catalogPath
+      ? ([['model_catalog_json', JSON.stringify(profile.catalogPath)]] as [string, string][])
+      : []),
+    ...(profile.reasoningEffort
+      ? ([['model_reasoning_effort', `"${profile.reasoningEffort}"`]] as [string, string][])
+      : []),
   ]
-  if (config.base_url) {
+  const tomlLines = topLevel
+    .filter(([key]) => !userKeys.has(key))
+    .map(([key, value]) => `${key} = ${value}`)
+
+  // agent_settings goes here — after the platform's top-level keys and before
+  // any table. Appended at the end instead, a bare key in it would parse as a
+  // field of whatever table came last and never take effect.
+  if (isTomlAgentSettings) {
+    tomlLines.push('')
+    tomlLines.push('# agent_settings')
+    tomlLines.push(agentSettings)
+  }
+  // Same duplicate-table rule as [features] below: the user's own definition
+  // wins, because emitting both stops codex from starting at all.
+  if (config.base_url && !userTableNames.has('model_providers.custom')) {
     tomlLines.push('')
     tomlLines.push('[model_providers.custom]')
     tomlLines.push('name = "custom"')
     tomlLines.push(`base_url = "${config.base_url}"`)
-    tomlLines.push('wire_api = "responses"')
+    tomlLines.push(`wire_api = "${profile.wireApi ?? 'responses'}"`)
   }
   // MCP servers in config.toml format. HTTP entries skip this path: they are
   // wired through `loadAcpMcpServers` instead so per-session headers (notably
@@ -202,6 +232,12 @@ export async function loadConfig(): Promise<boolean> {
   // here — local processes don't go through cp proxy and don't need tokens.
   for (const [name, cfg] of Object.entries(mcpServers)) {
     if (cfg.url) continue
+    if (
+      userTableNames.has(`mcp_servers.${name}`) ||
+      userTableNames.has(`mcp_servers.${JSON.stringify(name)}`)
+    ) {
+      continue
+    }
     tomlLines.push('')
     tomlLines.push(`[mcp_servers.${JSON.stringify(name)}]`)
     if (cfg.command) {
@@ -217,17 +253,14 @@ export async function loadConfig(): Promise<boolean> {
       }
     }
   }
-  // Append user-provided agent_settings (TOML format) if present
-  // Skip JSON content (from claude-code settings) — not valid TOML
-  if (isTomlAgentSettings) {
+  // Platform-enforced: disable built-in memory (managed by platform memory).
+  // Skipped when the user declared their own [features]: a table defined twice
+  // is a TOML error, and codex would refuse to start over it.
+  if (!userTableNames.has('features')) {
     tomlLines.push('')
-    tomlLines.push('# agent_settings')
-    tomlLines.push(agentSettings)
+    tomlLines.push('[features]')
+    tomlLines.push('memories = false')
   }
-  // Platform-enforced: disable built-in memory (managed by platform memory)
-  tomlLines.push('')
-  tomlLines.push('[features]')
-  tomlLines.push('memories = false')
   writeFileSync(join(codexDir, 'config.toml'), `${tomlLines.join('\n')}\n`)
 
   // Write ~/.codex/auth.json
@@ -236,7 +269,7 @@ export async function loadConfig(): Promise<boolean> {
   }
 
   console.log(
-    `[agent] Config written: model=${config.model} provider=${config.provider_type} prompt=${prompt.length}chars`,
+    `[agent] Config written: model=${config.model} provider=${config.provider_type} prompt=${prompt.length}chars catalog=${profile.catalogPath ? 'yes' : 'no'}`,
   )
   return true
 }

--- a/control-plane/migrations/138_provider_model_profile.sql
+++ b/control-plane/migrations/138_provider_model_profile.sql
@@ -1,0 +1,14 @@
+-- A provider serves models the platform knows nothing about: there is no model
+-- table, and `workspace_config.model` is free text. Codex needs the metadata
+-- anyway (context window, reasoning levels, tool shapes, base instructions) and
+-- warns on every session without it, so the provider — the only row that knows
+-- which upstream is being talked to — is where the declaration belongs.
+--
+-- Shaped as a per-core object rather than one catalog column so a second core's
+-- keys don't collide with codex's:
+--   {"codex": {"model_catalog": {...}, "reasoning_effort": "high", ...}}
+--
+-- NULL means "declare nothing", which is the behaviour every existing provider
+-- has today. Not sensitive: readable by anyone who can read the provider, so a
+-- shared provider carries its profile to everyone using it.
+ALTER TABLE model_providers ADD COLUMN IF NOT EXISTS model_profile JSONB;

--- a/control-plane/src/routes/providers.ts
+++ b/control-plane/src/routes/providers.ts
@@ -4,6 +4,7 @@ import {
   ApiModelProviderSchema,
   ApiProviderGrantSchema,
   ModelListSchema,
+  type ModelProfile,
   ModelProviderCreateBodySchema,
   ModelProviderDeleteConflictSchema,
   ModelProviderTestBodySchema,
@@ -27,6 +28,7 @@ import {
   updateModelProvider,
 } from '../services/db/model-providers'
 import { getTeamMembership } from '../services/db/teams'
+import { catalogSlugs, checkModelProfile } from '../services/model-profile'
 
 const providers = new OpenAPIHono<AppEnv>()
 
@@ -45,6 +47,9 @@ function toApi(p: ProviderWithAccess): ApiModelProvider {
     provider_type: p.provider_type,
     base_url: p.base_url,
     api_key: '', // never expose api_key — owner edits via blank-keeps-existing pattern
+    // Unlike the key, the profile is readable by every viewer: a shared
+    // provider is only useful if the declaration travels with it.
+    model_profile: p.model_profile ?? null,
     user_id: p.user_id,
     owner_name: p.owner_name,
     is_owner: p.is_owner,
@@ -71,6 +76,31 @@ async function validateProviderGrants(
     if (!m) return { ok: false, error: `Team ${g.team_id} not accessible` }
   }
   return { ok: true }
+}
+
+/**
+ * Check a draft profile the way the store would, and say whether the model
+ * being tested is one the catalog actually covers — a catalog that parses but
+ * names other models leaves the tested model on codex's fallback metadata,
+ * which is the failure this whole field exists to prevent.
+ */
+function draftProfileVerdict(
+  raw: unknown,
+  model: string,
+): { profile_ok?: boolean; profile_detail?: string } {
+  if (raw === undefined) return {}
+  const check = checkModelProfile(raw)
+  if (!check.ok) return { profile_ok: false, profile_detail: check.error }
+
+  const slugs = catalogSlugs(check.profile)
+  if (slugs.length === 0) return { profile_ok: true }
+  if (model && !slugs.includes(model)) {
+    return {
+      profile_ok: false,
+      profile_detail: `Catalog covers ${slugs.join(', ')} — nothing for "${model}"`,
+    }
+  }
+  return { profile_ok: true, profile_detail: `Catalog covers ${slugs.join(', ')}` }
 }
 
 function resolveAnthropicUrl(provider: { provider_type: string; base_url: string }): string {
@@ -171,6 +201,9 @@ providers.openapi(createRouteDef, async (c) => {
   const grantCheck = await validateProviderGrants(user.sub, grants)
   if (!grantCheck.ok) return c.json({ error: grantCheck.error }, 400)
 
+  const profileCheck = checkModelProfile(body.model_profile)
+  if (!profileCheck.ok) return c.json({ error: profileCheck.error }, 400)
+
   try {
     const provider = await createModelProvider(body.name, {
       description: body.description,
@@ -179,6 +212,7 @@ providers.openapi(createRouteDef, async (c) => {
       api_key: body.api_key,
       user_id: user.sub,
       visibility,
+      model_profile: profileCheck.profile,
     })
     if (grants.length > 0) await setProviderGrants(provider.id, grants, user.sub)
     const decorated = await getProviderForUser(provider.id, user.sub)
@@ -253,6 +287,14 @@ providers.openapi(updateRouteDef, async (c) => {
     await setProviderGrants(id, [], user.sub)
   }
 
+  // Absent leaves the stored profile alone; an explicit null clears it.
+  let nextProfile: ModelProfile | null | undefined
+  if (body.model_profile !== undefined) {
+    const profileCheck = checkModelProfile(body.model_profile)
+    if (!profileCheck.ok) return c.json({ error: profileCheck.error }, 400)
+    nextProfile = profileCheck.profile
+  }
+
   const updated = await updateModelProvider(id, {
     name: body.name,
     description: body.description,
@@ -260,6 +302,7 @@ providers.openapi(updateRouteDef, async (c) => {
     base_url: body.base_url,
     api_key: body.api_key,
     visibility: nextVisibility,
+    model_profile: nextProfile,
   })
   if (!updated) return c.json({ error: 'Provider not found' }, 404)
 
@@ -382,10 +425,16 @@ providers.openapi(testRoute, async (c) => {
   const body = c.req.valid('json')
   const model = body.model?.trim() || ''
 
+  // The profile verdict rides along with the connection probe rather than
+  // living on its own route: the dialog asks one question ("is this provider
+  // configured right?") and a bad catalog is not a connection failure, so the
+  // two answers stay in separate fields.
+  const profile = draftProfileVerdict(body.model_profile, model)
+
   // A model is mandatory: the probe issues a real completion request, so there
   // is no safe provider-agnostic default to fall back to.
   if (!model) {
-    return c.json({ ok: false, detail: 'Select a model to test this provider.' }, 200)
+    return c.json({ ...profile, ok: false, detail: 'Select a model to test this provider.' }, 200)
   }
 
   // Merge optional draft config over the stored provider so the Edit Provider
@@ -463,19 +512,22 @@ providers.openapi(testRoute, async (c) => {
       }
     } else {
       return c.json(
-        { ok: false, detail: `Unsupported provider type: ${effective.provider_type}` },
+        { ...profile, ok: false, detail: `Unsupported provider type: ${effective.provider_type}` },
         200,
       )
     }
 
-    if (res.ok) return c.json({ ok: true }, 200)
+    if (res.ok) return c.json({ ...profile, ok: true }, 200)
     const text = await res.text().catch(() => '')
     return c.json(
-      { ok: false, detail: `${res.status} ${res.statusText}: ${text.slice(0, 200)}` },
+      { ...profile, ok: false, detail: `${res.status} ${res.statusText}: ${text.slice(0, 200)}` },
       200,
     )
   } catch (e) {
-    return c.json({ ok: false, detail: (e as Error).message || 'Connection failed' }, 200)
+    return c.json(
+      { ...profile, ok: false, detail: (e as Error).message || 'Connection failed' },
+      200,
+    )
   }
 })
 

--- a/control-plane/src/routes/workspace/config.ts
+++ b/control-plane/src/routes/workspace/config.ts
@@ -95,6 +95,7 @@ config.get('/v1/workspaces/:id/config', requireWorkspaceParam(), async (c) => {
     model: config.model,
     base_url: config.base_url,
     api_key: config.api_key,
+    model_profile: config.model_profile ?? null,
     small_model: config.small_model,
     system_prompt: config.system_prompt,
     mcp_config: mcpConfig,

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -295,6 +295,7 @@ read.openapi(getConfigRoute, async (c) => {
       model: config.model,
       base_url: config.base_url,
       api_key: '',
+      model_profile: config.model_profile ?? null,
       small_model: config.small_model,
       system_prompt: config.system_prompt,
       mcp_config: config.mcp_config,

--- a/control-plane/src/services/db/model-providers.ts
+++ b/control-plane/src/services/db/model-providers.ts
@@ -1,3 +1,4 @@
+import type { ModelProfile } from '../../../../internal/types/api'
 import { generateId, pool } from './pool'
 import type { ModelProvider, ProviderVisibility, Workspace } from './types'
 
@@ -147,6 +148,7 @@ function decorateProvider(
     provider_type: row.provider_type,
     base_url: row.base_url,
     api_key: row.api_key,
+    model_profile: row.model_profile ?? null,
     is_public: row.is_public,
     visibility: row.visibility,
     created_at: row.created_at,
@@ -167,12 +169,13 @@ export async function createModelProvider(
     api_key: string
     user_id: string
     visibility: ProviderVisibility
+    model_profile?: ModelProfile | null
   },
 ): Promise<ModelProvider> {
   const id = generateId()
   await pool.query(
-    `INSERT INTO model_providers (id, name, description, provider_type, base_url, api_key, user_id, visibility, is_public)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+    `INSERT INTO model_providers (id, name, description, provider_type, base_url, api_key, user_id, visibility, is_public, model_profile)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
       id,
       name,
@@ -183,6 +186,7 @@ export async function createModelProvider(
       opts.user_id,
       opts.visibility,
       opts.visibility === 'public',
+      opts.model_profile ?? null,
     ],
   )
   return (await getModelProvider(id))!
@@ -193,7 +197,13 @@ export async function updateModelProvider(
   updates: Partial<
     Pick<
       ModelProvider,
-      'name' | 'description' | 'provider_type' | 'base_url' | 'api_key' | 'visibility'
+      | 'name'
+      | 'description'
+      | 'provider_type'
+      | 'base_url'
+      | 'api_key'
+      | 'visibility'
+      | 'model_profile'
     >
   >,
 ): Promise<ModelProvider | null> {
@@ -207,6 +217,13 @@ export async function updateModelProvider(
       sets.push(`${field} = $${paramIndex++}`)
       values.push(updates[field])
     }
+  }
+
+  // Explicit null clears the declaration, which is why this one is not folded
+  // into the loop above: `null` is a value here, not "leave it alone".
+  if (updates.model_profile !== undefined) {
+    sets.push(`model_profile = $${paramIndex++}`)
+    values.push(updates.model_profile)
   }
 
   if (updates.visibility !== undefined) {

--- a/control-plane/src/services/db/types.ts
+++ b/control-plane/src/services/db/types.ts
@@ -1,4 +1,4 @@
-import type { ComputeResources, LayoutSkeleton } from '../../../../internal/types/api'
+import type { ComputeResources, LayoutSkeleton, ModelProfile } from '../../../../internal/types/api'
 
 export interface User {
   id: string
@@ -124,6 +124,8 @@ export interface WorkspaceConfig {
   model: string
   base_url: string
   api_key: string
+  /** The resolved provider's model declaration; null when it has none. */
+  model_profile: ModelProfile | null
   small_model: string
   system_prompt: string
   mcp_config: string
@@ -357,6 +359,7 @@ export interface ModelProvider {
   provider_type: string
   base_url: string
   api_key: string
+  model_profile: ModelProfile | null
   user_id: string
   is_public: boolean
   visibility: ProviderVisibility

--- a/control-plane/src/services/db/workspaces.ts
+++ b/control-plane/src/services/db/workspaces.ts
@@ -312,6 +312,8 @@ export async function getWorkspaceConfig(workspaceId: string): Promise<Workspace
        CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wp.api_key, ''), tp.api_key, wc.api_key)
             WHEN wc.provider_id IS NOT NULL THEN COALESCE(NULLIF(wp.api_key, ''), wc.api_key)
             ELSE wc.api_key END AS api_key,
+       CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(wp.model_profile, tp.model_profile)
+            ELSE wp.model_profile END AS model_profile,
        CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.model, ''), tv.model)
             ELSE wc.model END AS model,
        CASE WHEN wc.template_id IS NOT NULL THEN COALESCE(NULLIF(wc.small_model, ''), tv.small_model)
@@ -370,6 +372,8 @@ export async function updateWorkspaceConfig(
       | 'prompt_content'
       | 'template_name'
       | 'template_latest_version'
+      // Read-only projection of the resolved provider's own column.
+      | 'model_profile'
     >
   >,
 ): Promise<void> {

--- a/control-plane/src/services/model-profile.test.ts
+++ b/control-plane/src/services/model-profile.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { catalogSlugs, checkModelProfile } from './model-profile'
+
+const catalogModel = (slug: string, efforts: string[] = ['low', 'high']) => ({
+  slug,
+  display_name: slug,
+  supported_reasoning_levels: efforts.map((effort) => ({ effort, description: effort })),
+})
+
+const profile = (over: Record<string, unknown> = {}) => ({
+  codex: {
+    model_catalog: { models: [catalogModel('deepseek-v4-flash'), catalogModel('deepseek-v4-pro')] },
+    ...over,
+  },
+})
+
+describe('checkModelProfile', () => {
+  it('treats undefined and null alike as no profile', () => {
+    expect(checkModelProfile(undefined)).toEqual({ ok: true, profile: null })
+    expect(checkModelProfile(null)).toEqual({ ok: true, profile: null })
+  })
+
+  it('accepts a catalog and keeps fields it does not know about', () => {
+    const result = checkModelProfile(profile({ validated_with: '0.144.6' }))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // Codex reads far more per-model fields than cp validates; dropping the
+    // unknown ones here would ship a catalog that no longer describes the model.
+    const model = result.profile?.codex?.model_catalog?.models[0] as Record<string, unknown>
+    expect(model.display_name).toBe('deepseek-v4-flash')
+    expect(result.profile?.codex?.validated_with).toBe('0.144.6')
+  })
+
+  it('keeps a core it has never heard of', () => {
+    const result = checkModelProfile({ ...profile(), someFutureCore: { anything: true } })
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects a non-object', () => {
+    expect(checkModelProfile('{}')).toEqual({
+      ok: false,
+      error: 'model_profile must be an object',
+    })
+    expect(checkModelProfile([])).toEqual({
+      ok: false,
+      error: 'model_profile must be an object',
+    })
+  })
+
+  it('rejects a catalog with no models', () => {
+    const result = checkModelProfile({ codex: { model_catalog: { models: [] } } })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a model without a slug — codex matches by slug', () => {
+    const result = checkModelProfile({
+      codex: { model_catalog: { models: [{ display_name: 'no slug' }] } },
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects duplicate slugs', () => {
+    const result = checkModelProfile({
+      codex: {
+        model_catalog: {
+          models: [catalogModel('deepseek-v4-pro'), catalogModel('deepseek-v4-pro')],
+        },
+      },
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('more than once')
+  })
+
+  it('rejects a reasoning effort no model in the catalog declares', () => {
+    const result = checkModelProfile(profile({ reasoning_effort: 'medium' }))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('medium')
+    expect(result.error).toContain('high, low')
+  })
+
+  it('accepts an effort declared by any model, since the workspace picks later', () => {
+    const result = checkModelProfile({
+      codex: {
+        model_catalog: {
+          models: [catalogModel('flash', ['low']), catalogModel('pro', ['low', 'max'])],
+        },
+        reasoning_effort: 'max',
+      },
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts an effort with no catalog to check it against', () => {
+    const result = checkModelProfile({ codex: { reasoning_effort: 'high' } })
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects an effort codex has no notion of', () => {
+    const result = checkModelProfile({ codex: { reasoning_effort: 'ludicrous' } })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a profile past the size ceiling', () => {
+    const bulk = 'x'.repeat(1024 * 1024)
+    const result = checkModelProfile({ codex: { model_catalog: { models: [catalogModel(bulk)] } } })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('over the')
+  })
+})
+
+describe('catalogSlugs', () => {
+  it('lists what a catalog covers', () => {
+    const result = checkModelProfile(profile())
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(catalogSlugs(result.profile)).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro'])
+  })
+
+  it('is empty without a profile', () => {
+    expect(catalogSlugs(null)).toEqual([])
+    expect(catalogSlugs({ codex: {} })).toEqual([])
+  })
+})

--- a/control-plane/src/services/model-profile.ts
+++ b/control-plane/src/services/model-profile.ts
@@ -1,0 +1,95 @@
+/**
+ * Validation for a provider's model profile.
+ *
+ * A codex model catalog is not advisory: codex refuses to start when the file
+ * fails to parse, so an unchecked profile turns "this provider is misconfigured"
+ * into "this workspace never comes up". This is the gate that keeps a bad
+ * catalog out of the database; the agent has a second one that keeps a catalog
+ * cp accepted but a newer codex rejects from taking the pod down with it.
+ *
+ * The checks stop at the shape cp itself acts on. Copying codex's full model
+ * descriptor schema here would make every codex release that adds a field
+ * reject profiles that work — the agent's fallback covers that half.
+ */
+
+import { type ModelProfile, ModelProfileSchema } from '../../../internal/types/api'
+
+/** Serialized ceiling for one profile. DeepSeek's official catalog is ~76KB. */
+const MAX_PROFILE_BYTES = 1024 * 1024
+
+type ModelProfileCheck = { ok: true; profile: ModelProfile | null } | { ok: false; error: string }
+
+/**
+ * Validate a profile submitted by a client.
+ *
+ * `undefined` means the caller did not touch the profile; `null` clears it.
+ * Both are accepted and reported as a null profile, so callers can pass the
+ * result straight through to the store.
+ */
+export function checkModelProfile(raw: unknown): ModelProfileCheck {
+  if (raw === undefined || raw === null) return { ok: true, profile: null }
+
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'model_profile must be an object' }
+  }
+
+  const size = Buffer.byteLength(JSON.stringify(raw), 'utf8')
+  if (size > MAX_PROFILE_BYTES) {
+    return {
+      ok: false,
+      error: `model_profile is ${Math.round(size / 1024)}KB, over the ${MAX_PROFILE_BYTES / 1024}KB limit`,
+    }
+  }
+
+  const parsed = ModelProfileSchema.safeParse(raw)
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    const path = first?.path.join('.')
+    return { ok: false, error: path ? `${path}: ${first?.message}` : (first?.message ?? 'invalid') }
+  }
+
+  const codex = parsed.data.codex
+  if (codex) {
+    const catalog = codex.model_catalog
+    if (catalog) {
+      const slugs = catalog.models.map((m) => m.slug)
+      const dupes = slugs.filter((s, i) => slugs.indexOf(s) !== i)
+      if (dupes.length > 0) {
+        return {
+          ok: false,
+          error: `model_catalog lists ${dupes[0]} more than once; codex matches a model by slug`,
+        }
+      }
+    }
+
+    // Reasoning effort is checked against the union of what the catalog
+    // declares, not per model: the provider serves several models and the
+    // workspace picks one later. The agent narrows it to the model actually in
+    // use and drops the setting when that model doesn't declare the level.
+    if (codex.reasoning_effort && catalog) {
+      const declared = new Set<string>()
+      for (const model of catalog.models) {
+        const levels = (model as { supported_reasoning_levels?: unknown })
+          .supported_reasoning_levels
+        if (!Array.isArray(levels)) continue
+        for (const level of levels) {
+          const effort = (level as { effort?: unknown })?.effort
+          if (typeof effort === 'string') declared.add(effort)
+        }
+      }
+      if (declared.size > 0 && !declared.has(codex.reasoning_effort)) {
+        return {
+          ok: false,
+          error: `reasoning_effort "${codex.reasoning_effort}" is not declared by any model in the catalog (declared: ${[...declared].sort().join(', ')})`,
+        }
+      }
+    }
+  }
+
+  return { ok: true, profile: parsed.data }
+}
+
+/** Slugs a profile's codex catalog covers, for display and for the test route. */
+export function catalogSlugs(profile: ModelProfile | null | undefined): string[] {
+  return profile?.codex?.model_catalog?.models.map((m) => m.slug) ?? []
+}

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -341,6 +341,53 @@ export const ApiConfigMemoryAttachmentSchema = z.object({
 
 export type ApiConfigMemoryAttachment = z.infer<typeof ApiConfigMemoryAttachmentSchema>
 
+/**
+ * What a provider declares about the models it serves, grouped by agent core.
+ *
+ * The platform has no model table — `workspace_config.model` is free text — so
+ * the provider row is the only place that knows which upstream is answering.
+ * Codex needs that metadata (context window, reasoning levels, tool shapes,
+ * base instructions) and warns on every session without it.
+ *
+ * Deliberately not validated field-by-field: the catalog's real schema belongs
+ * to a specific codex version, and copying it here would make cp fail whenever
+ * codex adds a field. cp checks the shape it acts on; the agent guards the rest
+ * by falling back to no catalog when the file it wrote does not load.
+ */
+export const CodexReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh', 'max'])
+export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>
+
+export const CodexModelCatalogSchema = z
+  .object({
+    models: z
+      .array(z.object({ slug: z.string().min(1) }).passthrough())
+      .min(1, 'model_catalog.models must list at least one model'),
+  })
+  .passthrough()
+
+export const CodexModelProfileSchema = z
+  .object({
+    /** Contents of codex's `models.json`, written verbatim into the pod. */
+    model_catalog: CodexModelCatalogSchema.optional(),
+    /** Must be one of the levels the catalog declares for the model in use. */
+    reasoning_effort: CodexReasoningEffortSchema.optional(),
+    /** Overrides the wire protocol inferred from `provider_type`. */
+    wire_api: z.enum(['responses', 'chat']).optional(),
+    /** Codex version the catalog was accepted against, for upgrade triage. */
+    validated_with: z.string().optional(),
+  })
+  .passthrough()
+
+export type CodexModelProfile = z.infer<typeof CodexModelProfileSchema>
+
+// Unknown top-level keys pass through: a core added later must not be rejected
+// by an older control-plane sitting in front of a newer web.
+export const ModelProfileSchema = z
+  .object({ codex: CodexModelProfileSchema.optional() })
+  .passthrough()
+
+export type ModelProfile = z.infer<typeof ModelProfileSchema>
+
 export const ApiWorkspaceConfigSchema = z.object({
   agent_type: z.string(),
   provider_id: z.string().nullable(),
@@ -356,6 +403,8 @@ export const ApiWorkspaceConfigSchema = z.object({
   base_url: z.string(),
   /** Always returned as empty string; the real value is write-only. */
   api_key: z.string(),
+  /** The resolved provider's declaration about its models; null when it has none. */
+  model_profile: ModelProfileSchema.nullable(),
   small_model: z.string(),
   system_prompt: z.string(),
   mcp_config: z.string(),
@@ -794,6 +843,9 @@ export const ApiModelProviderSchema = z.object({
   provider_type: z.string(),
   base_url: z.string(),
   api_key: z.string(),
+  /** Not a secret: readable by anyone who can read the provider, so a shared
+   * provider carries its declaration to everyone using it. */
+  model_profile: ModelProfileSchema.nullable(),
   user_id: z.string(),
   owner_name: z.string(),
   is_owner: z.boolean(),
@@ -831,6 +883,7 @@ export const ModelProviderCreateBodySchema = z.object({
   provider_type: z.string().default(''),
   base_url: z.string().default(''),
   api_key: z.string().default(''),
+  model_profile: ModelProfileSchema.nullable().optional(),
   is_public: z.boolean().optional(),
   visibility: ProviderVisibilitySchema.optional(),
   grants: z.array(ProviderGrantSchema).optional(),
@@ -843,6 +896,7 @@ export const ModelProviderUpdateBodySchema = z
     provider_type: z.string(),
     base_url: z.string(),
     api_key: z.string(),
+    model_profile: ModelProfileSchema.nullable(),
     is_public: z.boolean(),
     visibility: ProviderVisibilitySchema,
     grants: z.array(ProviderGrantSchema),
@@ -858,6 +912,10 @@ export const ModelProviderTestBodySchema = z.object({
   provider_type: z.string().optional(),
   base_url: z.string().optional(),
   api_key: z.string().optional(),
+  // Unvalidated on the way in: the point of sending a draft profile is to hear
+  // back what is wrong with it, so a malformed one must reach the checker
+  // rather than bounce off the request schema.
+  model_profile: z.unknown().optional(),
 })
 
 export const ModelListSchema = z.object({
@@ -868,6 +926,10 @@ export const ModelListSchema = z.object({
 export const ModelProviderTestResultSchema = z.object({
   ok: z.boolean(),
   detail: z.string().optional(),
+  /** Absent when no profile was submitted; otherwise the profile's own verdict,
+   * reported separately so a good connection is not hidden by a bad catalog. */
+  profile_ok: z.boolean().optional(),
+  profile_detail: z.string().optional(),
 })
 
 export const ModelProviderUsageSchema = z.object({

--- a/web/src/components/dialogs/CreateProviderDialog.tsx
+++ b/web/src/components/dialogs/CreateProviderDialog.tsx
@@ -10,6 +10,7 @@ import { SaveButton } from '@/components/ui/save-button'
 import type { DialogProps } from '@/contexts/DialogStackContext'
 import { getProviderDoc, getProviderDocsHint } from '@/docs/inline-help/provider-docs'
 import { useCreateProvider } from '@/hooks/useProviders'
+import { buildModelProfile } from '@/lib/model-profile'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -22,6 +23,9 @@ const INITIAL_FORM: ProviderForm = {
   api_key: '',
   visibility: 'private',
   team_ids: [],
+  model_profile: null,
+  catalog_text: '',
+  reasoning_effort: '',
 }
 
 /**
@@ -52,9 +56,10 @@ export default function CreateProviderDialog({ open, onOpenChange }: DialogProps
     if (Object.keys(next).length > 0) return
     setGeneralError(null)
     try {
-      const { team_ids, visibility, ...rest } = form
+      const { team_ids, visibility, catalog_text, reasoning_effort, model_profile, ...rest } = form
       await createProvider.mutateAsync({
         ...rest,
+        model_profile: buildModelProfile(model_profile, catalog_text, reasoning_effort),
         visibility,
         grants:
           visibility === 'team'
@@ -76,6 +81,7 @@ export default function CreateProviderDialog({ open, onOpenChange }: DialogProps
     baseUrl: errors.baseUrl ? t(errors.baseUrl) : undefined,
     apiKey: errors.apiKey ? t(errors.apiKey) : undefined,
     teams: errors.teams ? t(errors.teams) : undefined,
+    catalog: errors.catalog ? t(errors.catalog) : undefined,
   }
 
   return (

--- a/web/src/components/dialogs/ProviderFormFields.tsx
+++ b/web/src/components/dialogs/ProviderFormFields.tsx
@@ -12,10 +12,11 @@ import {
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { api } from '@/lib/api/client'
-import type { ApiTeam, ProviderVisibility } from '@/lib/api/types'
+import type { ApiModelProvider, ApiTeam, ModelProfile, ProviderVisibility } from '@/lib/api/types'
+import { catalogToText, parseCatalogText } from '@/lib/model-profile'
 import { cn } from '@/lib/utils'
 import { useQuery } from '@tanstack/react-query'
-import { Eye, EyeOff, Lock, Users, X } from 'lucide-react'
+import { ChevronRight, Eye, EyeOff, Lock, Upload, Users, X } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -28,6 +29,16 @@ export interface ProviderForm {
   visibility: ProviderVisibility
   /** Set of team_ids the provider is shared with. Permission is always 'viewer'. */
   team_ids: string[]
+  /**
+   * The stored profile, carried through untouched. The form edits two of its
+   * fields below and folds them back in on save, so keys this build knows
+   * nothing about are not dropped by someone editing an unrelated setting.
+   */
+  model_profile: ModelProfile | null
+  /** codex.model_catalog as editable JSON text; '' declares no catalog. */
+  catalog_text: string
+  /** codex.reasoning_effort; '' leaves it to codex. */
+  reasoning_effort: string
 }
 
 export type ProviderFormErrors = Partial<{
@@ -35,6 +46,7 @@ export type ProviderFormErrors = Partial<{
   baseUrl: string
   apiKey: string
   teams: string
+  catalog: string
 }>
 
 interface ProviderFormFieldsProps {
@@ -77,6 +89,10 @@ export function ProviderFormFields({ form, setForm, errors, isEditing }: Provide
   const { t } = useTranslation()
   const [showKey, setShowKey] = useState(false)
   const isOauthOnly = form.provider_type === 'claude-code-oauth'
+  // The profile only carries codex keys today, and codex only speaks to the
+  // OpenAI-shaped types — offering the section elsewhere would promise an
+  // effect the agent never applies.
+  const isCodexCapable = form.provider_type === 'openai' || form.provider_type === 'openai-chat'
 
   const { data: teams = [] } = useQuery<ApiTeam[]>({
     queryKey: ['teams'],
@@ -201,6 +217,10 @@ export function ProviderFormFields({ form, setForm, errors, isEditing }: Provide
         </div>
       </Field>
 
+      {isCodexCapable && (
+        <ModelDeclarationSection form={form} setForm={setForm} error={errors?.catalog} />
+      )}
+
       <div className="space-y-3 rounded-md border border-border/60 bg-muted/30 p-3">
         <div className="flex flex-col gap-1.5">
           <Label className="block text-xs">
@@ -295,6 +315,161 @@ export function ProviderFormFields({ form, setForm, errors, isEditing }: Provide
   )
 }
 
+const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+
+/**
+ * The provider's declaration about the models it serves.
+ *
+ * Collapsed by default and worded as an escape hatch: most providers serve
+ * models codex already knows, and the catalog is a large document nobody
+ * writes by hand — it comes from the model vendor, which is why loading a file
+ * and copying another provider's are the two first-class ways in.
+ */
+function ModelDeclarationSection({
+  form,
+  setForm,
+  error,
+}: {
+  form: ProviderForm
+  setForm: (next: (prev: ProviderForm) => ProviderForm) => void
+  error?: string
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const parsed = parseCatalogText(form.catalog_text)
+
+  const { data: providers = [] } = useQuery<ApiModelProvider[]>({
+    queryKey: ['providers'],
+    queryFn: () => api.listProviders(),
+    enabled: open,
+  })
+  const donors = providers.filter((p) => p.model_profile?.codex?.model_catalog)
+
+  function loadFile(file: File | undefined) {
+    if (!file) return
+    file.text().then((text) => setForm((f) => ({ ...f, catalog_text: text.trim() })))
+  }
+
+  const summary = parsed.slugs.length
+    ? t('components.createProvider.modelDeclaration.covers', { models: parsed.slugs.join(', ') })
+    : t('components.createProvider.modelDeclaration.empty')
+
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/30">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left"
+      >
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 text-muted-foreground transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <span className="text-xs font-medium">
+          {t('components.createProvider.modelDeclaration.title')}
+        </span>
+        <span className="ml-auto truncate text-tiny text-muted-foreground">{summary}</span>
+      </button>
+
+      {open && (
+        <div className="space-y-2.5 border-t border-border/60 p-3">
+          <p className="text-tiny text-muted-foreground">
+            {t('components.createProvider.modelDeclaration.help')}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-tiny"
+              asChild
+            >
+              <label>
+                <Upload className="h-3 w-3" />
+                {t('components.createProvider.modelDeclaration.loadFile')}
+                <input
+                  type="file"
+                  accept="application/json,.json"
+                  className="hidden"
+                  onChange={(e) => loadFile(e.target.files?.[0])}
+                />
+              </label>
+            </Button>
+            {donors.length > 0 && (
+              <Combobox
+                placeholder={t('components.createProvider.modelDeclaration.copyFrom')}
+                value=""
+                onValueChange={(id) => {
+                  const donor = donors.find((p) => p.id === id)
+                  if (!donor) return
+                  setForm((f) => ({
+                    ...f,
+                    catalog_text: catalogToText(donor.model_profile),
+                    reasoning_effort:
+                      donor.model_profile?.codex?.reasoning_effort ?? f.reasoning_effort,
+                  }))
+                }}
+                options={donors.map((p) => ({ value: p.id, label: p.name }))}
+              />
+            )}
+            {form.catalog_text && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 text-tiny text-muted-foreground"
+                onClick={() => setForm((f) => ({ ...f, catalog_text: '' }))}
+              >
+                {t('components.createProvider.modelDeclaration.clear')}
+              </Button>
+            )}
+          </div>
+
+          <Textarea
+            className="min-h-[140px] font-mono text-tiny"
+            spellCheck={false}
+            placeholder={t('components.createProvider.modelDeclaration.placeholder')}
+            value={form.catalog_text}
+            onChange={(e) => setForm((f) => ({ ...f, catalog_text: e.target.value }))}
+          />
+          {(error || !parsed.ok) && (
+            <div className="text-xs text-destructive">{error ?? parsed.error}</div>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <Label className="block text-tiny text-muted-foreground">
+              {t('components.createProvider.modelDeclaration.reasoningEffort')}
+            </Label>
+            <Select
+              value={form.reasoning_effort || 'default'}
+              onValueChange={(v) =>
+                setForm((f) => ({ ...f, reasoning_effort: v === 'default' ? '' : v }))
+              }
+            >
+              <SelectTrigger className="h-8 text-xs focus:ring-inset">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default" className="py-1.5">
+                  {t('components.createProvider.modelDeclaration.effortDefault')}
+                </SelectItem>
+                {REASONING_EFFORTS.map((level) => (
+                  <SelectItem key={level} value={level} className="py-1.5">
+                    {level}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function Field({
   label,
   error,
@@ -332,6 +507,11 @@ export function validateProviderForm(
   }
   if (form.visibility === 'team' && form.team_ids.length === 0) {
     errors.teams = 'components.createProvider.errors.teamRequired'
+  }
+  // A catalog codex cannot read stops it from starting at all, so a broken one
+  // must not reach the store — the agent's fallback is a backstop, not a plan.
+  if (!parseCatalogText(form.catalog_text).ok) {
+    errors.catalog = 'components.createProvider.errors.catalogInvalid'
   }
   return errors
 }

--- a/web/src/components/management/ProvidersSection.tsx
+++ b/web/src/components/management/ProvidersSection.tsx
@@ -28,6 +28,7 @@ import { getProviderDoc, getProviderDocsHint } from '@/docs/inline-help/provider
 import { useDeleteProvider, useProviders, useUpdateProvider } from '@/hooks/useProviders'
 import { api } from '@/lib/api/client'
 import type { ApiModelProvider } from '@/lib/api/types'
+import { buildModelProfile, catalogToText, draftProfile } from '@/lib/model-profile'
 import { useInstancePersistentState } from '@/stores/instance-state-store'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
@@ -42,6 +43,9 @@ const INITIAL_FORM: ProviderForm = {
   api_key: '',
   visibility: 'private',
   team_ids: [],
+  model_profile: null,
+  catalog_text: '',
+  reasoning_effort: '',
 }
 
 export function ProvidersSection({ instanceId }: { instanceId: string }) {
@@ -118,6 +122,9 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
       api_key: '',
       visibility: p.visibility,
       team_ids: [],
+      model_profile: p.model_profile,
+      catalog_text: catalogToText(p.model_profile),
+      reasoning_effort: p.model_profile?.codex?.reasoning_effort ?? '',
     })
     setEditingId(p.id)
     setErrors({})
@@ -140,9 +147,14 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
         provider_type: form.provider_type,
         base_url: form.base_url,
         api_key: form.api_key,
+        model_profile: draftProfile(form),
       })
-      setTestState(res.ok ? 'ok' : 'fail')
-      setTestDetail(res.detail || '')
+      // A catalog that does not describe the model being tested is worth
+      // saying out loud even when the connection itself is fine: the request
+      // succeeds and codex still runs on fallback metadata.
+      const profileNote = res.profile_detail ? ` · ${res.profile_detail}` : ''
+      setTestState(res.ok && res.profile_ok !== false ? 'ok' : 'fail')
+      setTestDetail(`${res.detail || ''}${profileNote}`.trim())
     } catch (err) {
       setTestState('fail')
       setTestDetail(err instanceof Error ? err.message : t('common.errors.requestFailed'))
@@ -155,10 +167,11 @@ export function ProvidersSection({ instanceId }: { instanceId: string }) {
     if (Object.keys(next).length > 0) return
     if (!editingId) return
     setGeneralError(null)
-    const { team_ids, visibility, ...rest } = form
+    const { team_ids, visibility, catalog_text, reasoning_effort, model_profile, ...rest } = form
     const payload: Parameters<typeof updateProvider.mutateAsync>[0] = {
       id: editingId,
       ...rest,
+      model_profile: buildModelProfile(model_profile, catalog_text, reasoning_effort),
       visibility,
       grants:
         visibility === 'team'

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -76,10 +76,12 @@ import type {
   LayoutSkeleton,
   McpCatalogEntry,
   MemoryAccess,
+  ModelProfile,
   PendingMessage,
   PromptGrant,
   PromptVisibility,
   ProviderGrant,
+  ProviderTestResult,
   ProviderVisibility,
   SandboxInfo,
   SandboxListResponse,
@@ -1417,6 +1419,7 @@ class ApiClient {
     provider_type: string
     base_url: string
     api_key: string
+    model_profile?: ModelProfile | null
     visibility?: ProviderVisibility
     grants?: ProviderGrant[]
   }): Promise<ApiModelProvider> {
@@ -1434,6 +1437,7 @@ class ApiClient {
       provider_type: string
       base_url: string
       api_key: string
+      model_profile: ModelProfile | null
       visibility: ProviderVisibility
       grants: ProviderGrant[]
     }>,
@@ -1538,9 +1542,10 @@ class ApiClient {
       provider_type?: string
       base_url?: string
       api_key?: string
+      model_profile?: ModelProfile | null
     },
-  ): Promise<{ ok: boolean; detail?: string }> {
-    return this.request<{ ok: boolean; detail?: string }>(`/providers/${id}/test`, {
+  ): Promise<ProviderTestResult> {
+    return this.request<ProviderTestResult>(`/providers/${id}/test`, {
       method: 'POST',
       body: JSON.stringify(opts ?? {}),
     })

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -60,9 +60,18 @@ export type { ApiWorkspaceLayout, LayoutSkeleton } from '@neutree-ai/types'
 export type {
   ApiModelProvider,
   ApiProviderGrant,
+  ModelProfile,
   ProviderGrant,
   ProviderVisibility,
 } from '@neutree-ai/types'
+
+/** Provider probe outcome: connection and profile answered separately. */
+export interface ProviderTestResult {
+  ok: boolean
+  detail?: string
+  profile_ok?: boolean
+  profile_detail?: string
+}
 
 export type {
   ApiEnvironment,

--- a/web/src/lib/model-profile.test.ts
+++ b/web/src/lib/model-profile.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { buildModelProfile, catalogToText, parseCatalogText } from './model-profile'
+
+const catalog = { models: [{ slug: 'deepseek-v4-flash' }, { slug: 'deepseek-v4-pro' }] }
+
+describe('parseCatalogText', () => {
+  it('accepts empty text as "no catalog"', () => {
+    expect(parseCatalogText('   ')).toEqual({ ok: true, slugs: [] })
+  })
+
+  it('lists the slugs a catalog covers', () => {
+    expect(parseCatalogText(JSON.stringify(catalog))).toEqual({
+      ok: true,
+      slugs: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+    })
+  })
+
+  it('rejects malformed JSON, a missing models array, and a model without a slug', () => {
+    expect(parseCatalogText('{').ok).toBe(false)
+    expect(parseCatalogText('{"models":[]}').ok).toBe(false)
+    expect(parseCatalogText('{"models":[{"display_name":"x"}]}').ok).toBe(false)
+  })
+
+  it('rejects duplicate slugs, which codex would resolve arbitrarily', () => {
+    expect(parseCatalogText('{"models":[{"slug":"a"},{"slug":"a"}]}').ok).toBe(false)
+  })
+})
+
+describe('buildModelProfile', () => {
+  it('keeps profile keys the form does not edit', () => {
+    const stored = {
+      codex: { wire_api: 'responses', validated_with: '0.144.6' },
+      futureCore: { anything: true },
+    } as never
+    const next = buildModelProfile(stored, JSON.stringify(catalog), 'high') as Record<string, never>
+    const codex = next.codex as Record<string, unknown>
+    expect(codex.wire_api).toBe('responses')
+    expect(codex.validated_with).toBe('0.144.6')
+    expect(next.futureCore).toEqual({ anything: true })
+    expect(codex.reasoning_effort).toBe('high')
+  })
+
+  it('drops the catalog and the effort when both are cleared', () => {
+    const stored = { codex: { model_catalog: catalog, reasoning_effort: 'high' } } as never
+    expect(buildModelProfile(stored, '', '')).toBeNull()
+  })
+
+  it('leaves other cores in place when codex is emptied', () => {
+    const stored = { codex: { model_catalog: catalog }, futureCore: { on: true } } as never
+    expect(buildModelProfile(stored, '', '')).toEqual({ futureCore: { on: true } })
+  })
+
+  it('round-trips through the editor unchanged', () => {
+    const built = buildModelProfile(null, JSON.stringify(catalog), '')
+    expect(JSON.parse(catalogToText(built))).toEqual(catalog)
+  })
+})

--- a/web/src/lib/model-profile.ts
+++ b/web/src/lib/model-profile.ts
@@ -1,0 +1,107 @@
+/**
+ * Editing helpers for a provider's model profile.
+ *
+ * The form edits two of the profile's fields — the codex catalog and the
+ * reasoning effort — but writes back the whole object, so everything else it
+ * finds there (a wire_api override, a core added after this build) has to
+ * survive the round trip untouched.
+ */
+
+import type { ModelProfile } from '@/lib/api/types'
+
+interface CatalogParse {
+  ok: boolean
+  /** Slugs the catalog covers, for the summary line. */
+  slugs: string[]
+  /** Populated only when `ok` is false. */
+  error?: string
+}
+
+/** Read the catalog text the way cp will, so the dialog reports the same verdict. */
+export function parseCatalogText(text: string): CatalogParse {
+  const trimmed = text.trim()
+  if (!trimmed) return { ok: true, slugs: [] }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (e) {
+    return { ok: false, slugs: [], error: (e as Error).message }
+  }
+
+  const models = (parsed as { models?: unknown })?.models
+  if (!Array.isArray(models) || models.length === 0) {
+    return { ok: false, slugs: [], error: 'Expected a { "models": [...] } object' }
+  }
+
+  const slugs: string[] = []
+  for (const model of models) {
+    const slug = (model as { slug?: unknown })?.slug
+    if (typeof slug !== 'string' || !slug) {
+      return { ok: false, slugs: [], error: 'Every model needs a slug' }
+    }
+    slugs.push(slug)
+  }
+  const dupe = slugs.find((s, i) => slugs.indexOf(s) !== i)
+  if (dupe) return { ok: false, slugs: [], error: `Duplicate slug: ${dupe}` }
+
+  return { ok: true, slugs }
+}
+
+/** The catalog as text for the editor, or '' when the provider declares none. */
+export function catalogToText(profile: ModelProfile | null | undefined): string {
+  const catalog = profile?.codex?.model_catalog
+  return catalog ? JSON.stringify(catalog, null, 2) : ''
+}
+
+/**
+ * Fold edited catalog + effort back into the stored profile.
+ *
+ * Returns null when nothing is left to declare, which is what clears the column.
+ */
+export function buildModelProfile(
+  stored: ModelProfile | null | undefined,
+  catalogText: string,
+  reasoningEffort: string,
+): ModelProfile | null {
+  const codex: Record<string, unknown> = { ...(stored?.codex ?? {}) }
+
+  const trimmed = catalogText.trim()
+  if (trimmed) {
+    codex.model_catalog = JSON.parse(trimmed)
+  } else {
+    // biome-ignore lint/performance/noDelete: undefined would stay in Object.keys() and the profile would never collapse back to null
+    delete codex.model_catalog
+  }
+
+  if (reasoningEffort) {
+    codex.reasoning_effort = reasoningEffort
+  } else {
+    // biome-ignore lint/performance/noDelete: undefined would stay in Object.keys() and the profile would never collapse back to null
+    delete codex.reasoning_effort
+  }
+
+  const next: Record<string, unknown> = { ...(stored ?? {}) }
+  if (Object.keys(codex).length > 0) {
+    next.codex = codex
+  } else {
+    // biome-ignore lint/performance/noDelete: undefined would stay in Object.keys() and the profile would never collapse back to null
+    delete next.codex
+  }
+  return Object.keys(next).length > 0 ? (next as ModelProfile) : null
+}
+
+/** The profile a half-edited form would save, for the provider Test probe. */
+export function draftProfile(form: {
+  model_profile: ModelProfile | null
+  catalog_text: string
+  reasoning_effort: string
+}): ModelProfile | null | undefined {
+  try {
+    return buildModelProfile(form.model_profile, form.catalog_text, form.reasoning_effort)
+  } catch {
+    // Unparseable text: let the probe answer about the connection only, the
+    // editor already shows what is wrong with the catalog.
+    return undefined
+  }
+}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2082,7 +2082,20 @@
         "baseUrlRequired": "Base URL is required",
         "apiKeyRequired": "API Key is required",
         "teamRequired": "Pick at least one team or change visibility",
-        "createFailed": "Failed to create provider"
+        "createFailed": "Failed to create provider",
+        "catalogInvalid": "Catalog is not valid JSON, or has no models with a slug"
+      },
+      "modelDeclaration": {
+        "title": "Model declaration (Codex)",
+        "help": "Codex needs metadata for the models this provider serves — context window, reasoning levels, tool shapes. Without it, every session warns and falls back to defaults. The catalog comes from the model vendor; load the file here and everyone using this provider gets it.",
+        "covers": "Covers {{models}}",
+        "empty": "Not declared",
+        "loadFile": "Load JSON file",
+        "copyFrom": "Copy from provider…",
+        "clear": "Clear",
+        "placeholder": "{ \"models\": [ { \"slug\": \"...\", ... } ] }",
+        "reasoningEffort": "Default reasoning effort",
+        "effortDefault": "Leave to Codex"
       }
     },
     "createRoute": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2107,7 +2107,20 @@
         "baseUrlRequired": "Base URL 不能为空",
         "apiKeyRequired": "API Key 不能为空",
         "teamRequired": "请至少选择一个团队，或更换可见性",
-        "createFailed": "创建 API 供应商失败"
+        "createFailed": "创建 API 供应商失败",
+        "catalogInvalid": "catalog 不是合法 JSON，或没有带 slug 的模型"
+      },
+      "modelDeclaration": {
+        "title": "模型声明（Codex）",
+        "help": "Codex 需要这个供应商所服务模型的元数据——上下文窗口、推理档位、工具形态。缺了它，每次会话都会告警并退回默认值。catalog 由模型厂商提供；在这里载入文件后，所有使用该供应商的人都会生效。",
+        "covers": "已覆盖 {{models}}",
+        "empty": "未声明",
+        "loadFile": "载入 JSON 文件",
+        "copyFrom": "从其他供应商复制…",
+        "clear": "清除",
+        "placeholder": "{ \"models\": [ { \"slug\": \"...\", ... } ] }",
+        "reasoningEffort": "默认推理档位",
+        "effortDefault": "交给 Codex 决定"
       }
     },
     "createRoute": {


### PR DESCRIPTION
## Why

The platform has no model table — `workspace_config.model` is free text — so nothing tells an agent what the model behind a provider actually is. Codex wants that metadata and warns once per session when it has none:

```
warning: Model metadata for `deepseek-v4-flash` not found.
Defaulting to fallback metadata; this can degrade performance and cause issues.
```

The fallback is not only noisy: it misstates the context window, the reasoning levels, and the tool shapes the model was tuned for. Vendors that ship a codex integration publish a `models.json` for exactly this, but there was nowhere to put it.

## What

Providers get an optional `model_profile`, grouped by agent core:

```json
{
  "codex": {
    "model_catalog": { "models": [ ... ] },
    "reasoning_effort": "high",
    "wire_api": "responses"
  }
}
```

`NULL` keeps today's behaviour. The profile is readable by anyone who can read the provider — a shared provider is only useful if its declaration travels with it, and one person filling it in covers everyone using that provider.

- **control-plane** — new column, delivered down the existing provider/template resolution chain, validated on save. Validation stops at the shape cp acts on (the catalog parses, slugs are unique, the effort is one the catalog declares); copying codex's full model descriptor schema would reject working profiles the moment codex adds a field.
- **agents/codex** — writes the catalog to `~/.codex/models.json` and points codex at it with a **top-level** `model_catalog_json`. Emitted after a table header the key parses as that table's field and the warning stays, which is easy to get wrong.
- **web** — a collapsed advanced section on the provider form: load a JSON file, copy another provider's declaration, or paste. Parse errors block save.

## Failing safe

An unreadable `model_catalog_json` — bad JSON, or a path with no file — makes codex exit instead of start. So the agent reads the file back and parses it before writing the path, and drops the key entirely if that fails: the session returns to codex's own metadata rather than the pod failing to come up. That is also the guard for a profile an older cp accepted and a newer codex rejects.

## Included fix: agent_settings landed inside the wrong TOML table

`agent_settings` was appended after every table in `config.toml`, so a bare key in it parsed as a field of whichever table came last. A user writing `sandbox_mode = "read-only"` got nothing — and `userHasKey` still dropped the platform default it was meant to replace. It now sits between the platform's top-level keys and the first table; every platform top-level key yields to a user key of the same name; and a table the user already declared is not emitted a second time. TOML rejects duplicate keys and duplicate tables alike, and codex treats either as fatal.

## Verification

- `tsc --noEmit` and biome clean in control-plane, web, agents/codex
- New unit tests: 14 (control-plane) + 8 (web); full suites pass
- End to end against a real codex build: with the generated `models.json` and config, the metadata warning is gone and the session header goes from `reasoning effort: none` to the declared level