### PR TITLE
fix(self-host): give the control plane room to migrate before liveness fires

### DIFF
--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -215,6 +215,20 @@ spec:
             limits:
               memory: "4Gi"
               cpu: "1000m"
+          # cp runs every pending schema migration in initDb() before it opens
+          # the port, so an upgrade that lands a long migration (129 REINDEXes
+          # the whole sessions table) has no listener for the duration. Without
+          # a startupProbe, liveness kills the pod ~100s in and the restart
+          # re-runs the same migration — a crash loop that never converges. A
+          # self-host site upgrading across several releases at once takes the
+          # whole backlog in one boot, so the grace has to cover the sum.
+          # 120 x 5s = 10 minutes; liveness takes over after.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            periodSeconds: 5
+            failureThreshold: 120
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Problem

`initDb()` runs every pending schema migration before `serve()` opens the port. For the length of that run there is no listener, so both the liveness and readiness probes fail. With only a liveness probe configured, the pod is killed roughly 100s in (`initialDelaySeconds: 10` + 3 × `periodSeconds: 30`), and the restart re-runs the same migration from the top — a crash loop that never converges, and the longer the migration the more certain it is.

The exposure is worst where recovery is hardest: a self-hosted site upgrading across several releases at once takes the entire migration backlog in a single boot. That backlog currently includes `129_reindex_sessions`, a full `REINDEX TABLE public.sessions`, whose cost scales with how long the site has been running.

## Change

Add a `startupProbe` to the control-plane Deployment: `periodSeconds: 5`, `failureThreshold: 120` — 10 minutes of boot grace. Kubernetes holds liveness and readiness off until it succeeds, after which both behave exactly as before. No other field changes.