### PR TITLE
Switch an MCP server off without deleting its config

### DIFF
--- a/control-plane/src/routes/workspace/config.test.ts
+++ b/control-plane/src/routes/workspace/config.test.ts
@@ -69,6 +69,26 @@ describe('GET /workspace/v1/workspaces/:id/config', () => {
     expect(config).not.toHaveBeenCalled()
   })
 
+  // A switched-off server stays in the workspace config so it can be switched
+  // back on, but it must never be handed to the agent.
+  it('withholds disabled MCP servers from the agent', async () => {
+    verify.mockResolvedValue({ workspaceId: 'ws1', userId: 'alice' })
+    config.mockResolvedValue({
+      agent_type: 'claude-code',
+      mcp_config: JSON.stringify({
+        mcpServers: {
+          live: { type: 'http', url: 'https://example.com/mcp' },
+          paused: { type: 'http', url: 'https://paused.example.com/mcp', disabled: true },
+        },
+      }),
+    } as never)
+
+    const res = await get('/v1/workspaces/ws1/config', 'ws_good')
+
+    const served = JSON.parse((await res.json()).mcp_config)
+    expect(Object.keys(served.mcpServers)).toEqual(['live'])
+  })
+
   it('404s when the workspace has no config', async () => {
     verify.mockResolvedValue({ workspaceId: 'ws1', userId: 'alice' })
     config.mockResolvedValue(null as never)

--- a/control-plane/src/routes/workspace/config.ts
+++ b/control-plane/src/routes/workspace/config.ts
@@ -44,6 +44,12 @@ config.get('/v1/workspaces/:id/config', requireWorkspaceParam(), async (c) => {
     // teamwork task context. Keeping a static injection here would create
     // a duplicate definition that conflicts with the sidecar's dynamic one.
     if (parsed.mcpServers) {
+      // A server the user has switched off keeps its config in the workspace
+      // but never reaches the agent. This endpoint is the single place an
+      // agent obtains its MCP config, so filtering here covers every core.
+      for (const [name, server] of Object.entries(parsed.mcpServers) as [string, any][]) {
+        if (server?.disabled) delete parsed.mcpServers[name]
+      }
       for (const server of Object.values(parsed.mcpServers) as any[]) {
         // Inject workspace context for all MCP servers
         if (server.url) {

--- a/web/src/components/workspace/McpConfigEditor.test.ts
+++ b/web/src/components/workspace/McpConfigEditor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { buildMcpJson, parseStructuredState } from './McpConfigEditor'
+
+const knownServers = {
+  search: {
+    label: 'Search',
+    description: '',
+    url: 'https://search.example.com/mcp',
+    params: [{ header: 'X-Limit', label: 'Limit', type: 'number' as const, default: '10' }],
+    group: 'Tools',
+  },
+  notes: {
+    label: 'Notes',
+    description: '',
+    url: 'https://notes.example.com/mcp',
+    params: [],
+    group: 'Tools',
+  },
+}
+const knownKeys = Object.keys(knownServers)
+
+function build(
+  enabled: Record<string, boolean>,
+  present: Record<string, boolean>,
+  paramValues: Record<string, Record<string, string>> = {},
+  customs: Parameters<typeof buildMcpJson>[4] = [],
+) {
+  return JSON.parse(buildMcpJson(knownServers, enabled, present, paramValues, customs)).mcpServers
+}
+
+describe('catalog servers', () => {
+  // The point of the flag: switching a server off must not cost the user the
+  // params they typed in.
+  it('keeps a switched-off server, with its params, marked disabled', () => {
+    const servers = build({ search: false }, { search: true }, { search: { 'X-Limit': '50' } })
+
+    expect(servers.search).toEqual({
+      type: 'http',
+      url: 'https://search.example.com/mcp',
+      disabled: true,
+      headers: { 'X-Limit': '50' },
+    })
+  })
+
+  it('leaves a server that was never added out of the config', () => {
+    expect(build({ search: false }, { search: false })).toEqual({})
+  })
+
+  it('drops the flag when the server is switched back on', () => {
+    const servers = build({ search: true }, { search: true })
+
+    expect(servers.search.disabled).toBeUndefined()
+  })
+
+  it('reads a disabled entry back as present but off', () => {
+    const raw = JSON.stringify({
+      mcpServers: {
+        search: {
+          type: 'http',
+          url: 'https://search.example.com/mcp',
+          disabled: true,
+          headers: { 'X-Limit': '50' },
+        },
+      },
+    })
+
+    const state = parseStructuredState(raw, knownServers, knownKeys)
+
+    expect(state.enabled.search).toBe(false)
+    expect(state.present.search).toBe(true)
+    expect(state.paramValues.search['X-Limit']).toBe('50')
+    expect(state.enabled.notes).toBe(false)
+    expect(state.present.notes).toBe(false)
+  })
+})
+
+describe('custom servers', () => {
+  it('round-trips a disabled structured server', () => {
+    const raw = JSON.stringify({
+      mcpServers: {
+        internal: {
+          type: 'http',
+          url: 'https://internal.example.com/mcp',
+          headers: { Authorization: 'Bearer t' },
+          disabled: true,
+        },
+      },
+    })
+
+    const state = parseStructuredState(raw, knownServers, knownKeys)
+    expect(state.customs[0]).toMatchObject({ mode: 'struct', name: 'internal', disabled: true })
+
+    const servers = build({}, {}, {}, state.customs)
+    expect(servers.internal).toEqual({
+      type: 'http',
+      url: 'https://internal.example.com/mcp',
+      headers: { Authorization: 'Bearer t' },
+      disabled: true,
+    })
+  })
+
+  // The flag is editor state, so a hand-written config keeps reading as its
+  // own JSON rather than growing a field the user did not type.
+  it('keeps the flag out of the JSON a raw server shows', () => {
+    const raw = JSON.stringify({
+      mcpServers: {
+        odd: { type: 'sse', url: 'https://odd.example.com/mcp', disabled: true },
+      },
+    })
+
+    const state = parseStructuredState(raw, knownServers, knownKeys)
+    const draft = state.customs[0]
+
+    expect(draft).toMatchObject({ mode: 'raw', disabled: true })
+    expect(draft.mode === 'raw' && JSON.parse(draft.json).disabled).toBeUndefined()
+    expect(build({}, {}, {}, [draft]).odd.disabled).toBe(true)
+  })
+})

--- a/web/src/components/workspace/McpConfigEditor.tsx
+++ b/web/src/components/workspace/McpConfigEditor.tsx
@@ -66,6 +66,8 @@ function catalogToKnown(catalog: McpCatalogEntry[]): {
 type OAuthState = { connected: boolean; expires_at?: string } | null | 'loading' | 'error'
 
 interface McpServerConfig {
+  /** Switched off: the entry is kept here but cp withholds it from the agent. */
+  disabled?: boolean
   type?: string
   url?: string
   command?: string
@@ -82,6 +84,7 @@ interface McpConfig {
 interface StructuredDraft {
   mode: 'struct'
   name: string
+  disabled: boolean
   transport: 'http' | 'stdio'
   url: string
   command: string
@@ -93,6 +96,7 @@ interface StructuredDraft {
 interface RawDraft {
   mode: 'raw'
   name: string
+  disabled: boolean
   json: string
 }
 
@@ -102,7 +106,7 @@ type CustomDraft = StructuredDraft | RawDraft
 function canStructure(cfg: McpServerConfig): boolean {
   const isStdio = cfg.type === 'stdio' || cfg.type === 'command' || !!cfg.command
   const isHttp = !isStdio
-  const knownKeys = new Set(['type', 'url', 'headers', 'command', 'args', 'env'])
+  const knownKeys = new Set(['type', 'url', 'headers', 'command', 'args', 'env', 'disabled'])
   const hasUnknown = Object.keys(cfg).some((k) => !knownKeys.has(k))
   if (hasUnknown) return false
   if (isHttp && cfg.type && cfg.type !== 'http' && cfg.type !== 'streamable-http') return false
@@ -110,13 +114,18 @@ function canStructure(cfg: McpServerConfig): boolean {
 }
 
 function configToDraft(name: string, cfg: McpServerConfig): CustomDraft {
+  // The flag is draft state of its own, so it never shows up in the JSON the
+  // user edits by hand — it is re-applied on the way back out.
+  const disabled = !!cfg.disabled
   if (!canStructure(cfg)) {
-    return { mode: 'raw', name, json: JSON.stringify(cfg, null, 2) }
+    const { disabled: _, ...rest } = cfg
+    return { mode: 'raw', name, disabled, json: JSON.stringify(rest, null, 2) }
   }
   const isStdio = cfg.type === 'stdio' || cfg.type === 'command' || !!cfg.command
   return {
     mode: 'struct',
     name,
+    disabled,
     transport: isStdio ? 'stdio' : 'http',
     url: cfg.url || '',
     command: cfg.command || '',
@@ -127,11 +136,13 @@ function configToDraft(name: string, cfg: McpServerConfig): CustomDraft {
 }
 
 function draftToConfig(draft: CustomDraft): McpServerConfig {
+  const mark = (cfg: McpServerConfig): McpServerConfig =>
+    draft.disabled ? { ...cfg, disabled: true } : cfg
   if (draft.mode === 'raw') {
     try {
-      return JSON.parse(draft.json)
+      return mark(JSON.parse(draft.json))
     } catch {
-      return {}
+      return mark({})
     }
   }
   if (draft.transport === 'stdio') {
@@ -142,20 +153,21 @@ function draftToConfig(draft: CustomDraft): McpServerConfig {
       draft.env.filter((e) => e.key.trim()).map((e) => [e.key, e.value]),
     )
     if (Object.keys(env).length > 0) cfg.env = env
-    return cfg
+    return mark(cfg)
   }
   const cfg: McpServerConfig = { type: 'http', url: draft.url }
   const headers = Object.fromEntries(
     draft.headers.filter((h) => h.key.trim()).map((h) => [h.key, h.value]),
   )
   if (Object.keys(headers).length > 0) cfg.headers = headers
-  return cfg
+  return mark(cfg)
 }
 
 function emptyDraft(): StructuredDraft {
   return {
     mode: 'struct',
     name: '',
+    disabled: false,
     transport: 'http',
     url: '',
     command: '',
@@ -185,17 +197,21 @@ function prettyJson(raw: string): string {
 }
 
 /** Build the JSON string from structured state */
-function buildMcpJson(
+export function buildMcpJson(
   knownServers: Record<string, KnownServerDef>,
   enabled: Record<string, boolean>,
+  present: Record<string, boolean>,
   paramValues: Record<string, Record<string, string>>,
   customs: CustomDraft[],
 ): string {
   const mcpServers: Record<string, unknown> = {}
 
   for (const [key, def] of Object.entries(knownServers)) {
-    if (!enabled[key] && !def.required) continue
+    // Switching a server off keeps the entry — with its params — and marks it
+    // disabled. A server that was never added at all still stays out.
+    if (!enabled[key] && !def.required && !present[key]) continue
     const entry: McpServerConfig = { type: 'http', url: def.url }
+    if (!enabled[key] && !def.required) entry.disabled = true
     const headers: Record<string, string> = {}
     for (const p of def.params) {
       const val = paramValues[key]?.[p.header]
@@ -220,7 +236,7 @@ function buildMcpJson(
 }
 
 /** Parse current JSON into structured state */
-function parseStructuredState(
+export function parseStructuredState(
   raw: string,
   knownServers: Record<string, KnownServerDef>,
   knownKeys: string[],
@@ -229,10 +245,12 @@ function parseStructuredState(
   const servers = parsed.mcpServers ?? {}
 
   const enabled: Record<string, boolean> = {}
+  const present: Record<string, boolean> = {}
   const paramValues: Record<string, Record<string, string>> = {}
 
   for (const [key, def] of Object.entries(knownServers)) {
-    enabled[key] = def.required || key in servers
+    present[key] = key in servers
+    enabled[key] = def.required || (key in servers && !(servers[key] as McpServerConfig)?.disabled)
     paramValues[key] = {}
     const serverHeaders = (servers[key] as McpServerConfig)?.headers ?? {}
     for (const p of def.params) {
@@ -247,7 +265,7 @@ function parseStructuredState(
     .filter(([k]) => !knownKeys.includes(k))
     .map(([name, cfg]) => configToDraft(name, cfg as McpServerConfig))
 
-  return { enabled, paramValues, customs }
+  return { enabled, present, paramValues, customs }
 }
 
 // ─── Server fields form ───────────────────────────────────────────
@@ -417,6 +435,9 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
   const [rawDraft, setRawDraft] = useState('')
 
   const [enabled, setEnabled] = useState<Record<string, boolean>>({})
+  // Which catalog servers already have an entry in the config — switching one
+  // off keeps that entry, so presence and enablement are no longer the same.
+  const [present, setPresent] = useState<Record<string, boolean>>({})
   const [paramValues, setParamValues] = useState<Record<string, Record<string, string>>>({})
   const [customs, setCustoms] = useState<CustomDraft[]>([])
 
@@ -573,6 +594,7 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
   useEffect(() => {
     const state = parseStructuredState(value, catalog.servers, catalog.keys)
     setEnabled(state.enabled)
+    setPresent(state.present)
     setParamValues(state.paramValues)
     setCustoms(state.customs)
     // Auto-open groups that have enabled servers or required servers.
@@ -594,7 +616,7 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
     pv: Record<string, Record<string, string>>,
     cu: CustomDraft[],
   ) {
-    onChange(buildMcpJson(catalog.servers, en, pv, cu))
+    onChange(buildMcpJson(catalog.servers, en, present, pv, cu))
   }
 
   function toggleServer(key: string) {
@@ -618,6 +640,12 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
 
   function removeCustom(index: number) {
     const next = customs.filter((_, i) => i !== index)
+    setCustoms(next)
+    emitChange(enabled, paramValues, next)
+  }
+
+  function toggleCustom(index: number) {
+    const next = customs.map((c, i) => (i === index ? { ...c, disabled: !c.disabled } : c))
     setCustoms(next)
     emitChange(enabled, paramValues, next)
   }
@@ -801,14 +829,38 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
             return (
               <div
                 key={draft.name}
-                className="rounded border border-border bg-background/60 p-3 space-y-2"
+                className={cn(
+                  'rounded border p-3 space-y-2 transition-colors',
+                  draft.disabled
+                    ? 'border-border/50 bg-muted/30'
+                    : 'border-border bg-background/60',
+                )}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium text-foreground">{draft.name}</span>
+                    <input
+                      type="checkbox"
+                      className="h-3.5 w-3.5 rounded"
+                      checked={!draft.disabled}
+                      onChange={() => toggleCustom(i)}
+                      title={t('components.mcpConfigEditor.actions.toggleServer')}
+                    />
+                    <span
+                      className={cn(
+                        'font-medium',
+                        draft.disabled ? 'text-muted-foreground' : 'text-foreground',
+                      )}
+                    >
+                      {draft.name}
+                    </span>
                     <span className="rounded bg-muted px-1.5 py-0.5 text-mini text-muted-foreground">
                       {typeLabel}
                     </span>
+                    {draft.disabled && (
+                      <span className="rounded bg-muted-foreground/10 px-1.5 py-0.5 text-mini text-muted-foreground">
+                        {t('components.mcpConfigEditor.labels.disabled')}
+                      </span>
+                    )}
                     {renderOAuthBadge(serverOrigin, oauth)}
                   </div>
                   <Button

--- a/web/src/hooks/useWsApps.ts
+++ b/web/src/hooks/useWsApps.ts
@@ -218,10 +218,14 @@ export function useWsApps(workspaceId: string | undefined): AppDefinition[] {
     // Extensions — user-installed plugin apps (MCP-driven)
     if (config?.mcp_config && catalog) {
       try {
-        const parsed = JSON.parse(config.mcp_config) as { mcpServers?: Record<string, unknown> }
+        const parsed = JSON.parse(config.mcp_config) as {
+          mcpServers?: Record<string, { disabled?: boolean }>
+        }
         const servers = parsed.mcpServers ?? {}
         for (const entry of catalog) {
-          if (!entry.ui_panel || !(entry.id in servers)) continue
+          // A disabled server keeps its entry but is withheld from the agent,
+          // so its panel goes away with it.
+          if (!entry.ui_panel || !(entry.id in servers) || servers[entry.id]?.disabled) continue
           // Three states for the panel:
           //  - registered (bundle loaded): use its label() — supports i18n
           //  - lazy descriptor only: use the static manifest label so the

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2740,7 +2740,8 @@
         "environment": "Environment"
       },
       "labels": {
-        "json": "json"
+        "json": "json",
+        "disabled": "Disabled"
       },
       "placeholders": {
         "serverName": "Server name",
@@ -2764,7 +2765,8 @@
       "actions": {
         "addField": "+ {{label}}",
         "add": "Add",
-        "addServer": "Add MCP Server"
+        "addServer": "Add MCP Server",
+        "toggleServer": "Enable or disable this server"
       },
       "builder": {
         "title": "Builder Mode",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2764,7 +2764,8 @@
         "environment": "环境变量"
       },
       "labels": {
-        "json": "json"
+        "json": "json",
+        "disabled": "已禁用"
       },
       "placeholders": {
         "serverName": "服务名",
@@ -2788,7 +2789,8 @@
       "actions": {
         "addField": "+ {{label}}",
         "add": "添加",
-        "addServer": "添加 MCP 服务"
+        "addServer": "添加 MCP 服务",
+        "toggleServer": "启用 / 禁用该服务"
       },
       "builder": {
         "title": "Builder 模式",

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
       // the UI SDK, so tests need its source alias (type-only @neutree-ai/*
       // imports are erased and don't).
       '@neutree-ai/ui-sdk': resolve(__dirname, '../internal/ui-sdk/src/index.ts'),
+      // Same reason: the MCP editor pulls the Builder cap catalog — a runtime
+      // value — out of @neutree-ai/types.
+      '@neutree-ai/types': resolve(__dirname, '../internal/types/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
Closes #246.

An MCP server could only be added or removed, so taking one out of the loop for a while meant deleting the entry and typing the whole thing back in afterwards. Each server now carries a `disabled` marker instead.

## Control plane

`GET /v1/workspaces/:id/config` drops disabled servers before it injects headers and rewrites URLs. That endpoint is the only place an agent obtains its MCP config, so all four cores are covered and no sidecar changes are needed. The agent never sees the field.

## Web

- Catalog servers: unchecking one now keeps its entry and the params typed into it, marked disabled, rather than dropping it. A server that was never added at all still stays out of the config, so existing workspaces don't grow entries they never had.
- Custom servers: same toggle on the card, which dims and shows a `Disabled` badge while the URL, headers, env, or raw JSON stay untouched. The marker is editor state, so it never appears in the JSON block a hand-written server shows.
- Plugin panels follow the server they belong to and disappear while it is off.

Config is fetched per turn/session, so toggling takes effect on save — no container rebuild.

## Tests

- control-plane: a disabled server is withheld from the served config.
- web: params survive a switch-off, a never-added server stays out, re-enabling clears the marker, and both structured and raw custom servers round-trip.

`vitest.config.ts` needed a `@neutree-ai/types` alias — the editor pulls a runtime value from it, so the component could not be imported from a test before.