### PR TITLE
Add limit/offset pagination to the messages API

### DIFF
--- a/control-plane/src/routes/workspaces/read.ts
+++ b/control-plane/src/routes/workspaces/read.ts
@@ -191,7 +191,11 @@ const listMessagesRoute = createRoute({
   security: [{ bearerAuth: [] }],
   request: {
     params: WorkspaceIdParam,
-    query: z.object({ session_id: z.string() }),
+    query: z.object({
+      session_id: z.string(),
+      limit: z.coerce.number().int().min(1).max(500).optional(),
+      offset: z.coerce.number().int().min(0).optional(),
+    }),
   },
   responses: {
     200: {
@@ -208,12 +212,12 @@ const listMessagesRoute = createRoute({
 read.openapi(listMessagesRoute, async (c) => {
   const currentUser = c.get('user')
   const { id } = c.req.valid('param')
-  const { session_id } = c.req.valid('query')
+  const { session_id, limit, offset } = c.req.valid('query')
   const workspace = await getWorkspace(id)
   if (!workspace || !canManage(workspace, currentUser)) {
     return c.json({ error: 'Workspace not found' }, 404)
   }
-  const messages = await getMessagesWithBlocks(id, session_id)
+  const messages = await getMessagesWithBlocks(id, session_id, { limit, offset })
   return c.json(
     messages.map((m) => ({
       id: String(m.id),

--- a/control-plane/src/services/db/messages.test.ts
+++ b/control-plane/src/services/db/messages.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./pool', () => ({ pool: { query: vi.fn() }, generateId: vi.fn(() => 'gen-id') }))
+
+import { getMessages } from './messages'
+import { pool } from './pool'
+
+const q = vi.mocked(pool.query)
+
+beforeEach(() => {
+  q.mockReset()
+  q.mockResolvedValue({ rows: [], rowCount: 0 } as never)
+})
+
+describe('getMessages', () => {
+  it('fetches the full history when no pagination is given', async () => {
+    await getMessages('ws1', 'sess1')
+
+    const [sql, params] = q.mock.calls[0]
+    expect(String(sql)).not.toContain('LIMIT')
+    expect(String(sql)).not.toContain('OFFSET')
+    expect(params).toEqual(['ws1', 'sess1'])
+  })
+
+  it('appends LIMIT and OFFSET as trailing bound params', async () => {
+    await getMessages('ws1', 'sess1', { limit: 50, offset: 100 })
+
+    const [sql, params] = q.mock.calls[0]
+    expect(String(sql)).toContain('LIMIT $3')
+    expect(String(sql)).toContain('OFFSET $4')
+    expect(params).toEqual(['ws1', 'sess1', 50, 100])
+  })
+
+  it('supports limit without offset', async () => {
+    await getMessages('ws1', 'sess1', { limit: 20 })
+
+    const [sql, params] = q.mock.calls[0]
+    expect(String(sql)).toContain('LIMIT $3')
+    expect(String(sql)).not.toContain('OFFSET')
+    expect(params).toEqual(['ws1', 'sess1', 20])
+  })
+})

--- a/control-plane/src/services/db/messages.ts
+++ b/control-plane/src/services/db/messages.ts
@@ -37,11 +37,23 @@ async function getMessage(id: string): Promise<Message | null> {
   return (rows[0] as Message) ?? null
 }
 
-export async function getMessages(workspaceId: string, sessionId: string): Promise<Message[]> {
-  const { rows } = await pool.query(
-    'SELECT * FROM messages WHERE workspace_id = $1 AND session_id = $2 ORDER BY created_at ASC',
-    [workspaceId, sessionId],
-  )
+export async function getMessages(
+  workspaceId: string,
+  sessionId: string,
+  pagination?: { limit?: number; offset?: number },
+): Promise<Message[]> {
+  const params: unknown[] = [workspaceId, sessionId]
+  let query =
+    'SELECT * FROM messages WHERE workspace_id = $1 AND session_id = $2 ORDER BY created_at ASC'
+  if (pagination?.limit !== undefined) {
+    params.push(pagination.limit)
+    query += ` LIMIT $${params.length}`
+  }
+  if (pagination?.offset !== undefined) {
+    params.push(pagination.offset)
+    query += ` OFFSET $${params.length}`
+  }
+  const { rows } = await pool.query(query, params)
   return rows as Message[]
 }
 
@@ -263,8 +275,9 @@ export async function getMessageBlock(
 export async function getMessagesWithBlocks(
   workspaceId: string,
   sessionId: string,
+  pagination?: { limit?: number; offset?: number },
 ): Promise<MessageWithBlocks[]> {
-  const messages = await getMessages(workspaceId, sessionId)
+  const messages = await getMessages(workspaceId, sessionId, pagination)
   if (messages.length === 0) return []
   const events = await getEventsByMessageIds(messages.map((m) => m.id))
   return messages.map((m) => withTiming(m, events.get(m.id)))


### PR DESCRIPTION
## Summary
- Third-party clients previously had to fetch a session's full message history on every request, which is fragile over unstable networks.
- `GET /workspaces/{id}/messages` now accepts optional `limit` (1-500) and `offset` query params.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/services/db/messages.test.ts`