### PR TITLE
fix(web): make mermaid diagram export actually work

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -65,6 +65,7 @@
         "lodash": "^4.18.1",
         "lucide-react": "^0.468.0",
         "marked": "^18.0.5",
+        "mermaid": "^11.14.0",
         "papaparse": "^5.5.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -79,6 +79,7 @@
     "lodash": "^4.18.1",
     "lucide-react": "^0.468.0",
     "marked": "^18.0.5",
+    "mermaid": "^11.14.0",
     "papaparse": "^5.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/src/components/ui/markdown.tsx
+++ b/web/src/components/ui/markdown.tsx
@@ -1,8 +1,10 @@
+import { MermaidDiagram } from "@/components/ui/mermaid-diagram";
 import { PlatformCmd } from "@/components/ui/platform-cmd";
 import { useSkillsBasePath } from "@/hooks/useSkillsBasePath";
 import { useWorkspaceFileLink } from "@/hooks/useWorkspaceFileLink";
 import { type DriveKind, fileUrl } from "@/lib/api/agent-files";
 import { cn } from "@/lib/utils";
+import { rehypeMermaid } from "@/lib/rehype-mermaid";
 import { canonicalizeAgentPath, isSkillTmpPath } from "@/lib/workspace-file-link";
 import { ChevronDown, ExternalLink, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, type ReactNode, memo, useMemo, useState } from "react";
