### PR TITLE
Resolve relative markdown links in the file preview

### DIFF
--- a/web/src/components/ui/markdown.tsx
+++ b/web/src/components/ui/markdown.tsx
@@ -124,23 +124,36 @@ const sysSanitizeSchema = {
 // schema to whitelist `<agent-sys>`; the rest stays in lockstep with
 // Streamdown so katex / raw HTML / link hardening keep working. Revisit on
 // Streamdown upgrades.
-export const markdownRehypePlugins: PluggableList = [
-  rehypeRaw,
-  [rehypeKatex, { errorColor: "var(--color-muted-foreground)" }],
-  [rehypeSanitize, sysSanitizeSchema],
-  [
-    harden,
-    {
-      allowedImagePrefixes: ["*"],
-      allowedLinkPrefixes: ["*"],
-      allowedProtocols: ["*"],
-      defaultOrigin: undefined,
-      allowDataImages: true,
-    },
-  ],
-  // Last: the custom tag it emits must not be seen by rehype-sanitize.
-  rehypeMermaid,
-];
+//
+// `beforeHarden` is for plugins that rewrite hrefs/srcs — harden judges what
+// they produce, so they have to run first (see `lib/rehype-relative-paths.ts`);
+// `afterHarden` is for everything layered on the rendered tree.
+export function markdownRehypePluginsWith(
+  beforeHarden: PluggableList = [],
+  afterHarden: PluggableList = [],
+): PluggableList {
+  return [
+    rehypeRaw,
+    [rehypeKatex, { errorColor: "var(--color-muted-foreground)" }],
+    [rehypeSanitize, sysSanitizeSchema],
+    ...beforeHarden,
+    [
+      harden,
+      {
+        allowedImagePrefixes: ["*"],
+        allowedLinkPrefixes: ["*"],
+        allowedProtocols: ["*"],
+        defaultOrigin: undefined,
+        allowDataImages: true,
+      },
+    ],
+    // After harden: the custom tag it emits must not be seen by rehype-sanitize.
+    rehypeMermaid,
+    ...afterHarden,
+  ];
+}
+
+export const markdownRehypePlugins: PluggableList = markdownRehypePluginsWith();
 
 function AgentSysBlock({ children }: { children?: ReactNode }) {
   const { t } = useTranslation();

--- a/web/src/components/workspace/FileViewer.tsx
+++ b/web/src/components/workspace/FileViewer.tsx
@@ -380,6 +380,8 @@ export function FileViewer({
       ) : (
         <FilePreview
           filename={filePath}
+          filePath={filePath}
+          drive={drive}
           fileUrl={fetchUrl}
           previewUrl={fetchPreviewUrl}
           content={isEditing ? editedContent : fileContent}

--- a/web/src/components/workspace/file-preview/FilePreview.tsx
+++ b/web/src/components/workspace/file-preview/FilePreview.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
+import type { DriveKind } from '@/lib/api/agent-files'
 import { useMarkdownPreferencesStore } from '@/stores/markdown-preferences-store'
 import { Code, Eye, FileText, Table, WrapText } from 'lucide-react'
 import { Suspense, lazy, useState } from 'react'
@@ -83,6 +84,13 @@ function PreviewFallback() {
 interface FilePreviewProps {
   filename: string
   content: string
+  /**
+   * Where the file lives, when it lives on a workspace drive. Lets the
+   * markdown preview resolve document-relative links against the file's own
+   * directory; omitted (skill editor) they stay unresolved.
+   */
+  filePath?: string
+  drive?: DriveKind
   /** URL to fetch the raw file (used for binary previews like images). */
   fileUrl?: string
   /** URL that returns a rendered PDF for Office documents. */
@@ -102,6 +110,8 @@ interface FilePreviewProps {
 export function FilePreview({
   filename,
   content,
+  filePath,
+  drive,
   fileUrl,
   previewUrl,
   isEditing,
@@ -221,7 +231,7 @@ export function FilePreview({
       )}
       <Suspense fallback={<PreviewFallback />}>
         {useRendered && previewType === 'markdown' ? (
-          <MarkdownPreview content={content} />
+          <MarkdownPreview content={content} filePath={filePath} drive={drive} />
         ) : useRendered && previewType === 'image' && fileUrl ? (
           <ImagePreview
             src={fileUrl}

--- a/web/src/components/workspace/file-preview/MarkdownPreview.tsx
+++ b/web/src/components/workspace/file-preview/MarkdownPreview.tsx
@@ -1,12 +1,13 @@
-import { Markdown, markdownRehypePlugins } from '@/components/ui/markdown'
+import { Markdown, markdownRehypePluginsWith } from '@/components/ui/markdown'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import type { DriveKind } from '@/lib/api/agent-files'
+import { rehypeRelativePaths } from '@/lib/rehype-relative-paths'
 import { cn } from '@/lib/utils'
 import { useMarkdownPreferencesStore } from '@/stores/markdown-preferences-store'
 import { ChevronDown } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import rehypeSlug from 'rehype-slug'
-import type { PluggableList } from 'unified'
 
 // Streamdown's `rehypePlugins` prop replaces its whole pipeline rather than
 // extending it. Passing just `[rehypeSlug]` would drop rehype-raw (inline
@@ -14,9 +15,12 @@ import type { PluggableList } from 'unified'
 // vanish from the preview. Layer slug on top of the app's own stack instead;
 // sanitize stays in place, so this is still XSS-safe, and mermaid fences keep
 // rendering through our block.
-// Hoisted so the memoized Markdown sees a stable reference; otherwise a new
-// array every render busts the memo.
-const REHYPE_PLUGINS: PluggableList = [...markdownRehypePlugins, rehypeSlug]
+
+/** Drive-relative directory holding `filePath`, e.g. `/document/ctcli`. */
+function dirOf(filePath: string): string {
+  const idx = filePath.lastIndexOf('/')
+  return idx <= 0 ? '/' : filePath.slice(0, idx)
+}
 
 interface TocItem {
   id: string
@@ -41,13 +45,36 @@ function readTocFromDom(root: HTMLElement): TocItem[] {
   return out
 }
 
-export function MarkdownPreview({ content }: { content: string }) {
+interface MarkdownPreviewProps {
+  content: string
+  /** Path of the previewed file within `drive`, used to resolve relative links. */
+  filePath?: string
+  drive?: DriveKind
+}
+
+export function MarkdownPreview({ content, filePath, drive }: MarkdownPreviewProps) {
   const { t } = useTranslation()
   const tocVisible = useMarkdownPreferencesStore((s) => s.tocVisible)
   const [mobileOpen, setMobileOpen] = useState(false)
   const [toc, setToc] = useState<TocItem[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
   const scrollRootRef = useRef<HTMLDivElement | null>(null)
+
+  // Relative links (`USAGE.md`, `./docs/x.md`) are resolved against the
+  // previewed file's own directory, then routed into the Files panel like any
+  // other workspace path. Without a known location they stay untouched — and
+  // harden blocks them, which is the safe fallback.
+  const linkifyWorkspaceFiles = !!filePath && !!drive
+  // Hoisted through useMemo so the memoized Markdown sees a stable reference;
+  // a new array every render would bust the memo.
+  const rehypePlugins = useMemo(
+    () =>
+      markdownRehypePluginsWith(
+        filePath && drive ? [[rehypeRelativePaths, { baseDir: dirOf(filePath), drive }]] : [],
+        [rehypeSlug],
+      ),
+    [filePath, drive],
+  )
 
   const getViewport = (): HTMLElement | null =>
     scrollRootRef.current?.querySelector<HTMLElement>('[data-radix-scroll-area-viewport]') ?? null
@@ -143,7 +170,9 @@ export function MarkdownPreview({ content }: { content: string }) {
         )}
         <ScrollArea ref={scrollRootRef} className="flex-1">
           <div className="p-4">
-            <Markdown rehypePlugins={REHYPE_PLUGINS}>{content}</Markdown>
+            <Markdown rehypePlugins={rehypePlugins} linkifyWorkspaceFiles={linkifyWorkspaceFiles}>
+              {content}
+            </Markdown>
           </div>
         </ScrollArea>
       </div>

--- a/web/src/lib/rehype-relative-paths.test.ts
+++ b/web/src/lib/rehype-relative-paths.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { rehypeRelativePaths, resolveRelativePath } from './rehype-relative-paths'
+
+interface Node {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: Node[]
+}
+
+function run(node: Node, baseDir = '/document/ctcli', drive: 'workspace' | 'afs' = 'workspace') {
+  const transform = rehypeRelativePaths({ baseDir, drive }) as (tree: Node) => void
+  const tree: Node = { type: 'root', children: [node] }
+  transform(tree)
+  return node.properties
+}
+
+function link(href: unknown): Node {
+  return { type: 'element', tagName: 'a', properties: { href }, children: [] }
+}
+
+describe('resolveRelativePath', () => {
+  it('resolves bare, dot and parent-relative paths', () => {
+    expect(resolveRelativePath('/document/ctcli', 'USAGE.md')).toBe('/document/ctcli/USAGE.md')
+    expect(resolveRelativePath('/document/ctcli', './docs/testing.md')).toBe(
+      '/document/ctcli/docs/testing.md',
+    )
+    expect(resolveRelativePath('/document/ctcli', '../shared/x.md')).toBe('/document/shared/x.md')
+    expect(resolveRelativePath('/', 'README.md')).toBe('/README.md')
+  })
+
+  it('keeps a trailing slash and rejects climbing above the root', () => {
+    expect(resolveRelativePath('/document', 'docs/')).toBe('/document/docs/')
+    expect(resolveRelativePath('/document', '../../etc')).toBeNull()
+  })
+})
+
+describe('rehypeRelativePaths', () => {
+  it('rewrites relative link and image targets onto the drive', () => {
+    expect(run(link('USAGE.md')).href).toBe('/workspace/document/ctcli/USAGE.md')
+    expect(run(link('./CHANGELOG.md')).href).toBe('/workspace/document/ctcli/CHANGELOG.md')
+    expect(run(link('docs/release.md'), '/document/ctcli', 'afs').href).toBe(
+      '/mnt/afs/document/ctcli/docs/release.md',
+    )
+    const img: Node = {
+      type: 'element',
+      tagName: 'img',
+      properties: { src: 'images/arch.png' },
+      children: [],
+    }
+    expect(run(img).src).toBe('/workspace/document/ctcli/images/arch.png')
+  })
+
+  it('drops the fragment so the target file still opens', () => {
+    expect(run(link('USAGE.md#install')).href).toBe('/workspace/document/ctcli/USAGE.md')
+  })
+
+  it('leaves absolute, protocol and anchor hrefs alone', () => {
+    expect(run(link('https://example.com/x')).href).toBe('https://example.com/x')
+    expect(run(link('mailto:a@example.com')).href).toBe('mailto:a@example.com')
+    expect(run(link('/workspace/other/y.md')).href).toBe('/workspace/other/y.md')
+    expect(run(link('#section')).href).toBe('#section')
+    expect(run(link(undefined)).href).toBeUndefined()
+  })
+
+  it('walks nested content such as table cells', () => {
+    const cell: Node = {
+      type: 'element',
+      tagName: 'td',
+      properties: {},
+      children: [link('config.yaml.example')],
+    }
+    const transform = rehypeRelativePaths({ baseDir: '/document/ctcli', drive: 'workspace' }) as (
+      tree: Node,
+    ) => void
+    transform({ type: 'root', children: [cell] })
+    expect(cell.children?.[0].properties?.href).toBe(
+      '/workspace/document/ctcli/config.yaml.example',
+    )
+  })
+})

--- a/web/src/lib/rehype-relative-paths.ts
+++ b/web/src/lib/rehype-relative-paths.ts
@@ -1,0 +1,82 @@
+import type { DriveKind } from '@/lib/api/agent-files'
+import type { Plugin } from 'unified'
+
+interface HastNode {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+interface RelativePathOptions {
+  /** Drive-relative directory holding the document, e.g. `/document/ctcli`. */
+  baseDir: string
+  drive: DriveKind
+}
+
+const DRIVE_ROOTS: Record<DriveKind, string> = {
+  workspace: '/workspace',
+  afs: '/mnt/afs',
+}
+
+/** Anything with a scheme, a protocol-relative host, a fragment, or already rooted. */
+function isAbsoluteRef(url: string): boolean {
+  return (
+    url.startsWith('/') ||
+    url.startsWith('#') ||
+    url.startsWith('?') ||
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url)
+  )
+}
+
+/**
+ * Resolve `rel` against `baseDir`, both drive-relative. Returns `null` when the
+ * path climbs above the drive root, which the file viewer cannot serve anyway.
+ */
+export function resolveRelativePath(baseDir: string, rel: string): string | null {
+  const segments = baseDir.split('/').filter(Boolean)
+  for (const part of rel.split('/')) {
+    if (part === '' || part === '.') continue
+    if (part === '..') {
+      if (segments.length === 0) return null
+      segments.pop()
+      continue
+    }
+    segments.push(part)
+  }
+  const path = `/${segments.join('/')}`
+  return rel.endsWith('/') && !path.endsWith('/') ? `${path}/` : path
+}
+
+function rewrite(url: unknown, { baseDir, drive }: RelativePathOptions): string | null {
+  if (typeof url !== 'string' || url === '' || isAbsoluteRef(url)) return null
+  // Markdown anchors (`USAGE.md#install`) point inside the linked document; the
+  // file viewer opens whole files, so the target file is the useful part.
+  const path = resolveRelativePath(baseDir, url.split('#')[0].split('?')[0])
+  return path === null ? null : `${DRIVE_ROOTS[drive]}${path}`
+}
+
+/**
+ * Rewrites document-relative link/image targets into the container-absolute
+ * paths the rest of the stack understands (`/workspace/...`, `/mnt/afs/...`),
+ * so a README's `[USAGE.md](USAGE.md)` resolves next to the README instead of
+ * against the site origin.
+ *
+ * Must run *before* `rehype-harden`: harden drops bare relative hrefs outright
+ * (rendering them as `text [blocked]`) and rebases `./x` ones onto the site
+ * root.
+ */
+export const rehypeRelativePaths: Plugin<[RelativePathOptions]> =
+  (options: RelativePathOptions) => (tree: unknown) => {
+    const walk = (node: HastNode) => {
+      if (node.type === 'element' && node.properties) {
+        const attr = node.tagName === 'a' ? 'href' : node.tagName === 'img' ? 'src' : null
+        if (attr) {
+          const next = rewrite(node.properties[attr], options)
+          if (next !== null) node.properties[attr] = next
+        }
+      }
+      for (const child of node.children ?? []) walk(child)
+    }
+    walk(tree as HastNode)
+  }


### PR DESCRIPTION
## Problem

Relative link targets inside a previewed markdown file had no base directory to resolve against, so the render pipeline mangled them:

- Bare relative paths (`[USAGE.md](USAGE.md)`) were rejected as invalid URLs by `rehype-harden` and degraded to plain text: `USAGE.md [blocked]`.
- Dot-relative ones (`[CHANGELOG.md](./CHANGELOG.md)`) resolved against the site root, so clicking went to `<origin>/CHANGELOG.md` and 404'd.

Relative image sources (`![](images/x.png)`) hit the same path and rendered as `[Image blocked]`.

## Changes

- New `lib/rehype-relative-paths.ts`: resolves relative `href`/`src` against the previewed file's own directory, emitting the container-absolute paths the rest of the stack already understands (`/workspace/...`, `/mnt/afs/...`). Absolute paths, scheme URLs and `#anchor` refs pass through untouched; targets climbing above the drive root are left alone for harden to block. The preview opens whole files, so only the file part of a fragment link is kept.
- `components/ui/markdown.tsx`: the `markdownRehypePlugins` constant becomes a `markdownRehypePluginsWith(beforeHarden, afterHarden)` factory. Plugins that rewrite URLs must run before `harden` so their output is still validated. The constant stays, so other callers are unaffected.
- `MarkdownPreview` takes optional `filePath` / `drive`; with both, it layers in the rewrite plugin and enables `linkifyWorkspaceFiles`, routing links through the existing `useWorkspaceFileLink` so a click opens the target in the Files panel instead of a new tab. Without them (the skill editor) behaviour is unchanged.
- `FilePreview` / `FileViewer` pass `filePath` + `drive` down.

## Verification

- New `rehype-relative-paths.test.ts`: bare relative, `./`, `../`, trailing-slash directories, links nested in table cells, pass-through for absolute and `mailto:` targets, fragment handling.
- `npx tsc --noEmit` clean; `vitest run` passes 15 files / 195 tests.