### PR TITLE
feat(agents): preinstall sqlite3 and file in agent base images

### DIFF
--- a/agents/claude-code/Dockerfile
+++ b/agents/claude-code/Dockerfile
@@ -51,7 +51,7 @@ COPY .npmrc /root/.npmrc
 # System packages — slowest layer, changes least
 RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip openssh-client poppler-utils \
-    tmux sudo locales vim-tiny sshpass \
+    tmux sudo locales vim-tiny sshpass sqlite3 file \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen \
     && echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/agents/codex/Dockerfile
+++ b/agents/codex/Dockerfile
@@ -55,7 +55,7 @@ COPY .npmrc /root/.npmrc
 # System packages — slowest layer, changes least
 RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip openssh-client poppler-utils \
-    tmux sudo locales vim-tiny sshpass \
+    tmux sudo locales vim-tiny sshpass sqlite3 file \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen \
     && echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/agents/dsh/Dockerfile
+++ b/agents/dsh/Dockerfile
@@ -62,7 +62,7 @@ COPY .npmrc /root/.npmrc
 # System packages — slowest layer, changes least
 RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip bzip2 openssh-client poppler-utils \
-    tmux sudo locales vim-tiny sshpass \
+    tmux sudo locales vim-tiny sshpass sqlite3 file \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen \
     && echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/agents/goose/Dockerfile
+++ b/agents/goose/Dockerfile
@@ -55,7 +55,7 @@ COPY .npmrc /root/.npmrc
 # System packages — slowest layer, changes least
 RUN apt-get update && apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
     git bash curl ca-certificates python3 python-is-python3 python3-requests python3-yaml ripgrep jq less unzip bzip2 openssh-client poppler-utils \
-    tmux sudo locales vim-tiny sshpass \
+    tmux sudo locales vim-tiny sshpass sqlite3 file \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen \
     && echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \


### PR DESCRIPTION
Adds `sqlite3` and `file` to the apt line of all four agent images (claude-code, codex, dsh, goose). Both were requested on the base-image tooling thread.

## Cost

Measured on `node:20-slim` with the full existing apt set already installed.

| package | download | installed | notes |
| --- | --- | --- | --- |
| `sqlite3` | 353 kB | 546 kB | `libsqlite3-0` already present (pulled in by `python3`) — only the CLI was missing |
| `file` | 451 kB | 8.6 MB | pulls `libmagic1` + `libmagic-mgc`, neither present; almost all of the 8.6 MB is the magic database |

Neither adds a layer or a `RUN` step. Build time increase is ~1s.

## Conflicts

None. The `sqlite3` CLI ships the same `3.40.1-2+deb12u2` as the library already installed, with no `/usr/bin/sqlite3` occupant and no alternatives/symlink conflict. `file` introduces two entirely new packages.

## Caveat to document for users

The workspace volume (including `HOME`) is an NFSv4.1 mount. `local_lock=none` plus RWO + `Recreate` means a single client and single process, so SQLite's default rollback journal is safe. **WAL mode is not** — it relies on `-shm` shared-memory files, which SQLite explicitly does not support on network filesystems. Heavy write batches should also be wrapped in a single transaction to avoid a network round-trip fsync per row.