### PR TITLE
Allow editing credential metadata without re-entering the value

### DIFF
--- a/control-plane/src/routes/credentials.ts
+++ b/control-plane/src/routes/credentials.ts
@@ -67,7 +67,8 @@ const upsertRoute = createRoute({
   method: 'put',
   path: '/{name}',
   tags: ['credentials'],
-  summary: 'Upsert a credential. For env injection the name must be a valid env var identifier.',
+  summary:
+    'Upsert a credential. For env injection the name must be a valid env var identifier. Omit value to update only the metadata of an existing credential.',
   security: [{ bearerAuth: [] }],
   request: {
     params: NameParam,
@@ -109,7 +110,7 @@ credentials.openapi(upsertRoute, async (c) => {
     }
   }
 
-  await upsertUserCredential(
+  const written = await upsertUserCredential(
     currentUser.sub,
     name,
     body.value,
@@ -119,6 +120,9 @@ credentials.openapi(upsertRoute, async (c) => {
     body.scope,
     body.workspace_ids,
   )
+  if (!written) {
+    return c.json({ error: 'value is required when creating a credential' }, 400)
+  }
   await reloadUserWorkspaces(currentUser.sub)
   return c.json({ success: true }, 200)
 })

--- a/control-plane/src/services/db/credentials.ts
+++ b/control-plane/src/services/db/credentials.ts
@@ -61,28 +61,43 @@ export async function listWorkspaceCredentials(
   return rows as UserCredential[]
 }
 
+// An undefined `value` updates metadata only and keeps the stored secret, so
+// the credential must already exist; the boolean says whether a row was written.
 export async function upsertUserCredential(
   userId: string,
   name: string,
-  value: string,
+  value: string | undefined,
   inject: string,
   path?: string,
   mode?: string,
   scope?: string,
   workspaceIds?: string[],
-): Promise<void> {
+): Promise<boolean> {
   const resolvedScope = scope ?? 'global'
   const client = await pool.connect()
   try {
     await client.query('BEGIN')
-    await client.query(
-      `INSERT INTO user_credentials (user_id, name, encrypted_value, inject, path, mode, scope, status)
-       VALUES ($1, $2, encode(pgp_sym_encrypt($3, $4), 'base64'), $5, $6, $7, $8, 'active')
-       ON CONFLICT (user_id, name) DO UPDATE
-         SET encrypted_value = encode(pgp_sym_encrypt($3, $4), 'base64'),
-             inject = $5, path = $6, mode = $7, scope = $8, status = 'active', updated_at = NOW()`,
-      [userId, name, value, encKey(), inject, path ?? null, mode ?? null, resolvedScope],
-    )
+    if (value === undefined) {
+      const result = await client.query(
+        `UPDATE user_credentials
+            SET inject = $3, path = $4, mode = $5, scope = $6, status = 'active', updated_at = NOW()
+          WHERE user_id = $1 AND name = $2 AND status = 'active'`,
+        [userId, name, inject, path ?? null, mode ?? null, resolvedScope],
+      )
+      if ((result.rowCount ?? 0) === 0) {
+        await client.query('ROLLBACK')
+        return false
+      }
+    } else {
+      await client.query(
+        `INSERT INTO user_credentials (user_id, name, encrypted_value, inject, path, mode, scope, status)
+         VALUES ($1, $2, encode(pgp_sym_encrypt($3, $4), 'base64'), $5, $6, $7, $8, 'active')
+         ON CONFLICT (user_id, name) DO UPDATE
+           SET encrypted_value = encode(pgp_sym_encrypt($3, $4), 'base64'),
+               inject = $5, path = $6, mode = $7, scope = $8, status = 'active', updated_at = NOW()`,
+        [userId, name, value, encKey(), inject, path ?? null, mode ?? null, resolvedScope],
+      )
+    }
     await client.query(
       'DELETE FROM user_credential_workspaces WHERE user_id = $1 AND credential_name = $2',
       [userId, name],
@@ -97,6 +112,7 @@ export async function upsertUserCredential(
       }
     }
     await client.query('COMMIT')
+    return true
   } catch (e) {
     await client.query('ROLLBACK')
     throw e

--- a/internal/types/api.ts
+++ b/internal/types/api.ts
@@ -829,7 +829,9 @@ export const ApiCredentialMetaSchema = z.object({
 export type ApiCredentialMeta = z.infer<typeof ApiCredentialMetaSchema>
 
 export const CredentialUpsertBodySchema = z.object({
-  value: z.string().min(1),
+  // Omit to keep the stored value untouched — lets a caller edit only the
+  // metadata (scope, workspaces, path) of an existing credential.
+  value: z.string().min(1).optional(),
   inject: z.enum(['env', 'file']),
   path: z.string().optional(),
   mode: z.string().optional(),

--- a/web/src/components/dialogs/CredentialFormFields.tsx
+++ b/web/src/components/dialogs/CredentialFormFields.tsx
@@ -96,6 +96,8 @@ interface CredentialFormFieldsProps {
   errors?: CredentialFormErrors
   /** Edit mode locks preset / inject choice and tweaks copy. */
   isEditing?: boolean
+  /** In edit mode, whether a value must still be entered (i.e. the name changed). */
+  valueRequired?: boolean
 }
 
 export function CredentialFormFields({
@@ -103,6 +105,7 @@ export function CredentialFormFields({
   setForm,
   errors,
   isEditing,
+  valueRequired,
 }: CredentialFormFieldsProps) {
   const { t } = useTranslation()
   const [showValue, setShowValue] = useState(false)
@@ -305,7 +308,11 @@ export function CredentialFormFields({
           }
           placeholder={
             isEditing
-              ? t('components.credentialsSection.placeholders.editValue')
+              ? t(
+                  valueRequired
+                    ? 'components.credentialsSection.placeholders.renameValue'
+                    : 'components.credentialsSection.placeholders.editValue',
+                )
               : form.inject === 'env'
                 ? t('components.createCredential.placeholders.envValue')
                 : t('components.createCredential.placeholders.fileValue')
@@ -345,10 +352,15 @@ function Field({
   )
 }
 
-export function validateCredentialForm(form: CredentialForm): CredentialFormErrors {
+// `requireValue` is false when editing an existing credential under its current
+// name: an empty value then means "keep the stored one" rather than a mistake.
+export function validateCredentialForm(
+  form: CredentialForm,
+  { requireValue = true }: { requireValue?: boolean } = {},
+): CredentialFormErrors {
   const errors: CredentialFormErrors = {}
   if (!form.name) errors.name = 'components.createCredential.errors.nameRequired'
-  if (!form.value) errors.value = 'components.createCredential.errors.valueRequired'
+  if (requireValue && !form.value) errors.value = 'components.createCredential.errors.valueRequired'
   if (form.inject === 'file' && !form.path) {
     errors.path = 'components.createCredential.errors.pathRequired'
   }

--- a/web/src/components/management/CredentialsSection.tsx
+++ b/web/src/components/management/CredentialsSection.tsx
@@ -57,10 +57,13 @@ export function CredentialsSection(_: { instanceId: string }) {
 
   const upsertMutation = useMutation({
     mutationFn: async (data: CredentialForm & { editingName: string | null }) => {
-      let value = data.value
+      let value: string | undefined = data.value
       if (data.inject === 'file' && value && !value.endsWith('\n')) {
         value += '\n'
       }
+      // Editing under the same name with the value left blank keeps the stored
+      // secret — omitting the field tells the API to touch metadata only.
+      if (!value) value = undefined
       if (data.editingName && data.name !== data.editingName) {
         await api.deleteCredential(data.editingName)
       }
@@ -120,8 +123,12 @@ export function CredentialsSection(_: { instanceId: string }) {
     setDialogOpen(true)
   }
 
+  // A rename recreates the credential under the new name, so the value has to
+  // be supplied again; editing in place can leave it blank.
+  const valueRequired = editingName === null || form.name !== editingName
+
   function handleSave() {
-    const next = validateCredentialForm(form)
+    const next = validateCredentialForm(form, { requireValue: valueRequired })
     setErrors(next)
     if (Object.keys(next).length > 0) return
     setGeneralError(null)
@@ -238,7 +245,13 @@ export function CredentialsSection(_: { instanceId: string }) {
               {t('components.credentialsSection.dialogs.editTitle')}
             </DialogTitle>
           </DialogHeader>
-          <CredentialFormFields form={form} setForm={setForm} errors={localizedErrors} isEditing />
+          <CredentialFormFields
+            form={form}
+            setForm={setForm}
+            errors={localizedErrors}
+            isEditing
+            valueRequired={valueRequired}
+          />
           {generalError && <div className="mt-3 text-xs text-destructive">{generalError}</div>}
           <DialogFooter>
             <Button type="button" size="sm" variant="ghost" onClick={() => setDialogOpen(false)}>

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1394,7 +1394,8 @@ class ApiClient {
   async upsertCredential(
     name: string,
     data: {
-      value: string
+      // Omit to keep the stored value; only valid for an existing credential.
+      value?: string
       inject: string
       path?: string
       mode?: string

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2446,7 +2446,8 @@
         "editTitle": "Edit Credential"
       },
       "placeholders": {
-        "editValue": "Re-enter value (not shown for security)"
+        "editValue": "Leave blank to keep the current value (not shown for security)",
+        "renameValue": "Re-enter value (required when the name changes)"
       },
       "errors": {
         "loadFailed": "Failed to load credentials",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2470,7 +2470,8 @@
         "editTitle": "编辑凭证"
       },
       "placeholders": {
-        "editValue": "请重新输入值（出于安全原因不会展示原值）"
+        "editValue": "留空则保持当前值（出于安全原因不会展示原值）",
+        "renameValue": "重命名需要重新输入值（出于安全原因不会展示原值）"
       },
       "errors": {
         "loadFailed": "加载凭证失败",


### PR DESCRIPTION
## Problem

In `Credentials` → `Edit Credential`, changing only the scope / selected workspaces cannot be saved: the form fails with "Value is required", and the API always overwrites the encrypted value, so there was no way to touch metadata alone.

Reported with a screenshot: editing an `id_rsa` file credential to change its workspace list is blocked by the value validation.

## Change

- `PUT /api/credentials/{name}`: `value` is now optional. When omitted, only the metadata (inject / path / mode / scope / workspaces) is updated and the stored secret is kept. The credential must already exist — creating without a value still returns 400.
- DB: `upsertUserCredential` takes `value?: string` and runs a metadata-only `UPDATE` in that case; returns whether a row was written.
- Web: the edit dialog only requires a value when creating, or when the name changed (a rename still recreates the credential, so the value must be supplied). Placeholder copy updated in en-US / zh-CN: "leave blank to keep the current value" vs. the rename case.

## Verification

`tsc --noEmit` clean in `control-plane` and `web`.