### PR TITLE
Add a funasr ASR provider

### DIFF
--- a/control-plane/src/services/asr/providers/funasr.ts
+++ b/control-plane/src/services/asr/providers/funasr.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod'
+import type { AsrProviderModule } from '../registry'
+import type { AsrInput, AsrProvider, AsrResult } from '../types'
+
+const name = 'funasr'
+
+// Fun-ASR-Nano (Qwen3-0.6B + SenseVoice, ~800M). Alongside an OpenAI-compatible
+// /v1/audio/transcriptions endpoint it serves a richer native /asr endpoint
+// (hotwords, char-level timestamps, duration). We use /asr so the caller's
+// `hint` can be forwarded as hotwords and the reported duration kept.
+// Auth is HTTP Basic, not Bearer — the server rejects a Bearer token, so an
+// OpenAI-compatible client cannot talk to it directly.
+const configSchema = z.object({
+  base_url: z.string().url().default('http://localhost:8899'),
+  username: z.string().min(1).default('funasr'),
+  password: z.string().min(1),
+})
+
+type Config = z.infer<typeof configSchema>
+
+// The service takes a spelled-out language name, or none at all to auto-detect.
+// Map the canonical codes callers use onto what it expects; anything unknown
+// falls through to auto.
+const LANGUAGE_NAMES: Record<string, string> = {
+  zh: '中文',
+  en: 'English',
+  ja: '日本語',
+}
+
+interface AsrResponse {
+  text: string
+  // VAD-cut segments (up to 60s each), in order. We emit one per line so a long
+  // transcript arrives as readable chunks rather than a single paragraph.
+  segments?: { text?: string }[]
+  duration?: number // seconds
+}
+
+function create(config: Config): AsrProvider {
+  const authHeader = `Basic ${Buffer.from(`${config.username}:${config.password}`).toString('base64')}`
+
+  return {
+    name,
+    async transcribe(input: AsrInput): Promise<AsrResult> {
+      const baseUrl = config.base_url.replace(/\/+$/, '')
+
+      const form = new FormData()
+      // Audio reaches a provider already normalized to 16 kHz mono WAV, which is
+      // what this endpoint wants; it errors on containers like m4a and flac.
+      form.append(
+        'file',
+        new Blob([new Uint8Array(input.audio)], { type: 'audio/wav' }),
+        'audio.wav',
+      )
+      if (input.language && input.language !== 'auto') {
+        const langName = LANGUAGE_NAMES[input.language]
+        if (langName) form.append('language', langName)
+      }
+      // The caller's transcription hint doubles as hotwords: comma-separated
+      // domain terms that bias decoding.
+      if (input.hint) form.append('hotwords', input.hint)
+      form.append('timestamp', 'false')
+
+      const res = await fetch(`${baseUrl}/asr`, {
+        method: 'POST',
+        headers: { Authorization: authHeader },
+        body: form,
+      })
+
+      if (!res.ok) {
+        throw new Error(
+          `funasr transcribe failed: ${res.status} ${await res.text().catch(() => '')}`,
+        )
+      }
+
+      const data = (await res.json()) as AsrResponse
+      // One segment per line; fall back to the flat text when segments are absent.
+      const lines = data.segments?.map((s) => s.text?.trim() ?? '').filter(Boolean) ?? []
+      const text = lines.length ? lines.join('\n') : (data.text ?? '')
+      return {
+        text,
+        language: input.language && input.language !== 'auto' ? input.language : undefined,
+        duration_ms: data.duration != null ? Math.round(data.duration * 1000) : undefined,
+      }
+    },
+  }
+}
+
+export default { name, configSchema, create } satisfies AsrProviderModule<Config>

--- a/control-plane/src/services/asr/registry.ts
+++ b/control-plane/src/services/asr/registry.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod'
+import funasr from './providers/funasr'
 import openai from './providers/openai'
 import type { AsrProvider } from './types'
 
@@ -15,4 +16,5 @@ export interface AsrProviderModule<C = unknown> {
  */
 export const REGISTRY: Record<string, AsrProviderModule> = {
   [openai.name]: openai,
+  [funasr.name]: funasr,
 }


### PR DESCRIPTION
## Problem

`REGISTRY` in `services/asr` held a single provider. With only one transcription backend wired up, anything that takes it out — an outage, a rate limit, an exhausted account balance — takes voice input down for everyone, and there is nothing to switch to.

## Change

Add `funasr` as a second ASR provider and register it.

Fun-ASR-Nano needs its own module rather than the OpenAI one aimed at a different `base_url`:

- it authenticates with **HTTP Basic**, and rejects a Bearer token
- its native `/asr` endpoint takes **hotwords** — which is where a caller's transcription `hint` belongs — and returns VAD-cut **segments** plus a duration, none of which the OpenAI-compatible route exposes

The module emits one segment per line so a long transcript arrives as readable chunks, falling back to the flat `text` when the response carries no segments. Audio already reaches a provider as 16 kHz mono WAV, which is what this endpoint wants.

No other wiring is needed:

- the admin settings UI lists `Object.keys(REGISTRY)`, so the provider becomes selectable on its own
- `password` already matches `SECRET_FIELD_RE`, so it is stripped from GET responses and preserved across a round-tripped PUT

The active provider is unchanged — this only makes another one available to select.

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — 564 tests across 46 files, all passing
- `biome check` — clean
- Reachability confirmed against a running Fun-ASR endpoint: `POST /asr` without credentials returns 401, i.e. the route and its Basic-auth challenge are live
