### PR TITLE
control-plane: serve stored transcript images by URL

### DIFF
--- a/control-plane/src/routes/__tests__/workspace-image-blocks.test.ts
+++ b/control-plane/src/routes/__tests__/workspace-image-blocks.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `withImageUrls` is what keeps a long session's message payload small: image
+ * blocks are the bulk of stored transcript bytes, so history serves them by URL
+ * instead of inlining base64. The ordinal in that URL must match the block's
+ * position, because the serving route resolves it straight to the event id.
+ */
+import { describe, expect, it } from 'vitest'
+import { withImageUrls } from '../workspaces/_image-blocks'
+
+const IMAGE = { type: 'image', media_type: 'image/png', data: 'aGVsbG8=' }
+
+describe('withImageUrls', () => {
+  it('replaces inline base64 with a URL addressing the block position', () => {
+    const blocks = withImageUrls('ws-1', 'msg-1', [{ type: 'text', text: 'hi' }, IMAGE]) as any[]
+
+    expect(blocks[0]).toEqual({ type: 'text', text: 'hi' })
+    expect(blocks[1]).toEqual({
+      type: 'image',
+      media_type: 'image/png',
+      url: '/api/workspaces/ws-1/messages/msg-1/blocks/1/image',
+    })
+    expect(blocks[1]).not.toHaveProperty('data')
+  })
+
+  it('numbers each image by its own position, not by image count', () => {
+    const blocks = withImageUrls('ws-1', 'msg-1', [
+      IMAGE,
+      { type: 'text', text: 'between' },
+      IMAGE,
+    ]) as any[]
+
+    expect(blocks[0].url).toBe('/api/workspaces/ws-1/messages/msg-1/blocks/0/image')
+    expect(blocks[2].url).toBe('/api/workspaces/ws-1/messages/msg-1/blocks/2/image')
+  })
+
+  it('escapes ids so they cannot break out of the path', () => {
+    const blocks = withImageUrls('ws/../other', 'msg 1', [IMAGE]) as any[]
+
+    expect(blocks[0].url).toBe('/api/workspaces/ws%2F..%2Fother/messages/msg%201/blocks/0/image')
+  })
+
+  it('leaves image blocks that carry no inline data untouched', () => {
+    const alreadyByUrl = { type: 'image', media_type: 'image/png', url: '/elsewhere' }
+
+    expect(withImageUrls('ws-1', 'msg-1', [alreadyByUrl])).toEqual([alreadyByUrl])
+  })
+
+  it('passes through a non-array blocks value', () => {
+    expect(withImageUrls('ws-1', 'msg-1', null)).toBeNull()
+  })
+})

--- a/control-plane/src/routes/workspaces/_image-blocks.ts
+++ b/control-plane/src/routes/workspaces/_image-blocks.ts
@@ -1,0 +1,20 @@
+/**
+ * Swap the inline base64 out of image blocks for a URL serving the same bytes.
+ * Images dominate a long session's stored payload — tens of MB is routine — and
+ * inlining them makes the first paint wait on every image in the transcript.
+ * Behind a URL the browser fetches them lazily, in parallel, and caches them
+ * across reloads. The live stream still sends `data` inline; either field alone
+ * is enough to render.
+ */
+export function withImageUrls(workspaceId: string, messageId: string, blocks: unknown): unknown {
+  if (!Array.isArray(blocks)) return blocks
+  return blocks.map((block, ordinal) => {
+    const b = block as { type?: unknown; data?: unknown }
+    if (b?.type !== 'image' || typeof b.data !== 'string') return block
+    const { data: _inline, ...rest } = b
+    return {
+      ...rest,
+      url: `/api/workspaces/${encodeURIComponent(workspaceId)}/messages/${encodeURIComponent(messageId)}/blocks/${ordinal}/image`,
+    }
+  })
+}

