### PR TITLE
test(e2e): read the field the sandbox list route actually returns

### DIFF
--- a/control-plane/e2e/sandbox-client.ts
+++ b/control-plane/e2e/sandbox-client.ts
@@ -93,7 +93,7 @@ export function workspaceSandboxes(token: string, workspaceId: string) {
       resource?: Record<string, string>
       timeout_seconds?: number
     }) => cp<{ id: string }>('POST', `/api/workspaces/${workspaceId}/sandboxes`, body),
-    list: () => cp<{ sandboxes?: unknown[] }>('GET', `/api/workspaces/${workspaceId}/sandboxes`),
+    list: () => cp<{ items?: unknown[] }>('GET', `/api/workspaces/${workspaceId}/sandboxes`),
     endpoint: (sandboxId: string, port: number) =>
       cp<{ url: string }>(
         'GET',

--- a/control-plane/e2e/sandbox.test.ts
+++ b/control-plane/e2e/sandbox.test.ts
@@ -75,7 +75,7 @@ describeIfSandbox('sandboxes through the workspace API', () => {
 
   test('list is scoped to the workspace', async () => {
     const result = await workspaceSandboxes(runToken, wsId).list()
-    const ids = (result.sandboxes ?? []).map((s) => (s as { id: string }).id)
+    const ids = (result.items ?? []).map((s) => (s as { id: string }).id)
     expect(ids).toContain(sandboxId)
   })
 
@@ -88,7 +88,7 @@ describeIfSandbox('sandboxes through the workspace API', () => {
     await workspaceSandboxes(runToken, wsId).delete(sandboxId as string)
     const gone = await until('the sandbox to leave the workspace listing', async () => {
       const result = await workspaceSandboxes(runToken, wsId).list()
-      const ids = (result.sandboxes ?? []).map((s) => (s as { id: string }).id)
+      const ids = (result.items ?? []).map((s) => (s as { id: string }).id)
       return !ids.includes(sandboxId as string)
     })
     expect(gone).toBe(true)


### PR DESCRIPTION
## Problem

`GET /api/workspaces/:id/sandboxes` returns `{ items, pagination }` — verified against a live install:

```json
{"items":[],"pagination":{"page":1,"pageSize":20,"totalItems":0,...}}
```

The e2e client typed that response as `{ sandboxes?: unknown[] }`. A TypeScript type argument is an assertion, not a runtime conversion, so `result.sandboxes` was `undefined` and both readers fell through to `?? []`.

The two tests fail in opposite directions:

- **`list is scoped to the workspace`** asserts the freshly created sandbox appears in an array that is always empty → could never pass. This is the failure seen in release verification.
- **`delete releases the sandbox`** polls until the sandbox is *absent* from that same always-empty array → satisfied on the first poll, so it reported success without ever observing the deletion it exists to verify.

## Change

Read `items` in the client type and both call sites. No production code touched.

## Verification

Ran the suite against a live self-host install, before and after:

```
before:  1 failed | 3 passed | 9 skipped   ← list fails, delete passes vacuously
after:   4 passed | 9 skipped
```