### PR TITLE
Add array_contains filter op to webhook connector routes

### DIFF
--- a/channel-gateway/src/connectors/webhook.test.ts
+++ b/channel-gateway/src/connectors/webhook.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { matchFilters } from './webhook'
+
+const baseCtx = { query: {}, headers: {}, method: 'POST', path: '/hook' }
+
+describe('matchFilters — array_contains', () => {
+  const labels = [
+    { id: 1, title: 'bug', color: '#f00' },
+    { id: 2, title: 'zh-review', color: '#0f0' },
+  ]
+
+  it('matches when an array element has the target itemField value', () => {
+    const ctx = { ...baseCtx, body: { labels } }
+    const filters = [
+      {
+        field: 'body.labels',
+        op: 'array_contains' as const,
+        itemField: 'title',
+        value: 'zh-review',
+      },
+    ]
+
+    expect(matchFilters(filters, ctx)).toBe(true)
+  })
+
+  it('does not match when no element has the target itemField value', () => {
+    const ctx = { ...baseCtx, body: { labels } }
+    const filters = [
+      {
+        field: 'body.labels',
+        op: 'array_contains' as const,
+        itemField: 'title',
+        value: 'needs-triage',
+      },
+    ]
+
+    expect(matchFilters(filters, ctx)).toBe(false)
+  })
+
+  it('matches primitive array elements directly when itemField is omitted', () => {
+    const ctx = { ...baseCtx, body: { tags: ['a', 'b', 'c'] } }
+    const filters = [{ field: 'body.tags', op: 'array_contains' as const, value: 'b' }]
+
+    expect(matchFilters(filters, ctx)).toBe(true)
+  })
+
+  it('does not match when the field resolves to a non-array', () => {
+    const ctx = { ...baseCtx, body: { labels: 'not-an-array' } }
+    const filters = [
+      {
+        field: 'body.labels',
+        op: 'array_contains' as const,
+        itemField: 'title',
+        value: 'zh-review',
+      },
+    ]
+
+    expect(matchFilters(filters, ctx)).toBe(false)
+  })
+
+  it('is unaffected by element order', () => {
+    const ctx = { ...baseCtx, body: { labels: [...labels].reverse() } }
+    const filters = [
+      {
+        field: 'body.labels',
+        op: 'array_contains' as const,
+        itemField: 'title',
+        value: 'zh-review',
+      },
+    ]
+
+    expect(matchFilters(filters, ctx)).toBe(true)
+  })
+})

--- a/channel-gateway/src/connectors/webhook.ts
+++ b/channel-gateway/src/connectors/webhook.ts
@@ -57,8 +57,14 @@ function applyTemplate(
  */
 interface FilterRule {
   field: string
-  op: 'eq' | 'neq' | 'in' | 'contains' | 'exists'
+  op: 'eq' | 'neq' | 'in' | 'contains' | 'exists' | 'array_contains'
   value?: unknown
+  /**
+   * array_contains only: dot-path within each array element to compare against
+   * `value` (e.g. 'title' for GitLab MR `labels[].title`). Omit to compare
+   * elements directly, for arrays of primitives.
+   */
+  itemField?: string
 }
 
 /** Resolve a filter field from the request context. */
@@ -82,7 +88,10 @@ function resolveField(
 }
 
 /** Check if all filter rules match (AND logic). Empty filters = pass. */
-function matchFilters(filters: FilterRule[], ctx: Parameters<typeof resolveField>[1]): boolean {
+export function matchFilters(
+  filters: FilterRule[],
+  ctx: Parameters<typeof resolveField>[1],
+): boolean {
   for (const rule of filters) {
     const actual = resolveField(rule.field, ctx)
     switch (rule.op) {
@@ -98,6 +107,16 @@ function matchFilters(filters: FilterRule[], ctx: Parameters<typeof resolveField
         break
       case 'contains':
         if (!String(actual).includes(String(rule.value))) return false
+        break
+      case 'array_contains':
+        if (!Array.isArray(actual)) return false
+        if (
+          !actual.some((item) => {
+            const itemValue = rule.itemField ? resolve(item, rule.itemField) : item
+            return String(itemValue) === String(rule.value)
+          })
+        )
+          return false
         break
       case 'exists':
         if ((actual !== undefined && actual !== null) !== (rule.value !== false)) return false


### PR DESCRIPTION
## Summary
- GitLab MR webhooks carry `labels` as an array of objects (`[{id, title, color}]`), so existing filter ops (`eq`/`neq`/`in`/`contains`/`exists`) can't express "route only when labels include title=X" — `contains` stringifies the whole array and matches substrings, not elements.
- Adds `array_contains`: resolves a field to an array, then checks whether any element (optionally at a nested `itemField`) equals the target value. Works for both object arrays (`itemField: 'title'`) and primitive arrays.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (channel-gateway, 29/29 passing)