### PR TITLE
ci: tag nap-agent-dsh in the merge job

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -143,6 +143,7 @@ jobs:
           - nap-agent-claude-code
           - nap-agent-codex
           - nap-agent-goose
+          - nap-agent-dsh
     steps:
       # Same gate as the build job, plus the final tag set.
       - name: Gate & tags


### PR DESCRIPTION
`nap-agent-dsh` was added to the build matrix but never to the merge matrix. Its per-arch images get pushed by digest and no manifest list is ever created, so `ghcr.io/neutree-ai/agent-platform/nap-agent-dsh` has no `:latest` and no version tag — and a `nap-agent-dsh-v*` tag push builds images nothing can pull.

Found while cutting the `nap-*-v0.3.0` tag series, which had to skip dsh for this reason.