### PR TITLE
Fix chat scroll tug-of-war while search is open

### DIFF
--- a/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -408,10 +408,13 @@ export function WorkspaceChatPanel({
   }, [])
 
   // ── Scroll ──
-  const { scrollRef, showScrollBtn, markPendingScroll, handleScrollBtnClick } = useAutoScroll(
-    [messages],
-    activeSessionId,
-  )
+  const {
+    scrollRef,
+    showScrollBtn,
+    markPendingScroll,
+    handleScrollBtnClick,
+    setPaused: setAutoScrollPaused,
+  } = useAutoScroll([messages], activeSessionId)
 
   // Search — `panelRef` scopes the cmd+F shortcut to the chat panel root so
   // other panels (files, terminal) in adjacent slots keep browser-native Find.
@@ -426,6 +429,13 @@ export function WorkspaceChatPanel({
     searchInputRef,
     navigateSearch,
   } = useChatSearch(scrollRef, panelRef, messages)
+
+  // While the search bar is open it owns the viewport: follow-the-tail would
+  // otherwise snap back to the bottom on the next message and fight the jump
+  // to the highlighted match.
+  useEffect(() => {
+    setAutoScrollPaused(searchOpen)
+  }, [searchOpen, setAutoScrollPaused])
 
   // ── Virtualization ──
   // When search is open, fall back to flat rendering so the CSS Highlight API

--- a/web/src/hooks/useAutoScroll.ts
+++ b/web/src/hooks/useAutoScroll.ts
@@ -23,11 +23,16 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  *    whenever a long block rendered.
  *  - Returning to the bottom (by any means) re-arms `auto`, so a single
  *    detour up doesn't permanently break follow.
+ *  - `setPaused` suspends every scroll this hook performs while something else
+ *    owns the viewport (chat search jumping between matches). Programmatic
+ *    scrolls don't disarm `auto`, so without this the two fight: search scrolls
+ *    to a match, the next message update snaps back to the bottom.
  */
 export function useAutoScroll(deps: unknown[], resetKey?: unknown) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const pendingRef = useRef(false)
   const autoRef = useRef(true)
+  const pausedRef = useRef(false)
   const [showScrollBtn, setShowScrollBtn] = useState(false)
 
   const isAtBottom = useCallback(() => {
@@ -37,8 +42,13 @@ export function useAutoScroll(deps: unknown[], resetKey?: unknown) {
   }, [])
 
   const scrollToBottom = useCallback(() => {
+    if (pausedRef.current) return
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
+  }, [])
+
+  const setPaused = useCallback((paused: boolean) => {
+    pausedRef.current = paused
   }, [])
 
   // Scroll listener: only updates button visibility. It must NOT touch
@@ -129,10 +139,12 @@ export function useAutoScroll(deps: unknown[], resetKey?: unknown) {
     pendingRef.current = true
   }, [])
 
+  // Explicit user intent: honoured even while paused.
   const handleScrollBtnClick = useCallback(() => {
     autoRef.current = true
-    scrollToBottom()
-  }, [scrollToBottom])
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [])
 
   return {
     scrollRef,
@@ -140,5 +152,6 @@ export function useAutoScroll(deps: unknown[], resetKey?: unknown) {
     scrollToBottom,
     markPendingScroll,
     handleScrollBtnClick,
+    setPaused,
   }
 }

--- a/web/src/hooks/useChatSearch.ts
+++ b/web/src/hooks/useChatSearch.ts
@@ -78,18 +78,37 @@ export function useChatSearch(
     }
   }, [searchQuery, messages, scrollContainerRef])
 
-  // Reset index when query or matches change
+  // Jump to the first match when the query changes. Deliberately keyed on the
+  // query alone: message updates (streaming, reconnects) also rebuild the
+  // ranges, and scrolling on those would yank the viewport back to match 1
+  // every time the conversation grows.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: query-change only
   useEffect(() => {
     setSearchIndex(0)
-    if (rangesRef.current.length > 0 && supportsHighlightAPI) {
+    const first = rangesRef.current[0]
+    if (!first) return
+    if (supportsHighlightAPI) {
       CSS.highlights.delete(HIGHLIGHT_ACTIVE)
-      CSS.highlights.set(HIGHLIGHT_ACTIVE, new Highlight(rangesRef.current[0]))
-      rangesRef.current[0].startContainer.parentElement?.scrollIntoView({
-        block: 'center',
-        behavior: 'smooth',
-      })
+      CSS.highlights.set(HIGHLIGHT_ACTIVE, new Highlight(first))
     }
-  }, [searchQuery, messages])
+    first.startContainer.parentElement?.scrollIntoView({
+      block: 'center',
+      behavior: 'smooth',
+    })
+  }, [searchQuery])
+
+  // The ranges are rebuilt on every message update, so the active highlight
+  // has to be re-pointed at the current index — without moving the viewport.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `messages` is the signal that rangesRef was rebuilt
+  useEffect(() => {
+    if (!supportsHighlightAPI) return
+    CSS.highlights.delete(HIGHLIGHT_ACTIVE)
+    const ranges = rangesRef.current
+    if (ranges.length === 0) return
+    const idx = Math.min(searchIndex, ranges.length - 1)
+    if (idx !== searchIndex) setSearchIndex(idx)
+    CSS.highlights.set(HIGHLIGHT_ACTIVE, new Highlight(ranges[idx]))
+  }, [messages, searchIndex])
 
   const navigateSearch = useCallback((direction: 'prev' | 'next') => {
     const ranges = rangesRef.current


### PR DESCRIPTION
## Problem

With the chat search bar open, the message list ping-pongs between the first
match and the bottom of the conversation. It is most visible on a session that
is reconnecting, where message updates arrive in a burst.

Two independent forces drive the same scroll container:

- `useChatSearch` reset the index and `scrollIntoView`'d to match 1 on every
  `messages` change, not just when the query changed.
- `useAutoScroll` only disarms follow-the-tail on *user-initiated* scrolling
  (wheel / touchmove / keydown). The search jump is programmatic, so follow
  stayed armed and its ResizeObserver snapped the view back to the bottom.

Each message update therefore fired both: jump to match 1, snap to bottom.

## Fix

- Key the jump-to-first-match effect on `searchQuery` alone.
- Add a separate effect that re-points the active highlight at the current
  index after the ranges are rebuilt, without moving the viewport (with a
  clamp for when the match count shrinks).
- Give `useAutoScroll` a `setPaused`, and pause it while the search bar is
  open. The scroll-to-bottom button is explicit user intent and bypasses the
  pause.

## Verification

`npx tsc --noEmit` clean; `biome check` on the touched files drops from 3
warnings to 1, and the remaining one is pre-existing.