### PR TITLE
Keep the cache split dsh reports

### DIFF
--- a/internal/agent-usage/src/index.test.ts
+++ b/internal/agent-usage/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test, vi } from 'vitest'
-import { type UsageRecord, parseClaudeTranscript, parseCodexRollout } from './index.ts'
+import {
+  type UsageRecord,
+  parseAcpUsageLog,
+  parseClaudeTranscript,
+  parseCodexRollout,
+} from './index.ts'
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
@@ -336,5 +341,63 @@ describe('parseCodexRollout', () => {
       codexTokenCount({ input: 5, total: 5 }),
     ])
     expect(recs[0].sessionId).toBe('019e796d-real-id')
+  })
+})
+
+describe('parseAcpUsageLog', () => {
+  const dshTurn = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({
+      ts: '2026-08-18T10:00:00.000Z',
+      model: 'deepseek-v4-pro',
+      input_tokens: 1000,
+      output_tokens: 200,
+      cache_read_tokens: 800,
+      total_tokens: 1200,
+      ...over,
+    })
+
+  test('keeps the cache split dsh reports', () => {
+    const [rec] = parseAcpUsageLog([dshTurn()], { sessionId: 's1' })
+    // dsh buckets are disjoint: input is already the uncached half, so the
+    // two are priced separately rather than one being derived from the other.
+    expect(rec.inputTokens).toBe(1000)
+    expect(rec.cacheReadTokens).toBe(800)
+    expect(rec.fieldsIncomplete).toBe(false)
+  })
+
+  test('a turn that missed the cache is complete, not unknown', () => {
+    const [rec] = parseAcpUsageLog([dshTurn({ cache_read_tokens: 0 })], { sessionId: 's1' })
+    expect(rec.cacheReadTokens).toBe(0)
+    expect(rec.fieldsIncomplete).toBe(false)
+  })
+
+  test('goose lines, which carry no split, stay flagged', () => {
+    const line = JSON.stringify({
+      ts: '2026-08-18T10:00:00.000Z',
+      input_tokens: 1000,
+      output_tokens: 200,
+    })
+    const [rec] = parseAcpUsageLog([line], { sessionId: 's1' })
+    expect(rec.cacheReadTokens).toBe(0)
+    expect(rec.fieldsIncomplete).toBe(true)
+  })
+
+  test('dedup keys are unchanged by the cache split', () => {
+    // The ledger keys on these strings. Re-shaping them would make every line
+    // of every existing log re-insert as a new record on the next sweep.
+    const direct = parseAcpUsageLog([dshTurn(), dshTurn()], { sessionId: 's1' })
+    expect(direct.map((r) => r.dedupKey)).toEqual(['goose:s1:0', 'goose:s1:1'])
+
+    const accumulated = parseAcpUsageLog(
+      [
+        JSON.stringify({
+          ts: '2026-08-18T10:00:00.000Z',
+          accumulated_input_tokens: 10,
+          accumulated_output_tokens: 5,
+        }),
+      ],
+      { sessionId: 's1' },
+    )
+    expect(accumulated[0].dedupKey).toBe('goose:s1:15')
   })
 })

--- a/internal/agent-usage/src/index.ts
+++ b/internal/agent-usage/src/index.ts
@@ -428,9 +428,13 @@ export interface AcpUsageParseOpts {
  *
  * Values are PER-TURN sums (each LLM request bills its full input context, so
  * summing lines is the correct billing semantics — no cumulative/delta dance).
- * Cache/reasoning splits aren't available on this path (goose only reports
- * them via its gated custom MessageUsage notification), so records are
- * flagged `fieldsIncomplete`.
+ *
+ * Two agents write this format. dsh reports DISJOINT buckets — its
+ * `input_tokens` already excludes cached prompt tokens — and writes the
+ * cache-read count alongside, so both halves of a provider's hit/miss pricing
+ * survive. goose has no such split and omits the field; those records keep a
+ * zero cache-read and stay flagged `fieldsIncomplete`. Reasoning tokens are
+ * reported by neither.
  *
  * dedupKey uses the line index — stable across re-sweeps of the same
  * append-only file, so ledger re-inserts are idempotent.
@@ -482,6 +486,10 @@ export function parseAcpUsageLog(lines: string[], opts: AcpUsageParseOpts = {}):
     }
     if (input === 0 && output === 0) continue
 
+    // Absent (goose) is not the same as present-and-zero (dsh on a turn that
+    // missed the cache): only the former leaves the record incomplete.
+    const hasCacheSplit = obj.cache_read_tokens != null
+
     records.push({
       source: 'goose',
       sessionId,
@@ -489,15 +497,16 @@ export function parseAcpUsageLog(lines: string[], opts: AcpUsageParseOpts = {}):
       ts: typeof obj.ts === 'string' ? obj.ts : new Date(0).toISOString(),
       inputTokens: input,
       outputTokens: output,
-      cacheReadTokens: 0,
+      cacheReadTokens: num(obj.cache_read_tokens),
       cacheCreationTokens: 0,
       cacheCreation5mTokens: 0,
       cacheCreation1hTokens: 0,
       reasoningTokens: 0,
       webSearchRequests: 0,
       speed: null,
-      // cache/reasoning splits genuinely unavailable on this path
-      fieldsIncomplete: true,
+      // Reasoning is reported by neither agent on this path; cache-read is
+      // reported by dsh only.
+      fieldsIncomplete: !hasCacheSplit,
       dedupKey,
     })
   }


### PR DESCRIPTION
## The bug

`parseAcpUsageLog` hardcodes `cacheReadTokens: 0` and never reads `obj.cache_read_tokens`.

The parser was written for goose, which reports one number per turn and has no cache split, so the zero was accurate there. dsh writes the same `.acp-usage` file — and it *does* carry the split, because dsh reports **disjoint** buckets: `inputTokens` is the uncached half only (`prompt_tokens − cacheRead − cacheWrite`, normalized upstream), with the cached half alongside. The parser threw it away.

## What it cost us

Measured against four production dsh workspaces for a single day:

| layer | input | cache_read | output |
| --- | --- | --- | --- |
| agent's own `.acp-usage` logs | 52,298,638 | 36,646,272 | 625,425 |
| usage ledger | 52,298,638 | **0** | 625,425 |

The ledger prices hit and miss separately and a provider bills `prompt_tokens = input + cache_read`, so recorded input ran **41.2% short** of what was served, while output matched to the token — the signature that pointed here. Per-session spot checks match exactly: one session's runtime log summed to 4,092,247 input / 5,165,056 cache-read, and the ledger had the input right and the cache-read at zero.

It also made every dsh workspace read as a 0% cache hit rate, which looks like "this core cannot cache" in any cost analysis. The real rate is ~41%.

## The fix

Read the field, and stop flagging records that carry it as incomplete — absent (goose) and present-and-zero (dsh on a turn that missed) are different facts.

**Dedup keys are deliberately untouched.** They key the append-only ledger; re-shaping them would re-insert every line of every existing log as a new record on the next sweep and double-count the history. A test pins both key shapes.

Records already written keep their zero: `ON CONFLICT DO NOTHING` means a re-sweep cannot correct them. The on-disk logs still hold the numbers, so a backfill is possible as a separate one-off if the history matters.

## Note on cost

This corrects the *reported hit rate*, not much of the money: the missing tokens are cache hits, which price at a small fraction of misses. The recorded miss volume — what the bill is actually made of — was already right.