--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -10,12 +10,13 @@ import {
 import type { AppEnv } from '../../lib/types'
 import { getWorkspaceReplicaStatus } from '../../services/db/env-placements'
 import { listAttachmentsForWorkspace } from '../../services/db/memory'
-import { getMessagesWithBlocks } from '../../services/db/messages'
+import { getMessageBlock, getMessagesWithBlocks } from '../../services/db/messages'
 import { getSessionFacets, listSessions } from '../../services/db/sessions'
 import { getTagAssignmentsForUser } from '../../services/db/tags'
 import type { SessionWithPreview } from '../../services/db/types'
 import { getWorkspace, getWorkspaceConfig, listWorkspaces } from '../../services/db/workspaces'
 import * as k8s from '../../services/k8s'
+import { withImageUrls } from './_image-blocks'
 import { canManage, toApiWorkspace } from './_shared'
 
 function toApiSession(s: SessionWithPreview) {
@@ -157,6 +158,31 @@ const listSessionsRoute = createRoute({
   },
 })
 
+const messageBlockImageRoute = createRoute({
+  method: 'get',
+  path: '/{id}/messages/{messageId}/blocks/{ordinal}/image',
+  tags: ['workspaces'],
+  summary: 'Fetch the image bytes of one stored message block',
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: WorkspaceIdParam.extend({
+      messageId: z.string().openapi({ param: { name: 'messageId', in: 'path' } }),
+      ordinal: z.coerce
+        .number()
+        .int()
+        .min(0)
+        .openapi({ param: { name: 'ordinal', in: 'path' } }),
+    }),
+  },
+  responses: {
+    200: { description: 'Image bytes', content: { 'image/*': { schema: z.any() } } },
+    404: {
+      description: 'Workspace, message block, or image not found',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
+})
+
 const listMessagesRoute = createRoute({
   method: 'get',
   path: '/{id}/messages',
@@ -193,7 +219,7 @@ read.openapi(listMessagesRoute, async (c) => {
       id: String(m.id),
       role: m.role as 'user' | 'assistant',
       content: m.content,
-      blocks: m.blocks as any,
+      blocks: withImageUrls(id, String(m.id), m.blocks) as any,
       created_at: m.created_at,
       started_at: m.started_at,
       ended_at: m.ended_at,
@@ -355,6 +381,26 @@ read.openapi(getStatusRoute, async (c) => {
     console.error('Failed to get K8s status:', e)
     return c.json({ error: 'Failed to get status' }, 500)
   }
+})
+
+read.openapi(messageBlockImageRoute, async (c) => {
+  const currentUser = c.get('user')
+  const { id, messageId, ordinal } = c.req.valid('param')
+  const workspace = await getWorkspace(id)
+  if (!workspace || !canManage(workspace, currentUser)) {
+    return c.json({ error: 'Workspace not found' }, 404)
+  }
+  const block = await getMessageBlock(id, messageId, ordinal)
+  if (block?.type !== 'image' || typeof block.data !== 'string') {
+    return c.json({ error: 'Image not found' }, 404)
+  }
+  const mediaType =
+    typeof block.media_type === 'string' ? block.media_type : 'application/octet-stream'
+  // A stored block never changes, so the bytes are safe to cache indefinitely.
+  return c.body(Buffer.from(block.data, 'base64'), 200, {
+    'Content-Type': mediaType,
+    'Cache-Control': 'private, max-age=31536000, immutable',
+  })
 })
 
 export default read

--- a/control-plane/src/services/db/messages.ts
+++ b/control-plane/src/services/db/messages.ts
@@ -240,6 +240,26 @@ function withTiming(m: Message, ev: MessageEvents | undefined): MessageWithBlock
 }
 
 /** Convenience: fetch messages + attach their blocks in one batched query. */
+/**
+ * One stored block, addressed by its position within the message. Event ids are
+ * `<message_id>-<ordinal>` (see `eventId`), so the position maps straight onto
+ * the primary key. Scoped by workspace, so a workspace check is all the caller
+ * needs to authorize the read.
+ */
+export async function getMessageBlock(
+  workspaceId: string,
+  messageId: string,
+  ordinal: number,
+): Promise<Record<string, unknown> | null> {
+  const { rows } = await pool.query<{ payload: Record<string, unknown> }>(
+    `SELECT e.payload FROM session_events e
+     JOIN messages m ON m.id = e.message_id
+     WHERE e.id = $1 AND m.workspace_id = $2`,
+    [eventId(messageId, ordinal), workspaceId],
+  )
+  return rows[0]?.payload ?? null
+}
+
 export async function getMessagesWithBlocks(
   workspaceId: string,
   sessionId: string,

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -160,7 +160,15 @@ export const ApiContentPartSchema = z.discriminatedUnion('type', [
     is_error: z.boolean().optional(),
     parent_tool_use_id: z.string().nullable().optional(),
   }),
-  z.object({ type: z.literal('image'), data: z.string(), media_type: z.string() }),
+  // `data` (inline base64) is what the live stream sends; stored history
+  // instead carries `url`, a fetchable endpoint for the same bytes, so a long
+  // session's message payload stays small. Exactly one of the two is set.
+  z.object({
+    type: z.literal('image'),
+    media_type: z.string(),
+    data: z.string().optional(),
+    url: z.string().optional(),
+  }),
 ])
 
 export type ApiContentPart = z.infer<typeof ApiContentPartSchema>

--- a/internal/ui-sdk/src/components/MessageBubble.tsx
+++ b/internal/ui-sdk/src/components/MessageBubble.tsx
@@ -7,6 +7,15 @@ import { memo, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ToolCallBlock } from './ToolCallBlock'
 
+/**
+ * An image block carries either inline base64 (`data`, live stream) or a
+ * fetchable endpoint (`url`, stored history — keeps long sessions' payloads
+ * small). Resolve whichever is present.
+ */
+function imageSrc(block: { media_type: string; data?: string; url?: string }): string {
+  return block.url ?? `data:${block.media_type};base64,${block.data}`
+}
+
 function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
   return (
     <div
@@ -102,10 +111,11 @@ function MessageBubbleImpl({ message }: { message: ChatMessage }) {
               block.type === 'image' ? (
                 <img
                   key={idx}
-                  src={`data:${block.media_type};base64,${block.data}`}
+                  src={imageSrc(block)}
+                  loading="lazy"
                   alt={t('components.chat.messageBubble.alts.attachment')}
                   className="mt-2 max-w-full max-h-48 cursor-zoom-in rounded-md border border-primary-foreground/20"
-                  onClick={() => setZoomedSrc(`data:${block.media_type};base64,${block.data}`)}
+                  onClick={() => setZoomedSrc(imageSrc(block))}
                 />
               ) : null,
             )}
@@ -154,10 +164,11 @@ function MessageBubbleImpl({ message }: { message: ChatMessage }) {
             ) : block.type === 'image' ? (
               <img
                 key={idx}
-                src={`data:${block.media_type};base64,${block.data}`}
+                src={imageSrc(block)}
+                loading="lazy"
                 alt={t('components.chat.messageBubble.alts.content')}
                 className="my-2 max-w-full max-h-96 cursor-zoom-in rounded-md border border-foreground/[0.08]"
-                onClick={() => setZoomedSrc(`data:${block.media_type};base64,${block.data}`)}
+                onClick={() => setZoomedSrc(imageSrc(block))}
               />
             ) : null,
           )}

--- a/internal/ui-sdk/src/to-chat-message.ts
+++ b/internal/ui-sdk/src/to-chat-message.ts
@@ -22,7 +22,12 @@ export function toChatMessage(message: ApiMessage): ChatMessage {
     if (part.type === 'text') {
       blocks.push({ type: 'text', text: part.text })
     } else if (part.type === 'image') {
-      blocks.push({ type: 'image', data: (part as any).data, media_type: (part as any).media_type })
+      blocks.push({
+        type: 'image',
+        media_type: (part as any).media_type,
+        data: (part as any).data,
+        url: (part as any).url,
+      })
     } else if (part.type === 'tool_call') {
       const result = resultMap.get(part.call_id)
       let input: Record<string, unknown> = {}

--- a/internal/ui-sdk/src/types.ts
+++ b/internal/ui-sdk/src/types.ts
@@ -23,7 +23,9 @@ export type ApiContentPart =
       is_error?: boolean
       parent_tool_use_id?: string | null
     }
-  | { type: 'image'; data: string; media_type: string }
+  // Either `data` (inline base64, live stream) or `url` (fetchable endpoint,
+  // stored history) — never both.
+  | { type: 'image'; media_type: string; data?: string; url?: string }
 
 export interface ApiMessage {
   id: string
@@ -54,7 +56,7 @@ export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'tool'; tool: ToolCall }
   | { type: 'status'; label: string; detail?: string; isError?: boolean }
-  | { type: 'image'; data: string; media_type: string }
+  | { type: 'image'; media_type: string; data?: string; url?: string }
 
 export interface ChatMessage {
   id: string


### PR DESCRIPTION
## Problem

`GET /workspaces/:id/messages` returns a whole session at once, with every stored block inlined. Image blocks hold their bytes as base64 in the event payload, so they dominate that response.

A session reported as slow to open:

| | |
| --- | --- |
| messages | 506 |
| block payload | 21 MB |
| of which images | 10 MB (35 blocks) |
| Postgres execution | 140 ms |

The database is not the bottleneck — serializing and shipping the JSON is, on a single-replica control plane whose event loop every other request shares. Nothing shows up in aggregate latency graphs because the spikes are short.

## Change

History serves image blocks by reference:

- `withImageUrls` swaps the inline base64 for `url`, addressing the block by its position in the message (event ids are `<message_id>-<ordinal>`, so the position maps onto the primary key).
- A new route, `GET /workspaces/:id/messages/:messageId/blocks/:ordinal/image`, serves the bytes with `Cache-Control: immutable` — a stored block never changes.
- `MessageBubble` renders from `url` or inline `data`, whichever is set, and marks the images `loading="lazy"`. Live stream blocks keep arriving inline, so both shapes stay valid.

Storage is untouched: the base64 stays in the payload, only the wire format changes. That keeps this revertible and needs no migration.

## Result

Measured over the real blocks of the reported session: **19.55 MB → 9.53 MB (−51%)**.

The browser now fetches images lazily, in parallel, and caches them across reloads, so the visible first paint improves by more than that number suggests.

## Scope

This addresses one of two independent size drivers. The other — many messages, and individual blocks that are huge on their own (across all sessions, per-event payload p99.9 is 488 KB and the largest single event is 49 MB) — needs tail windowing with cursor pagination plus per-block truncation. A session whose bulk is tool output rather than images barely moves here: the worst session in the fleet goes 177.45 MB → 176.77 MB. That follow-up also has to keep in-session search and the coordinator's `call_agent` derivation working once history stops loading whole, so it is deliberately a separate change.

Public share pages (`routes/shares.ts`) still inline images; they need a share-scoped image endpoint and are left for that follow-up.

## Testing

- `control-plane`: new unit tests for `withImageUrls` (position numbering, path escaping, pass-through cases) — 5 passing.
- `web`: existing session store suite — 51 passing.
- `tsc --noEmit` clean in `control-plane` and `web`; `ui-sdk` builds.
- Transform verified against production block data for the reported session and for the largest session in the fleet.
