### PR TITLE
Mark switched-off MCP servers in template config views

### DIFF
--- a/web/src/components/library/TemplateConfigView.tsx
+++ b/web/src/components/library/TemplateConfigView.tsx
@@ -37,7 +37,7 @@ interface TemplateConfigViewProps {
   promptId?: string
   promptName?: string
   promptContent?: string
-  mcpServers?: Record<string, { type?: string; command?: string; url?: string }>
+  mcpServers?: Record<string, { type?: string; command?: string; url?: string; disabled?: boolean }>
   agentSettings?: Record<string, unknown>
   skillNames?: string[]
   resources?: {
@@ -262,7 +262,7 @@ function McpServerRow({
   catalogEntry,
 }: {
   name: string
-  cfg: { type?: string; command?: string; url?: string }
+  cfg: { type?: string; command?: string; url?: string; disabled?: boolean }
   catalogEntry?: McpCatalogEntry
 }) {
   const { t } = useTranslation()
@@ -270,23 +270,35 @@ function McpServerRow({
   const target = cfg.url || cfg.command || ''
   const label = catalogEntry?.label ?? name
   const description = catalogEntry?.description
+  // A server switched off keeps its config (and params) in the template but is
+  // stripped before the agent ever sees it, so it reads as off, not absent.
+  const off = cfg.disabled === true
 
   return (
     <SectionRow>
-      <div className="flex items-baseline gap-2">
+      <div className={cn('flex items-baseline gap-2', off && 'opacity-50')}>
         <span className="truncate text-sm font-medium text-foreground">{label}</span>
         {catalogEntry && (
           <span className="font-mono text-tiny text-muted-foreground/60">{catalogEntry.id}</span>
+        )}
+        {off && (
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-tiny text-muted-foreground">
+            {t('components.library.templateConfigView.labels.disabled')}
+          </span>
         )}
         <span className="ml-auto shrink-0 rounded bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-tiny text-muted-foreground">
           {transport}
         </span>
       </div>
       {description && (
-        <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{description}</div>
+        <div
+          className={cn('mt-0.5 line-clamp-2 text-xs text-muted-foreground', off && 'opacity-50')}
+        >
+          {description}
+        </div>
       )}
       {target && (
-        <div className="mt-1.5 flex min-w-0 items-center gap-1.5">
+        <div className={cn('mt-1.5 flex min-w-0 items-center gap-1.5', off && 'opacity-50')}>
           <span
             className="min-w-0 flex-1 truncate font-mono text-tiny text-muted-foreground/80"
             title={target}

--- a/web/src/components/library/TemplatesSection.tsx
+++ b/web/src/components/library/TemplatesSection.tsx
@@ -90,7 +90,12 @@ function getMcpServerNames(mcpConfigStr: string): string[] {
     const parsed = JSON.parse(mcpConfigStr)
     const servers = parsed?.mcpServers ?? parsed
     if (!servers || typeof servers !== 'object') return []
-    return Object.keys(servers).sort()
+    // A switched-off server keeps its entry so its params survive a re-enable.
+    // The diff compares what the agent actually gets, so leave those out.
+    return Object.entries(servers)
+      .filter(([, cfg]) => (cfg as { disabled?: boolean } | null)?.disabled !== true)
+      .map(([name]) => name)
+      .sort()
   } catch {
     return []
   }

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1080,6 +1080,7 @@
         "appsCount": "{{count}} apps",
         "labels": {
           "custom": "Custom",
+          "disabled": "Off",
           "resourcesSummary": "CPU: {{cpuRequest}} / {{cpuLimit}} · Memory: {{memoryRequest}} / {{memoryLimit}} · Storage: {{storage}}",
           "preset": "Preset",
           "cpu": "CPU",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1105,6 +1105,7 @@
         "appsCount": "{{count}} 个应用",
         "labels": {
           "custom": "自定义",
+          "disabled": "已关闭",
           "resourcesSummary": "CPU：{{cpuRequest}} / {{cpuLimit}} · 内存：{{memoryRequest}} / {{memoryLimit}} · 存储：{{storage}}",
           "preset": "预设",
           "cpu": "CPU",


### PR DESCRIPTION
## Problem

Unchecking an MCP server that already exists in a template does not remove its
entry — `buildMcpJson` keeps it, with its params, and flags it `disabled`, so
re-enabling it later does not lose configuration.

The control plane strips those entries before an agent reads the config
(`control-plane/src/routes/workspace/config.ts`), so a switched-off server is
genuinely never loaded. But the template summary rendered every key in
`mcpServers` identically — its props type did not even carry `disabled` — so a
switched-off server looked exactly like a loaded one. A user reported this as
"I unchecked it but it still shows up loaded", and reasonably guessed it was a
hidden dependency of the other servers in the same group.

The version diff had the same blind spot: `getMcpServerNames` returned every
key, so toggling a server off showed as no change.

## Change

- `TemplateConfigView` — carry `disabled` through the props and row types, show
  a badge on switched-off entries and dim the row. Kept visible rather than
  hidden so the retained params stay discoverable.
- `TemplatesSection` — filter disabled entries out of `getMcpServerNames`, so
  the diff reflects what the agent actually receives.
- New locale key `components.library.templateConfigView.labels.disabled`.

## Verification

`npx tsc --noEmit` clean; `biome check` reports only the pre-existing
`useExhaustiveDependencies` warning in `TemplatesSection.tsx:334`.
