### PR TITLE
Thread Slack channel/thread/user context to the agent's MCP headers

### DIFF
--- a/agents/codex/src/config.ts
+++ b/agents/codex/src/config.ts
@@ -459,7 +459,10 @@ export function loadRuntimeConfig(): RuntimeConfig | null {
  * ACP-session servers (config.toml supports 30s). In-cluster servers like
  * cp and rd answer within 1s, well under the ceiling.
  */
-export function loadAcpMcpServers(sessionToken?: string): McpServer[] {
+export function loadAcpMcpServers(
+  sessionToken?: string,
+  slackContext?: { channel_id?: string; thread_ts?: string; user_id?: string },
+): McpServer[] {
   if (!CP_URL || !WORKSPACE_ID) return []
 
   const servers: McpServer[] = []
@@ -477,6 +480,12 @@ export function loadAcpMcpServers(sessionToken?: string): McpServer[] {
   platformHeaders.set('X-Workspace-ID', WORKSPACE_ID)
   platformHeaders.set('X-Agent-ID', WORKSPACE_ID)
   if (sessionToken) platformHeaders.set('X-Session-Token', sessionToken)
+  // Slack envelope for a connector-triggered turn — lets a skill (e.g. a
+  // Jira reporter) read who triggered the session and where to reply,
+  // instead of inferring it from `<thread_context>` text.
+  if (slackContext?.channel_id) platformHeaders.set('X-Slack-Channel-Id', slackContext.channel_id)
+  if (slackContext?.thread_ts) platformHeaders.set('X-Slack-Thread-Ts', slackContext.thread_ts)
+  if (slackContext?.user_id) platformHeaders.set('X-Slack-User-Id', slackContext.user_id)
   servers.push({
     type: 'http',
     name: 'tos-platform',

--- a/control-plane/src/services/chat/dispatchChatTurn.ts
+++ b/control-plane/src/services/chat/dispatchChatTurn.ts
@@ -48,6 +48,7 @@ export async function dispatchChatTurn(opts: DispatchChatTurnOpts): Promise<Resp
     source: body.source,
     callerUserId,
     taskId: taskId ?? null,
+    slackContext: body.slack_context ?? null,
   })
 
   const ct = sseResponse.headers.get('Content-Type') ?? ''

--- a/control-plane/src/services/chat/executeChat.ts
+++ b/control-plane/src/services/chat/executeChat.ts
@@ -1,3 +1,4 @@
+import type { SlackContext } from '../../../../internal/types/api'
 import { ensureTokenForSession, mintToken } from '../../lib/session-token'
 import { createInterceptedSSEResponse } from '../../lib/sse'
 import { resolveAgentAddress } from '../../lib/workspace-address'
@@ -25,6 +26,8 @@ interface ExecuteChatOpts {
   source: string
   /** Who initiated the turn (used for session audit on new-session creation). */
   callerUserId?: string
+  /** Slack envelope for a connector-triggered turn; blind passthrough to the agent's MCP headers. */
+  slackContext?: SlackContext | null
   /**
    * Optional teamwork task context. When set, the new (or resumed) session
    * is registered as the coordinator session for this task, and the MCP
@@ -59,7 +62,7 @@ interface ExecuteChatOpts {
  * if the agent fetch fails outright.
  */
 export async function executeChat(opts: ExecuteChatOpts): Promise<Response> {
-  const { workspace, images, source, callerUserId } = opts
+  const { workspace, images, source, callerUserId, slackContext } = opts
   const { id: workspaceId } = workspace
   const sessionId = opts.sessionId
   let userMessageText: string | null = opts.message
@@ -140,6 +143,7 @@ export async function executeChat(opts: ExecuteChatOpts): Promise<Response> {
         images,
         source,
         sessionToken,
+        slackContext,
       }),
     )
 

--- a/control-plane/src/services/chat/request.test.ts
+++ b/control-plane/src/services/chat/request.test.ts
@@ -53,6 +53,31 @@ describe('buildAgentChatBody', () => {
     })
     expect('images' in emptyImages).toBe(false)
   })
+
+  it('includes slack_context only when set', () => {
+    const withContext = buildAgentChatBody({
+      message: 'hi',
+      sessionId: 's1',
+      images: null,
+      source: 'slack',
+      sessionToken: 'tok',
+      slackContext: { channel_id: 'C1', thread_ts: '123.456', user_id: 'U1' },
+    })
+    expect(withContext.slack_context).toEqual({
+      channel_id: 'C1',
+      thread_ts: '123.456',
+      user_id: 'U1',
+    })
+
+    const withoutContext = buildAgentChatBody({
+      message: 'hi',
+      sessionId: 's1',
+      images: null,
+      source: 'web',
+      sessionToken: 'tok',
+    })
+    expect('slack_context' in withoutContext).toBe(false)
+  })
 })
 
 describe('buildUserMessageBlocks', () => {

--- a/control-plane/src/services/chat/request.ts
+++ b/control-plane/src/services/chat/request.ts
@@ -1,4 +1,4 @@
-import type { ChatBody, ChatMode } from '../../../../internal/types/api'
+import type { ChatBody, ChatMode, SlackContext } from '../../../../internal/types/api'
 
 // Pure request-shaping helpers for chat dispatch, extracted from
 // executeChat/dispatchChatTurn so the wire contracts (agent /chat body,
@@ -21,6 +21,7 @@ export function buildAgentChatBody(opts: {
   images: ChatImage[] | null
   source: string
   sessionToken: string
+  slackContext?: SlackContext | null
 }): Record<string, unknown> {
   return {
     message: opts.message,
@@ -28,6 +29,7 @@ export function buildAgentChatBody(opts: {
     ...(opts.images?.length ? { images: opts.images } : {}),
     source: opts.source,
     session_token: opts.sessionToken,
+    ...(opts.slackContext ? { slack_context: opts.slackContext } : {}),
   }
 }
 

--- a/internal/acp-adapter/acp-server.ts
+++ b/internal/acp-adapter/acp-server.ts
@@ -31,7 +31,10 @@ export interface AcpAgentServerConfig {
   workspaceDir: string
   cpUrl?: string
   workspaceId?: string
-  loadMcpServers: (sessionToken?: string) => McpServer[]
+  loadMcpServers: (
+    sessionToken?: string,
+    slackContext?: ChatRequest['slack_context'],
+  ) => McpServer[]
   /** Whether MCP servers are configured in config.toml (requires waiting for startup) */
   hasMcpServers?: () => boolean
   loadConfig: () => Promise<boolean>
@@ -279,7 +282,13 @@ export function createAcpAgentApp(config: AcpAgentServerConfig) {
   // Chat - SSE streaming endpoint
   app.post('/chat', async (c) => {
     const body = await c.req.json<ChatRequest>()
-    const { message, session_id: sessionId, images, session_token: sessionToken } = body
+    const {
+      message,
+      session_id: sessionId,
+      images,
+      session_token: sessionToken,
+      slack_context: slackContext,
+    } = body
     // session_token: CP-minted opaque proxy id for this session. ACP
     // binds MCP servers at createSession/loadSession (we can't rewire per
     // turn), so the token is carried into headers there and stays for the
@@ -374,7 +383,7 @@ export function createAcpAgentApp(config: AcpAgentServerConfig) {
           )
           try {
             const loadStart = Date.now()
-            const mcpServers = config.loadMcpServers(sessionToken)
+            const mcpServers = config.loadMcpServers(sessionToken, slackContext)
             // Don't register handler before loadSession — the ACP protocol
             // replays the full conversation history via notifications during
             // loadSession, and we don't want those replayed events in the SSE
@@ -427,7 +436,7 @@ export function createAcpAgentApp(config: AcpAgentServerConfig) {
             `[agent] Bridge spawned (new session) bridge_spawn=${Date.now() - bridgeStart}ms`,
           )
           const createStart = Date.now()
-          const mcpServers = config.loadMcpServers(sessionToken)
+          const mcpServers = config.loadMcpServers(sessionToken, slackContext)
           currentSessionId = await newBridge.createSession({ mcpServers })
           console.log(
             `[agent] Session created session=${currentSessionId} session_create=${Date.now() - createStart}ms`,
@@ -518,7 +527,7 @@ export function createAcpAgentApp(config: AcpAgentServerConfig) {
           destroyBridge(currentSessionId)
           const rebuilt = await bridgeFactory!(currentSessionId)
           await rebuilt.loadSession(currentSessionId, {
-            mcpServers: config.loadMcpServers(sessionToken),
+            mcpServers: config.loadMcpServers(sessionToken, slackContext),
           })
           currentBridge = rebuilt
           reusedBridge = false

--- a/internal/acp-adapter/types.ts
+++ b/internal/acp-adapter/types.ts
@@ -12,4 +12,13 @@ export interface ChatRequest {
    * recover the session identity. Blind passthrough on the agent side.
    */
   session_token?: string
+  /**
+   * Slack envelope (channel/thread/triggering user) for a connector-triggered
+   * turn. Blind passthrough into MCP headers, same lifecycle as session_token.
+   */
+  slack_context?: {
+    channel_id?: string
+    thread_ts?: string
+    user_id?: string
+  }
 }

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -1718,6 +1718,19 @@ export const ChatImageSchema = z.object({
 })
 
 /**
+ * Slack envelope for a connector-triggered turn: where the reply should go
+ * and who triggered it. Threaded through to the agent's MCP headers so a
+ * skill (e.g. a Jira reporter) can read it instead of inferring it from
+ * `<thread_context>` text, which carries no marker at all for bot/job turns.
+ */
+export const SlackContextSchema = z.object({
+  channel_id: z.string().optional(),
+  thread_ts: z.string().optional(),
+  user_id: z.string().optional(),
+})
+export type SlackContext = z.infer<typeof SlackContextSchema>
+
+/**
  * Response delivery mode for a chat turn:
  *   - `stream` — SSE (`text/event-stream`) of UniversalEvent frames. The most
  *     flexible mode and the default.
@@ -1741,6 +1754,8 @@ export const ChatBodySchema = z.object({
   images: z.array(ChatImageSchema).optional(),
   /** Origin of the turn. Defaults to `api` for direct API callers. */
   source: z.enum(CHAT_SOURCES).optional().default('api'),
+  /** Set by scheduler for Slack-triggered turns; absent for other sources. */
+  slack_context: SlackContextSchema.optional(),
   /**
    * Response delivery mode. When set, takes precedence over `stream` and the
    * `Accept` header. Defaults to `stream`.

--- a/scheduler/src/handler.ts
+++ b/scheduler/src/handler.ts
@@ -189,6 +189,19 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
     // Build stream sink for connectors with reply_context.streaming === true (e.g. wecom)
     const streamSink = buildStreamSink(trigger)
 
+    // Slack envelope for a connector-triggered turn — lets the agent's
+    // platform-MCP headers carry who triggered it and where to reply,
+    // instead of only the `<thread_context>` text (which has no marker at
+    // all when the triggering Slack message itself came from a bot).
+    const slackContext =
+      trigger.type === 'slack'
+        ? {
+            channel_id: (replyContext?.channel_id as string | undefined) ?? undefined,
+            thread_ts: (replyContext?.thread_ts as string | undefined) ?? threadId,
+            user_id: triggerPayload?.user as string | undefined,
+          }
+        : undefined
+
     const source = trigger.type === 'cron' ? 'schedule' : trigger.type
     console.log(
       `[Scheduler] ${existingSessionId ? 'Continuing' : 'Starting new'} session job=${job.id}${streamSink ? ' (streaming)' : ''}`,
@@ -222,6 +235,7 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
       images,
       streamSink,
       bindThreadSession,
+      slackContext,
     )
 
     // If resuming failed, fallback to a fresh session
@@ -238,6 +252,7 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
         images,
         streamSink,
         bindThreadSession,
+        slackContext,
       )
     }
 
@@ -502,12 +517,14 @@ async function startAndConsumeSession(
   images?: Array<{ data: string; media_type: string }>,
   streamSink?: StreamSink | null,
   onSessionStarted?: (sessionId: string) => void,
+  slackContext?: { channel_id?: string; thread_ts?: string; user_id?: string } | null,
 ): Promise<JobResult | null> {
   const body = JSON.stringify({
     message: prompt,
     ...(sessionId ? { session_id: sessionId } : {}),
     ...(source ? { source } : {}),
     ...(images?.length ? { images } : {}),
+    ...(slackContext ? { slack_context: slackContext } : {}),
   })
   console.log(
     `[Scheduler] POST /chat workspace=${workspaceId} session=${sessionId ?? '(new)'} source=${source ?? '-'} images=${images?.length ?? 0} body_bytes=${body.length}`,


### PR DESCRIPTION
## Summary
- For Slack connector-triggered turns, the agent had no structured way to know who triggered a session or where to reply — only a `<thread_context>` text render that shows `[bot]` with no marker at all when the triggering message itself came from a bot. A skill relying on this (e.g. a Jira reporter) had to infer the reporter and sometimes got it wrong.
- `channel-gateway` already builds `reply_context` (`thread_id`/`thread_ts`/`channel_id`) and the triggering Slack user id, but `scheduler` only used them for thread-locking and reply routing, never forwarding past its own `/chat` call.
- Adds a `slack_context` field threaded through the existing chain (scheduler → cp's `ChatBody` → agent `/chat` → ACP `loadMcpServers`), mirroring how `session_token` already reaches MCP headers. The platform MCP server now sees `X-Slack-Channel-Id`/`X-Slack-Thread-Ts`/`X-Slack-User-Id` for the turn's lifetime.
- Scoped to `trigger.type === 'slack'`; other trigger sources (schedule/webhook/etc.) don't carry a Slack envelope and get no `slack_context`.

## Test plan
- [x] `npx tsc --noEmit` across control-plane, scheduler, agents/codex, agents/goose, agents/dsh
- [x] `npx vitest run src/services/chat/request.test.ts` (control-plane)