### PR TITLE
fix(web): keep manually collapsed MCP groups collapsed

### DIFF
--- a/web/src/components/workspace/McpConfigEditor.tsx
+++ b/web/src/components/workspace/McpConfigEditor.tsx
@@ -7,7 +7,7 @@ import type { McpCatalogEntry } from '@/lib/api/types'
 import { cn } from '@/lib/utils'
 import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, ChevronRight, Link, Loader2, Plus, Trash2, Unlink } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BuilderCapsEditor } from './BuilderCapsEditor'
 
@@ -589,6 +589,9 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
   }, [])
 
   const [groupOpen, setGroupOpen] = useState<Record<string, boolean>>({})
+  // Groups the user collapsed by hand. Auto-open skips these, so a collapse
+  // survives the config edits that re-run the sync effect below.
+  const collapsedByUser = useRef<Set<string>>(new Set())
 
   // Sync from value prop
   useEffect(() => {
@@ -603,6 +606,7 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
     setGroupOpen((prev) => {
       const openState: Record<string, boolean> = { ...prev }
       for (const { group, servers } of catalog.groups) {
+        if (collapsedByUser.current.has(group)) continue
         const hasRequired = servers.some(([, d]) => d.required)
         const hasEnabled = servers.some(([k]) => state.enabled[k])
         openState[group] = (prev[group] ?? false) || hasRequired || hasEnabled
@@ -610,6 +614,12 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
       return openState
     })
   }, [value, catalog])
+
+  function setGroupOpenByUser(group: string, open: boolean) {
+    if (open) collapsedByUser.current.delete(group)
+    else collapsedByUser.current.add(group)
+    setGroupOpen((prev) => ({ ...prev, [group]: open }))
+  }
 
   function emitChange(
     en: Record<string, boolean>,
@@ -718,7 +728,7 @@ export function McpConfigEditor({ value, onChange, workspaceId }: McpConfigEdito
               <Collapsible
                 key={group}
                 open={groupOpen[group] ?? false}
-                onOpenChange={(open) => setGroupOpen((prev) => ({ ...prev, [group]: open }))}
+                onOpenChange={(open) => setGroupOpenByUser(group, open)}
               >
                 <CollapsibleTrigger className="flex items-center gap-1.5 w-full py-0.5 group">
                   <ChevronRight className="h-3 w-3 text-muted-foreground/50 transition-transform group-data-[state=open]:rotate-90" />


### PR DESCRIPTION
## 问题

在 workspace Settings → MCP 面板里，把 Core / Productivity 这类分组手动折叠后，只要接着编辑自建 MCP server 的 URL，分组就会自己弹开——每敲一个字符弹一次，正在编辑的输入框被撑到屏幕外。

只有**含 required 或已启用 server** 的分组会这样；空分组（如 `0/4` 的 Translation）不受影响。

## 根因

`McpConfigEditor` 的 sync effect 依赖 `[value, catalog]`，`value` 是 MCP 配置的 JSON 字符串。自建 server 的 URL 输入框每次 keystroke 都会 `updateCustom` → `emitChange` → `onChange(buildMcpJson(...))`，父组件回写新 `value`，effect 整体重跑。

其中的自动展开逻辑是 `openState[group] = (prev[group] ?? false) || hasRequired || hasEnabled`——"只开不关"。用户手动折叠让 `prev[group] = false`，但下一次 keystroke 时 `hasRequired || hasEnabled` 仍为 true，折叠状态被无声覆盖。

## 改动

用一个 ref 记录用户手动折叠过的分组，自动展开时跳过它们；手动展开会把该分组从集合中移除，之后自动展开对它重新生效。

保留的行为：首次进入时含 required / 已启用 server 的分组仍自动展开；勾选分组内的 server 仍会自动展开该分组——除非用户此前明确折叠过它。

## 验证

`npx tsc --noEmit` 通过。