@@ -122,7 +124,7 @@ const sysSanitizeSchema = {
 // schema to whitelist `<agent-sys>`; the rest stays in lockstep with
 // Streamdown so katex / raw HTML / link hardening keep working. Revisit on
 // Streamdown upgrades.
-const defaultRehypePlugins: PluggableList = [
+export const markdownRehypePlugins: PluggableList = [
   rehypeRaw,
   [rehypeKatex, { errorColor: "var(--color-muted-foreground)" }],
   [rehypeSanitize, sysSanitizeSchema],
@@ -136,6 +138,8 @@ const defaultRehypePlugins: PluggableList = [
       allowDataImages: true,
     },
   ],
+  // Last: the custom tag it emits must not be seen by rehype-sanitize.
+  rehypeMermaid,
 ];
 
 function AgentSysBlock({ children }: { children?: ReactNode }) {
@@ -177,6 +181,7 @@ export const Markdown = memo(function Markdown({
     () => ({
       "agent-sys": AgentSysBlock,
       "platform-cmd": PlatformCmd,
+      "mermaid-diagram": MermaidDiagram,
       ...(linkifyWorkspaceFiles ? { a: WorkspaceFileLink, img: WorkspaceFileImg } : {}),
     }),
     [linkifyWorkspaceFiles],
@@ -187,7 +192,7 @@ export const Markdown = memo(function Markdown({
       className={cn("prose prose-sm dark:prose-invert max-w-none text-[1em]", className)}
       shikiTheme={["github-light", "github-dark"]}
       components={components}
-      rehypePlugins={rehypePlugins ?? defaultRehypePlugins}
+      rehypePlugins={rehypePlugins ?? markdownRehypePlugins}
     >
       {children}
     </Streamdown>

--- a/web/src/components/ui/mermaid-diagram.tsx
+++ b/web/src/components/ui/mermaid-diagram.tsx
@@ -1,0 +1,323 @@
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useFullscreenContainer } from "@/hooks/useFullscreenContainer";
+import { downloadFile, svgToPngBlob } from "@/lib/mermaid-export";
+import { cn } from "@/lib/utils";
+import { Download, Maximize2, RotateCcw, X, ZoomIn, ZoomOut } from "lucide-react";
+import type { MermaidConfig } from "mermaid";
+import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 4;
+const ZOOM_STEP = 0.2;
+/** Long enough for a streamed fence to settle before we call it a syntax error. */
+const RENDER_DEBOUNCE_MS = 200;
+
+function baseConfig(dark: boolean): MermaidConfig {
+  return {
+    startOnLoad: false,
+    theme: dark ? "dark" : "default",
+    securityLevel: "strict",
+    fontFamily: "monospace",
+    suppressErrorRendering: true,
+  };
+}
+
+async function renderChart(chart: string, id: string, dark: boolean): Promise<string> {
+  const mermaid = (await import("mermaid")).default;
+  mermaid.initialize(baseConfig(dark));
+  const { svg } = await mermaid.render(id, chart);
+  return svg;
+}
+
+/** Tracks the `dark` class the theme switcher toggles on `<html>`. */
+function useIsDark(): boolean {
+  const [dark, setDark] = useState(() => document.documentElement.classList.contains("dark"));
+  useEffect(() => {
+    const observer = new MutationObserver(() =>
+      setDark(document.documentElement.classList.contains("dark")),
+    );
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+  return dark;
+}
+
+function nodeToText(node: ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeToText).join("");
+  if (typeof node === "object" && "props" in node) {
+    return nodeToText((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}
+
+interface ViewportProps {
+  svg: string;
+  className?: string;
+  showControls?: boolean;
+}
+
+/**
+ * Pan/zoom surface for a rendered diagram. Wheel zoom is modifier-gated so a
+ * diagram sitting in a long transcript never eats the page scroll.
+ */
+function DiagramViewport({ svg, className, showControls = true }: ViewportProps) {
+  const { t } = useTranslation();
+  const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const dragOrigin = useRef<{ x: number; y: number; offsetX: number; offsetY: number } | null>(
+    null,
+  );
+
+  const clampZoom = (value: number) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
+  const reset = () => {
+    setZoom(1);
+    setOffset({ x: 0, y: 0 });
+  };
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    dragOrigin.current = {
+      x: event.clientX,
+      y: event.clientY,
+      offsetX: offset.x,
+      offsetY: offset.y,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const origin = dragOrigin.current;
+    if (!origin) return;
+    setOffset({
+      x: origin.offsetX + (event.clientX - origin.x),
+      y: origin.offsetY + (event.clientY - origin.y),
+    });
+  };
+  const endDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragOrigin.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+  const onWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    if (!(event.ctrlKey || event.metaKey)) return;
+    event.preventDefault();
+    setZoom((current) => clampZoom(current - Math.sign(event.deltaY) * ZOOM_STEP));
+  };
+
+  return (
+    <div className={cn("relative overflow-hidden", className)}>
+      {showControls && (
+        <div className="absolute top-2 left-2 z-10 flex flex-col gap-1">
+          <button
+            type="button"
+            className="rounded-md border border-border bg-background/90 p-1 text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => setZoom((current) => clampZoom(current + ZOOM_STEP))}
+            title={t("components.mermaid.zoomIn")}
+          >
+            <ZoomIn className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-border bg-background/90 p-1 text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => setZoom((current) => clampZoom(current - ZOOM_STEP))}
+            title={t("components.mermaid.zoomOut")}
+          >
+            <ZoomOut className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-border bg-background/90 p-1 text-muted-foreground transition-colors hover:text-foreground"
+            onClick={reset}
+            title={t("components.mermaid.resetView")}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+      <div
+        className="size-full cursor-grab active:cursor-grabbing"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onWheel={onWheel}
+      >
+        <div
+          className="flex justify-center [&_svg]:max-w-full"
+          style={{
+            transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`,
+            transformOrigin: "center top",
+          }}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: mermaid output, rendered with securityLevel "strict"
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders a ```mermaid fence: diagram plus copy / download / fullscreen.
+ *
+ * Owning this block instead of using Streamdown's keeps the export path under
+ * our control — Streamdown feeds mermaid's raw HTML-flavoured SVG straight to
+ * an `<img>`, which fails to load whenever a label contains `<br>` and, when it
+ * does load, rasterizes at the browser's 300x150 fallback size. Both the
+ * failure and the size were invisible: Streamdown's mermaid block never wires
+ * up `onError`, so a failed export did nothing at all. See `lib/mermaid-export.ts`.
+ */
+export function MermaidDiagram({ children }: { children?: ReactNode }) {
+  const { t } = useTranslation();
+  const dark = useIsDark();
+  const chart = useMemo(() => nodeToText(children).trim(), [children]);
+  const renderId = useId().replace(/:/g, "");
+  const [svg, setSvg] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [fullscreen, setFullscreen] = useState(false);
+  const fullscreenContainer = useFullscreenContainer();
+
+  useEffect(() => {
+    if (!chart) return;
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      renderChart(chart, `${renderId}-${dark ? "dark" : "light"}`, dark)
+        .then((rendered) => {
+          if (cancelled) return;
+          setSvg(rendered);
+          setError(null);
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          setError(err instanceof Error ? err.message : String(err));
+        });
+    }, RENDER_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [chart, dark, renderId]);
+
+  useEffect(() => {
+    if (!fullscreen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setFullscreen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [fullscreen]);
+
+  const download = useCallback(
+    async (format: "svg" | "png" | "mmd") => {
+      try {
+        if (format === "mmd") {
+          downloadFile("diagram.mmd", chart, "text/plain");
+          return;
+        }
+        if (!svg) throw new Error(t("components.mermaid.notRenderedYet"));
+        if (format === "svg") {
+          const { normalizeSvg } = await import("@/lib/mermaid-export");
+          downloadFile("diagram.svg", normalizeSvg(svg), "image/svg+xml");
+          return;
+        }
+        downloadFile("diagram.png", await svgToPngBlob(svg), "image/png");
+      } catch (err) {
+        toast.error(t("components.mermaid.exportFailed"), {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [chart, svg, t],
+  );
+
+  const toolbar = (
+    <div className="flex items-center justify-end gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="cursor-pointer p-1 text-muted-foreground transition-colors hover:text-foreground"
+            title={t("components.mermaid.download")}
+          >
+            <Download className="h-3.5 w-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => void download("png")}>
+            {t("components.mermaid.downloadPng")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void download("svg")}>
+            {t("components.mermaid.downloadSvg")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void download("mmd")}>
+            {t("components.mermaid.downloadMmd")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CopyButton
+        value={chart}
+        size="icon"
+        className="h-6 w-6 text-muted-foreground hover:text-foreground"
+        title={t("components.mermaid.copySource")}
+      />
+      <button
+        type="button"
+        className="cursor-pointer p-1 text-muted-foreground transition-colors hover:text-foreground"
+        onClick={() => setFullscreen(true)}
+        title={t("components.mermaid.fullscreen")}
+      >
+        <Maximize2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+
+  if (error && !svg) {
+    return (
+      <div className="not-prose my-4 rounded-xl border border-destructive/40 bg-destructive/5 p-4">
+        <p className="font-mono text-destructive text-sm">
+          {t("components.mermaid.renderFailed")}: {error}
+        </p>
+        <details className="mt-2">
+          <summary className="cursor-pointer text-muted-foreground text-xs">
+            {t("components.mermaid.showSource")}
+          </summary>
+          <pre className="mt-2 overflow-x-auto rounded bg-muted p-2 text-xs">{chart}</pre>
+        </details>
+      </div>
+    );
+  }
+
+  return (
+    <div className="not-prose group relative my-4 rounded-xl border border-border p-4">
+      {toolbar}
+      <DiagramViewport svg={svg} className="min-h-[120px]" />
+      {fullscreen &&
+        createPortal(
+          <div className="fixed inset-0 z-50 flex flex-col bg-background/95 backdrop-blur-sm">
+            <div className="flex justify-end p-4">
+              <button
+                type="button"
+                className="rounded-md p-2 text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => setFullscreen(false)}
+                title={t("components.mermaid.exitFullscreen")}
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <DiagramViewport svg={svg} className="min-h-0 flex-1 px-4 pb-4" />
+          </div>,
+          fullscreenContainer ?? document.body,
+        )}
+    </div>
+  );
+}

--- a/web/src/components/workspace/file-preview/MarkdownPreview.tsx
+++ b/web/src/components/workspace/file-preview/MarkdownPreview.tsx
@@ -1,4 +1,4 @@
-import { Markdown } from '@/components/ui/markdown'
+import { Markdown, markdownRehypePlugins } from '@/components/ui/markdown'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 import { useMarkdownPreferencesStore } from '@/stores/markdown-preferences-store'
@@ -6,17 +6,17 @@ import { ChevronDown } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import rehypeSlug from 'rehype-slug'
-import { defaultRehypePlugins } from 'streamdown'
 import type { PluggableList } from 'unified'
 
 // Streamdown's `rehypePlugins` prop replaces its whole pipeline rather than
 // extending it. Passing just `[rehypeSlug]` would drop rehype-raw (inline
 // HTML), sanitize and harden — so `<table>` and other embedded HTML silently
-// vanish from the preview. Layer slug on top of the defaults instead; sanitize
-// stays in place, so this is still XSS-safe.
+// vanish from the preview. Layer slug on top of the app's own stack instead;
+// sanitize stays in place, so this is still XSS-safe, and mermaid fences keep
+// rendering through our block.
 // Hoisted so the memoized Markdown sees a stable reference; otherwise a new
 // array every render busts the memo.
-const REHYPE_PLUGINS: PluggableList = [...Object.values(defaultRehypePlugins), rehypeSlug]
+const REHYPE_PLUGINS: PluggableList = [...markdownRehypePlugins, rehypeSlug]
 
 interface TocItem {
   id: string

--- a/web/src/lib/mermaid-export.test.ts
+++ b/web/src/lib/mermaid-export.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_CANVAS_AREA,
+  MAX_CANVAS_DIMENSION,
+  PREFERRED_RASTER_SCALE,
+  computeRasterScale,
+  parseViewBox,
+} from './mermaid-export'
+
+describe('parseViewBox', () => {
+  it('reads the size out of a mermaid viewBox', () => {
+    expect(parseViewBox('0 0 1406.019 5027.546')).toEqual({
+      width: 1406.019,
+      height: 5027.546,
+    })
+  })
+
+  it('accepts comma separators', () => {
+    expect(parseViewBox('0,0,100,50')).toEqual({ width: 100, height: 50 })
+  })
+
+  it('rejects missing, malformed and degenerate boxes', () => {
+    expect(parseViewBox(null)).toBeNull()
+    expect(parseViewBox('')).toBeNull()
+    expect(parseViewBox('0 0 100')).toBeNull()
+    expect(parseViewBox('0 0 100 abc')).toBeNull()
+    expect(parseViewBox('0 0 0 50')).toBeNull()
+    expect(parseViewBox('0 0 100 -50')).toBeNull()
+  })
+})
+
+describe('computeRasterScale', () => {
+  it('upscales a small diagram to the preferred factor', () => {
+    expect(computeRasterScale({ width: 400, height: 300 })).toBe(PREFERRED_RASTER_SCALE)
+  })
+
+  it('clamps a tall diagram so no canvas edge exceeds the limit', () => {
+    const size = { width: 1406, height: 5028 }
+    const scale = computeRasterScale(size)
+    expect(scale).toBeLessThan(PREFERRED_RASTER_SCALE)
+    expect(size.height * scale).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION)
+    expect(size.width * scale * (size.height * scale)).toBeLessThanOrEqual(MAX_CANVAS_AREA + 1)
+  })
+
+  it('clamps on total area even when both edges fit', () => {
+    const size = { width: 5000, height: 3000 }
+    const scale = computeRasterScale(size)
+    // +1 absorbs float drift; the canvas itself rounds to whole pixels.
+    expect(size.width * scale * (size.height * scale)).toBeLessThanOrEqual(MAX_CANVAS_AREA + 1)
+  })
+
+  it('downscales a diagram whose natural size already exceeds the limits', () => {
+    expect(computeRasterScale({ width: 20000, height: 12000 })).toBeLessThan(1)
+  })
+
+  it('honours explicit limits', () => {
+    expect(
+      computeRasterScale({ width: 100, height: 100 }, { preferred: 4, maxDimension: 200 }),
+    ).toBe(2)
+  })
+})

--- a/web/src/lib/mermaid-export.ts
+++ b/web/src/lib/mermaid-export.ts
@@ -1,0 +1,154 @@
+/**
+ * Export helpers for rendered mermaid diagrams (see `components/ui/mermaid-diagram.tsx`).
+ *
+ * Mermaid serializes its output as HTML, not XML: `htmlLabels` mode wraps
+ * labels in `<foreignObject>` markup containing void tags such as `<br>`, and
+ * the root `<svg>` carries `width="100%"` with no height. Browsers parse
+ * `image/svg+xml` strictly, so that string fails to load in an `<img>` (which
+ * is how a PNG raster is produced) and opens with a parser error when saved as
+ * a `.svg` file. A percentage width also leaves the image at the 300x150
+ * default intrinsic box, so anything rasterized from it comes out at a fixed
+ * tiny size regardless of how large the diagram is.
+ *
+ * `normalizeSvg` re-serializes the markup as XML and pins the dimensions from
+ * the viewBox, which makes both export formats correct.
+ */
+
+/** Longest canvas edge we ask a browser for. Beyond this `toBlob` returns null. */
+export const MAX_CANVAS_DIMENSION = 8192
+/** Total canvas pixels we ask a browser for; iOS Safari gives up around 16.7M. */
+export const MAX_CANVAS_AREA = 16_700_000
+/** Upscale factor for a diagram small enough to afford it. */
+export const PREFERRED_RASTER_SCALE = 3
+
+interface SvgSize {
+  width: number
+  height: number
+}
+
+/** Reads the intrinsic size out of a `viewBox` attribute, or null if unusable. */
+export function parseViewBox(viewBox: string | null | undefined): SvgSize | null {
+  if (!viewBox) return null
+  const parts = viewBox
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number)
+  if (parts.length !== 4) return null
+  const [, , width, height] = parts
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null
+  }
+  return { width, height }
+}
+
+/**
+ * Picks a raster scale that keeps the canvas inside browser limits.
+ *
+ * Diagrams larger than the limits scale below 1 — a downscaled PNG beats the
+ * blank canvas a browser hands back when the requested size is refused.
+ */
+export function computeRasterScale(
+  { width, height }: SvgSize,
+  {
+    preferred = PREFERRED_RASTER_SCALE,
+    maxDimension = MAX_CANVAS_DIMENSION,
+    maxArea = MAX_CANVAS_AREA,
+  }: { preferred?: number; maxDimension?: number; maxArea?: number } = {},
+): number {
+  const scale = Math.min(
+    preferred,
+    maxDimension / width,
+    maxDimension / height,
+    Math.sqrt(maxArea / (width * height)),
+  )
+  return scale > 0 ? scale : 1
+}
+
+/**
+ * Re-serializes mermaid's HTML-flavoured SVG as XML and pins width/height from
+ * the viewBox. Returns the input untouched when the DOM APIs are unavailable.
+ */
+export function normalizeSvg(svg: string): string {
+  if (typeof DOMParser === 'undefined' || typeof XMLSerializer === 'undefined') return svg
+  const element = new DOMParser().parseFromString(svg, 'text/html').querySelector('svg')
+  if (!element) return svg
+  const size = parseViewBox(element.getAttribute('viewBox'))
+  if (size) {
+    element.setAttribute('width', String(size.width))
+    element.setAttribute('height', String(size.height))
+    // mermaid caps the rendered width for responsive layout; an exported file
+    // should be its natural size.
+    element.style.removeProperty('max-width')
+    if (!element.getAttribute('style')) element.removeAttribute('style')
+  }
+  return new XMLSerializer().serializeToString(element)
+}
+
+function toDataUrl(svg: string): string {
+  return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.crossOrigin = 'anonymous'
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Failed to load the diagram as an image'))
+    image.src = dataUrl
+  })
+}
+
+function rasterize(image: HTMLImageElement, size: SvgSize, scale: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.max(1, Math.round(size.width * scale))
+    canvas.height = Math.max(1, Math.round(size.height * scale))
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      reject(new Error('Failed to create a 2D canvas context'))
+      return
+    }
+    // SVG paints no background of its own; without this the PNG is transparent
+    // and unreadable in any viewer that defaults to a dark backdrop.
+    ctx.fillStyle = getComputedStyle(document.body).backgroundColor || '#ffffff'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob)
+      else reject(new Error('Failed to encode the diagram as PNG'))
+    }, 'image/png')
+  })
+}
+
+/** Rasterizes a rendered mermaid SVG to a PNG blob. */
+export async function svgToPngBlob(svg: string): Promise<Blob> {
+  const normalized = normalizeSvg(svg)
+  const image = await loadImage(toDataUrl(normalized))
+  const size: SvgSize =
+    image.naturalWidth > 0 && image.naturalHeight > 0
+      ? { width: image.naturalWidth, height: image.naturalHeight }
+      : { width: image.width, height: image.height }
+  const scale = computeRasterScale(size)
+  try {
+    return await rasterize(image, size, scale)
+  } catch (err) {
+    // A browser can still refuse a canvas that our limits considered fine
+    // (memory pressure, a stricter mobile cap). One retry at natural size
+    // turns "nothing happened" into a usable, if smaller, export.
+    if (scale <= 1) throw err
+    return rasterize(image, size, 1)
+  }
+}
+
+/** Triggers a browser download for generated content. */
+export function downloadFile(filename: string, data: Blob | string, mimeType: string): void {
+  const blob = typeof data === 'string' ? new Blob([data], { type: mimeType }) : data
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}

--- a/web/src/lib/rehype-mermaid.test.ts
+++ b/web/src/lib/rehype-mermaid.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { rehypeMermaid } from './rehype-mermaid'
+
+interface Node {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: Node[]
+  value?: string
+}
+
+const transform = rehypeMermaid() as (tree: Node) => void
+
+function codeFence(language: string, source: string): Node {
+  return {
+    type: 'element',
+    tagName: 'pre',
+    properties: {},
+    children: [
+      {
+        type: 'element',
+        tagName: 'code',
+        properties: { className: [`language-${language}`] },
+        children: [{ type: 'text', value: source }],
+      },
+    ],
+  }
+}
+
+function root(...children: Node[]): Node {
+  return { type: 'root', children }
+}
+
+describe('rehypeMermaid', () => {
+  it('replaces a mermaid fence with the custom element, keeping the source', () => {
+    const tree = root(codeFence('mermaid', 'flowchart TD\n  A --> B'))
+    transform(tree)
+    expect(tree.children?.[0]).toEqual({
+      type: 'element',
+      tagName: 'mermaid-diagram',
+      properties: {},
+      children: [{ type: 'text', value: 'flowchart TD\n  A --> B' }],
+    })
+  })
+
+  it('leaves other languages alone', () => {
+    const tree = root(codeFence('ts', 'const a = 1'))
+    transform(tree)
+    expect((tree.children?.[0] as Node).tagName).toBe('pre')
+  })
+
+  it('accepts a string className', () => {
+    const fence = codeFence('mermaid', 'graph TD')
+    const code = fence.children?.[0] as Node
+    code.properties = { className: 'language-mermaid hljs' }
+    const tree = root(fence)
+    transform(tree)
+    expect((tree.children?.[0] as Node).tagName).toBe('mermaid-diagram')
+  })
+
+  it('rewrites fences nested inside other elements', () => {
+    const tree = root({
+      type: 'element',
+      tagName: 'blockquote',
+      properties: {},
+      children: [codeFence('mermaid', 'graph TD')],
+    })
+    transform(tree)
+    const quoted = (tree.children?.[0] as Node).children?.[0] as Node
+    expect(quoted.tagName).toBe('mermaid-diagram')
+  })
+})

--- a/web/src/lib/rehype-mermaid.ts
+++ b/web/src/lib/rehype-mermaid.ts
@@ -1,0 +1,59 @@
+import type { Plugin } from 'unified'
+
+interface HastNode {
+  type: string
+  tagName?: string
+  properties?: { className?: unknown }
+  children?: HastNode[]
+  value?: string
+}
+
+function classNames(node: HastNode): string[] {
+  const raw = node.properties?.className
+  if (Array.isArray(raw)) return raw.map(String)
+  if (typeof raw === 'string') return raw.split(/\s+/)
+  return []
+}
+
+function isMermaidCode(node: HastNode): boolean {
+  return (
+    node.type === 'element' &&
+    node.tagName === 'code' &&
+    classNames(node).includes('language-mermaid')
+  )
+}
+
+/**
+ * Rewrites ```mermaid fences into `<mermaid-diagram>` so our own renderer
+ * handles them (see `components/ui/mermaid-diagram.tsx`) instead of
+ * Streamdown's built-in mermaid block.
+ *
+ * Runs after `rehype-sanitize` in the plugin list, so the custom tag it
+ * introduces does not need to be whitelisted in the sanitize schema.
+ */
+export const rehypeMermaid: Plugin = () => (tree: unknown) => {
+  const walk = (node: HastNode) => {
+    const children = node.children
+    if (!children) return
+    for (let i = 0; i < children.length; i += 1) {
+      const child = children[i]
+      const code =
+        child.type === 'element' && child.tagName === 'pre'
+          ? child.children?.find(isMermaidCode)
+          : isMermaidCode(child)
+            ? child
+            : undefined
+      if (code) {
+        children[i] = {
+          type: 'element',
+          tagName: 'mermaid-diagram',
+          properties: {},
+          children: code.children ?? [],
+        }
+        continue
+      }
+      walk(child)
+    }
+  }
+  walk(tree as HastNode)
+}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3401,6 +3401,22 @@
     "markdown": {
       "systemMessage": "System message"
     },
+    "mermaid": {
+      "download": "Download diagram",
+      "downloadPng": "PNG",
+      "downloadSvg": "SVG",
+      "downloadMmd": "Mermaid source",
+      "copySource": "Copy source",
+      "fullscreen": "View fullscreen",
+      "exitFullscreen": "Exit fullscreen",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "resetView": "Reset view",
+      "renderFailed": "Failed to render diagram",
+      "exportFailed": "Failed to export diagram",
+      "notRenderedYet": "The diagram has not finished rendering yet",
+      "showSource": "Show source"
+    },
     "management": {
       "providers": {
         "actions": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3425,6 +3425,22 @@
     "markdown": {
       "systemMessage": "系统消息"
     },
+    "mermaid": {
+      "download": "下载图表",
+      "downloadPng": "PNG",
+      "downloadSvg": "SVG",
+      "downloadMmd": "Mermaid 源码",
+      "copySource": "复制源码",
+      "fullscreen": "全屏查看",
+      "exitFullscreen": "退出全屏",
+      "zoomIn": "放大",
+      "zoomOut": "缩小",
+      "resetView": "重置视图",
+      "renderFailed": "图表渲染失败",
+      "exportFailed": "图表导出失败",
+      "notRenderedYet": "图表尚未渲染完成",
+      "showSource": "查看源码"
+    },
     "management": {
       "providers": {
         "actions": {


### PR DESCRIPTION
## Summary

Downloading a mermaid diagram as PNG did nothing at all — no file, no error, no console output. Three separate defects stacked up in Streamdown's mermaid block, so this PR takes the block over and fixes the export path.

1. **The SVG is not valid XML.** Mermaid's `htmlLabels` mode emits `<foreignObject>` labels containing unclosed `<br>` tags. PNG export loads that string through `data:image/svg+xml` in an `<img>`, which browsers parse strictly, so the image fails to load (`Opening and ending tag mismatch: br line 1 and p`). The SVG download writes the same string, so that file does not open either.
2. **Failures were silent.** The mermaid block never passes `onError`, and every failure path in the download handler is `onError?.(e)`. Nothing reached the user.
3. **The raster came out tiny.** The root `<svg>` carries `width="100%"` and no height, so `new Image()` falls back to the 300x150 intrinsic box: a 1406x5028 flowchart rasterized to 235x750 no matter what scale was applied. A fixed 5x scale is also unsafe in the other direction — on a large diagram it exceeds the browser canvas limit and `toBlob` hands back `null`.

## Changes

- `lib/mermaid-export.ts` — `normalizeSvg()` re-serializes mermaid's HTML-flavoured markup as XML and pins `width`/`height` from the viewBox; `computeRasterScale()` clamps the scale to browser canvas limits (8192 max edge, ~16.7M px area, preferring 3x) and downscales rather than requesting a canvas the browser will refuse; `svgToPngBlob()` rasterizes with one 1x retry; `downloadFile()` triggers the download.
- `components/ui/mermaid-diagram.tsx` — our own mermaid block: render (theme follows the `dark` class), pan/zoom with modifier-gated wheel zoom, fullscreen, copy source, download as PNG / SVG / Mermaid source, inline error state, and a toast when an export fails.
- `lib/rehype-mermaid.ts` — rewrites ```mermaid fences to `<mermaid-diagram>`. Runs after `rehype-sanitize`, so the custom tag needs no schema change.
- `markdown.tsx` registers the component and exports its rehype stack; `MarkdownPreview.tsx` now layers `rehype-slug` on that stack instead of Streamdown's defaults, which would have bypassed the new block.
- `mermaid` becomes a direct dependency of `web` (it was already present transitively); en-US / zh-CN strings added.

Streamdown 2.6.0 fixes the XML half of this upstream but still rasterizes at the fallback size, and its 2.x plugin split is a larger migration — worth doing separately.

## Testing

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 189 tests pass, including 12 new ones covering viewBox parsing, scale clamping and the fence rewrite.
- `npx biome check` on the touched files — clean (the two warnings in `MarkdownPreview.tsx` predate this change).
- End-to-end in a headless browser against a real 51-line flowchart with CJK labels and `<br/>` line breaks: before, `img.onerror` fired; after, the export produces a 2161x7728 / 1.04 MB PNG whose contents render correctly.
- Rendered the block through the real markdown pipeline in a dev build and drove the download menu: the PNG item triggers a `diagram.png` download, and unrelated code fences keep their shiki highlighting.

## Checklist

- [x] PR is scoped to a single logical change
- [x] Type-check passes (`npx tsc --noEmit`) for the affected component(s)
- [x] Lint/format passes (`npx biome check .`)
- [x] Tests added/updated where it makes sense, and passing
- [ ] Docs updated if behavior or configuration changed
