### PR TITLE
control-plane: retry a skills-content call the connection dropped

### DIFF
--- a/control-plane/src/services/skills-content.test.ts
+++ b/control-plane/src/services/skills-content.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { scsDeleteSource, scsListDraftTree, scsSyncSource } from './skills-content'
+
+/** Shape Node produces: the errno sits on `cause`, under `TypeError: fetch failed`. */
+const transportError = (code: string) =>
+  Object.assign(new TypeError('fetch failed'), {
+    cause: Object.assign(new Error(code.toLowerCase()), { code }),
+  })
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+/** Drains the retry backoff so a call under fake timers can settle. */
+async function settle<T>(promise: Promise<T>): Promise<T> {
+  await vi.runAllTimersAsync()
+  return promise
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('scs transport retry', () => {
+  it('retries an idempotent GET past a dropped connection', async () => {
+    fetchMock
+      .mockRejectedValueOnce(transportError('ECONNRESET'))
+      .mockResolvedValueOnce(jsonResponse({ entries: [] }))
+
+    const result = await settle(scsListDraftTree('src-1'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({ ok: true, value: { entries: [] } })
+  })
+
+  it('retries a DELETE, which is idempotent', async () => {
+    fetchMock
+      .mockRejectedValueOnce(transportError('ECONNRESET'))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+
+    const result = await settle(scsDeleteSource('src-1'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.ok).toBe(true)
+  })
+
+  it('retries a POST when the connection never opened', async () => {
+    fetchMock
+      .mockRejectedValueOnce(transportError('ECONNREFUSED'))
+      .mockResolvedValueOnce(jsonResponse({ source: {}, results: [], skipped: [] }))
+
+    const result = await settle(scsSyncSource('src-1', { published_by: 'u1' }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.ok).toBe(true)
+  })
+
+  it('leaves a POST that died in flight failed, so no version is created twice', async () => {
+    fetchMock.mockRejectedValue(transportError('ECONNRESET'))
+
+    const result = await settle(scsSyncSource('src-1', { published_by: 'u1' }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      ok: false,
+      status: 502,
+      error: 'skills-content-service unavailable (ECONNRESET)',
+    })
+  })
+
+  it('gives up after three attempts and names the errno', async () => {
+    fetchMock.mockRejectedValue(transportError('EAI_AGAIN'))
+
+    const result = await settle(scsListDraftTree('src-1'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result).toEqual({
+      ok: false,
+      status: 502,
+      error: 'skills-content-service unavailable (EAI_AGAIN)',
+    })
+  })
+
+  it('does not retry once the caller has aborted', async () => {
+    const controller = new AbortController()
+    fetchMock.mockImplementation(() => {
+      controller.abort()
+      return Promise.reject(transportError('ECONNRESET'))
+    })
+
+    const result = await settle(scsListDraftTree('src-1', controller.signal))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ ok: false, status: 499, error: 'Client disconnected' })
+  })
+
+  it('passes an upstream error status through untouched', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'source not found' }, 404))
+
+    const result = await settle(scsSyncSource('src-1', { published_by: 'u1' }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ ok: false, status: 404, error: 'source not found' })
+  })
+})

--- a/control-plane/src/services/skills-content.ts
+++ b/control-plane/src/services/skills-content.ts
@@ -49,19 +49,15 @@ export async function skillsContentFetch(
   signal?: AbortSignal,
   extraHeaders?: Record<string, string>,
 ): Promise<{ ok: true; response: Response } | { ok: false; error: string }> {
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: { 'Accept-Encoding': 'identity', ...(extraHeaders ?? {}) },
-      signal,
-    })
-    return { ok: true, response }
-  } catch (e: unknown) {
-    if (signal?.aborted) return { ok: false, error: 'Client disconnected' }
-    const msg = e instanceof Error ? e.message : String(e)
-    console.error(`[skills-content] fetch failed ${url}:`, msg)
-    return { ok: false, error: 'skills-content-service unavailable' }
-  }
+  const attempt = await fetchWithRetry(
+    'GET',
+    url,
+    { headers: { 'Accept-Encoding': 'identity', ...(extraHeaders ?? {}) } },
+    signal,
+  )
+  if (attempt.ok) return { ok: true, response: attempt.response }
+  if (attempt.aborted) return { ok: false, error: 'Client disconnected' }
+  return { ok: false, error: unavailable(attempt.code) }
 }
 
 // ── scan (pure parse, no side effects) ─────────────────────────────────────
@@ -421,18 +417,108 @@ export async function scsDeleteSkill(
 }
 
 // ── transport helpers ──────────────────────────────────────────────────────
+//
+// Retry policy. A throw from `fetch` means no response arrived: the request
+// either never left cp (DNS, connect refused) or the connection died in
+// flight — typically a pooled keep-alive socket scs had already closed. scs
+// runs as a single in-cluster replica, so these are transient and an attempt
+// a moment later succeeds; without a retry the user sees a bare 502 on an
+// otherwise healthy system.
+//
+// What is retried is bounded by what a duplicate request would cost:
+//   - idempotent methods (GET/PUT/DELETE): any transport error
+//   - POST/PATCH: only errors raised before a byte could be written, where
+//     the request provably never reached scs. One that died in flight may
+//     already have created a version, so it stays failed.
+// Streamed bodies are excluded — see `doStreamPost`.
+
+const MAX_ATTEMPTS = 3
+const RETRY_DELAYS_MS = [100, 300]
+
+/** Raised while resolving or opening the connection: nothing was sent. */
+const CONNECT_PHASE_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+])
+
+const IDEMPOTENT_METHODS = new Set(['GET', 'PUT', 'DELETE'])
+
+/** Node buries the real cause under `TypeError: fetch failed`, sometimes twice. */
+function errorCode(e: unknown): string | undefined {
+  let cur: unknown = e
+  for (let depth = 0; cur instanceof Error && depth < 4; depth++) {
+    const code = (cur as { code?: unknown }).code
+    if (typeof code === 'string') return code
+    cur = cur.cause
+  }
+  return undefined
+}
+
+function isRetryable(method: string, e: unknown): boolean {
+  if (IDEMPOTENT_METHODS.has(method)) return true
+  const code = errorCode(e)
+  return code !== undefined && CONNECT_PHASE_CODES.has(code)
+}
+
+/** Carries the errno so a user-reported 502 names its own cause. */
+function unavailable(code: string | undefined): string {
+  const base = 'skills-content-service unavailable'
+  return code ? `${base} (${code})` : base
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+type FetchAttempt =
+  | { ok: true; response: Response }
+  | { ok: false; aborted: true }
+  | { ok: false; aborted: false; code: string | undefined }
+
+/**
+ * `fetch` under the retry policy above. Resolves to the transport failure
+ * rather than throwing, so callers keep their `{ok:false}` shape. Caller
+ * aborts are surfaced as-is and never retried.
+ */
+async function fetchWithRetry(
+  method: string,
+  url: string,
+  init: RequestInit,
+  signal: AbortSignal | undefined,
+): Promise<FetchAttempt> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return { ok: true, response: await fetch(url, { ...init, method, signal }) }
+    } catch (e: unknown) {
+      if (signal?.aborted) return { ok: false, aborted: true }
+      const code = errorCode(e)
+      const detail = code ?? (e instanceof Error ? e.message : String(e))
+      if (attempt >= MAX_ATTEMPTS || !isRetryable(method, e)) {
+        console.error(`[skills-content] ${method} ${url} failed (${detail})`)
+        return { ok: false, aborted: false, code }
+      }
+      console.warn(
+        `[skills-content] ${method} ${url} failed (${detail}), retrying ${attempt}/${MAX_ATTEMPTS - 1}`,
+      )
+      await sleep(RETRY_DELAYS_MS[attempt - 1])
+    }
+  }
+}
+
+/** Map a transport failure onto the `ScsResult` shape shared by all callers. */
+function transportError<T>(attempt: { aborted: boolean; code?: string }): ScsResult<T> {
+  if (attempt.aborted) return { ok: false, status: 499, error: 'Client disconnected' }
+  return { ok: false, status: 502, error: unavailable(attempt.code) }
+}
 
 async function doJsonGet<T>(url: string, signal: AbortSignal | undefined): Promise<ScsResult<T>> {
-  let response: Response
-  try {
-    response = await fetch(url, { method: 'GET', signal })
-  } catch (e: unknown) {
-    if (signal?.aborted) return { ok: false, status: 499, error: 'Client disconnected' }
-    const msg = e instanceof Error ? e.message : String(e)
-    console.error(`[skills-content] GET ${url} failed:`, msg)
-    return { ok: false, status: 502, error: 'skills-content-service unavailable' }
-  }
-  return decodeResponse<T>(response)
+  const attempt = await fetchWithRetry('GET', url, {}, signal)
+  if (!attempt.ok) return transportError<T>(attempt)
+  return decodeResponse<T>(attempt.response)
 }
 
 async function doJsonPost<T>(
@@ -465,21 +551,14 @@ async function doJson<T>(
   body: unknown,
   signal: AbortSignal | undefined,
 ): Promise<ScsResult<T>> {
-  let response: Response
-  try {
-    response = await fetch(url, {
-      method,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      signal,
-    })
-  } catch (e: unknown) {
-    if (signal?.aborted) return { ok: false, status: 499, error: 'Client disconnected' }
-    const msg = e instanceof Error ? e.message : String(e)
-    console.error(`[skills-content] ${method} ${url} failed:`, msg)
-    return { ok: false, status: 502, error: 'skills-content-service unavailable' }
-  }
-  return decodeResponse<T>(response)
+  const attempt = await fetchWithRetry(
+    method,
+    url,
+    { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+    signal,
+  )
+  if (!attempt.ok) return transportError<T>(attempt)
+  return decodeResponse<T>(attempt.response)
 }
 
 async function doMethodNoBody<T>(
@@ -487,18 +566,16 @@ async function doMethodNoBody<T>(
   url: string,
   signal: AbortSignal | undefined,
 ): Promise<ScsResult<T>> {
-  let response: Response
-  try {
-    response = await fetch(url, { method, signal })
-  } catch (e: unknown) {
-    if (signal?.aborted) return { ok: false, status: 499, error: 'Client disconnected' }
-    const msg = e instanceof Error ? e.message : String(e)
-    console.error(`[skills-content] ${method} ${url} failed:`, msg)
-    return { ok: false, status: 502, error: 'skills-content-service unavailable' }
-  }
-  return decodeResponse<T>(response)
+  const attempt = await fetchWithRetry(method, url, {}, signal)
+  if (!attempt.ok) return transportError<T>(attempt)
+  return decodeResponse<T>(attempt.response)
 }
 
+/**
+ * Streamed upload. Deliberately outside the retry policy: the body is a
+ * one-shot `ReadableStream`, already partly consumed by the time the socket
+ * fails, so a second attempt would send a truncated payload.
+ */
 async function doStreamPost<T>(
   method: 'POST' | 'PUT',
   url: string,
@@ -522,9 +599,10 @@ async function doStreamPost<T>(
     })
   } catch (e: unknown) {
     if (signal?.aborted) return { ok: false, status: 499, error: 'Client disconnected' }
-    const msg = e instanceof Error ? e.message : String(e)
-    console.error(`[skills-content] ${method} ${url} failed:`, msg)
-    return { ok: false, status: 502, error: 'skills-content-service unavailable' }
+    const code = errorCode(e)
+    const detail = code ?? (e instanceof Error ? e.message : String(e))
+    console.error(`[skills-content] ${method} ${url} failed (${detail})`)
+    return { ok: false, status: 502, error: unavailable(code) }
   }
   return decodeResponse<T>(response)
 }


### PR DESCRIPTION
A user hit `scs 502: skills-content-service unavailable` while syncing a git-backed skill source. The service was healthy throughout — single replica, no restart, endpoint never left the EndpointSlice — and it logged nothing for that request, so it never arrived. The retry a few seconds later synced all 7 skills fine.

That error string has one origin: the catch around `fetch` in `skills-content.ts`. A throw there means no response arrived — the request either never left the control plane (DNS, refused connect) or the connection died in flight, typically a pooled keep-alive socket the service had already closed. Neither is worth showing a user on an otherwise healthy system.

## Retry

The four transport helpers each carried their own copy of the same try-catch, so they now share one `fetchWithRetry`: three attempts, 100ms then 300ms apart.

What gets retried is bounded by what a duplicate request would cost:

- **Idempotent methods** (GET/PUT/DELETE) — any transport error.
- **POST/PATCH** — only errnos raised before a byte could be written (`EAI_AGAIN`, `ECONNREFUSED`, `ENOTFOUND`, `EHOSTUNREACH`, `ENETUNREACH`, `ETIMEDOUT`), where the request provably never arrived. One that died in flight may already have created a version, so it stays failed.
- **Streamed uploads** (`doStreamPost`) — excluded entirely. The body is a one-shot `ReadableStream`, already partly consumed when the socket fails, so a second attempt would send a truncated payload.

A caller abort still returns 499 immediately and is never retried.

## Errno in the message

The 502 now reads `skills-content-service unavailable (ECONNRESET)`. Node buries the errno under `TypeError: fetch failed`, sometimes two levels deep, so `errorCode` walks the cause chain. A screenshot of the toast is then enough to tell a DNS failure from a refused connection — which is what this investigation lacked, since the control plane's own log line had already rotated away by the time anyone looked.

Retries log at `warn`, final give-up at `error`.

## Tests

New `skills-content.test.ts`, 7 cases: GET and DELETE recover from a dropped connection; POST recovers from a refused connect; POST that died in flight is *not* retried (guards against a double version); three attempts then a 502 naming the errno; abort is not retried; an upstream 404 passes through untouched.

`vitest run` 44 files / 555 tests green, `tsc --noEmit` and `biome check` clean.

## Not covered

If the original failure was `ECONNRESET` on the sync POST, this change would not have hidden it — that is the deliberate trade above. Closing that case properly means a dedicated undici Agent for this origin with a tighter keep-alive, which would have to work around the global `EnvHttpProxyAgent` dispatcher; out of scope here.
