### PR TITLE
self-host: separate the TURN bind address from the advertised one

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -187,6 +187,19 @@ export BROWSER_NODE_PORT="${BROWSER_NODE_PORT:-30085}"
 export BROWSER_JWT_SECRET="${BROWSER_JWT_SECRET:-}"
 export TURN_HOST="${TURN_HOST:-}"
 export TURN_PORT="${TURN_PORT:-3478}"
+# The address browsers dial and the address coturn binds are the same thing on
+# a LAN node and two different things behind 1:1 NAT (a cloud VM's public IP
+# lives on the gateway, never on the node's NIC, so binding it fails with
+# EADDRNOTAVAIL). TURN_HOST advertises, TURN_BIND_IP binds, and it defaults to
+# TURN_HOST so LAN installs configure one value as before.
+export TURN_BIND_IP="${TURN_BIND_IP:-$TURN_HOST}"
+# coturn takes the NAT mapping as PUBLIC/PRIVATE; a plain address when the two
+# are the same keeps the LAN rendering identical.
+if [ "$TURN_BIND_IP" = "$TURN_HOST" ]; then
+  export TURN_EXTERNAL_IP="$TURN_HOST"
+else
+  export TURN_EXTERNAL_IP="$TURN_HOST/$TURN_BIND_IP"
+fi
 export TURN_AUTH_SECRET="${TURN_AUTH_SECRET:-}"
 export COTURN_NODE_SELECTOR="${COTURN_NODE_SELECTOR:-}"
 
@@ -331,7 +344,7 @@ render_manifests() {
   VARS+='${SANDBOX_NODE_PORT}${SANDBOX_JWT_SECRET}${SANDBOX_SERVICE_KEY}${SANDBOX_DOMAIN}${OPENSANDBOX_URL}'
   VARS+='${SANDBOX_SERVICE_URL_RESOLVED}${BROWSER_SERVICE_URL_RESOLVED}'
   VARS+='${SANDBOX_OAUTH_REDIRECT_URI}${BROWSER_OAUTH_REDIRECT_URI}'
-  VARS+='${TURN_HOST}${TURN_PORT}${TURN_AUTH_SECRET}'
+  VARS+='${TURN_HOST}${TURN_BIND_IP}${TURN_EXTERNAL_IP}${TURN_PORT}${TURN_AUTH_SECRET}'
   VARS+='${AFS_STORAGE_SIZE}'
   VARS+='${SERVICE_TYPE}'
   VARS+='${PG_SYNC_REPLICAS}'

--- a/self-host/manifests/coturn.yaml
+++ b/self-host/manifests/coturn.yaml
@@ -37,12 +37,17 @@ spec:
             # Pin to a single IP. Without --listening-ip coturn enumerates
             # every host interface — including kube-ipvs0 / CNI dummy
             # interfaces carrying Service ClusterIPs that reject bind() with
-            # EADDRNOTAVAIL. We use ${TURN_HOST} (from values.env, also the
-            # address browsers dial) so a node whose kubelet registered the
-            # wrong InternalIP can still be overridden explicitly.
-            - "--listening-ip=${TURN_HOST}"
-            - "--relay-ip=${TURN_HOST}"
-            - "--external-ip=${TURN_HOST}"
+            # EADDRNOTAVAIL.
+            #
+            # Bind and advertise are separate addresses: ${TURN_BIND_IP} has to
+            # exist on this node's NIC, while ${TURN_HOST} is whatever browsers
+            # dial. They are the same value on a LAN node, and behind 1:1 NAT
+            # (a cloud VM's public IP) they are not — binding the public one
+            # there fails with EADDRNOTAVAIL. install.sh defaults TURN_BIND_IP
+            # to TURN_HOST and folds both into ${TURN_EXTERNAL_IP}.
+            - "--listening-ip=${TURN_BIND_IP}"
+            - "--relay-ip=${TURN_BIND_IP}"
+            - "--external-ip=${TURN_EXTERNAL_IP}"
             - "--min-port=49152"
             - "--max-port=49252"
             - "--realm=${NAP_HOST}"
@@ -68,6 +73,15 @@ spec:
             - name: turn-udp
               containerPort: 3478
               protocol: UDP
+          # coturn exits 255 when it cannot bind, and a bare Deployment reports
+          # the CrashLoop as 1/1 Running between restarts — one install ran a
+          # dead relay for months without a single failing signal. The probe
+          # makes an unbindable address show up as a failed rollout instead.
+          readinessProbe:
+            tcpSocket:
+              port: 3478
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             requests:
               cpu: 100m

--- a/self-host/values.env.example
+++ b/self-host/values.env.example
@@ -164,6 +164,12 @@ BROWSER_JWT_SECRET=
 # Public LAN / WAN IP that browsers reach TURN at (required when BROWSER_ENABLED=true).
 # Kubelet auto-detect is unreliable on multi-NIC nodes — set this explicitly.
 TURN_HOST=
+# Address coturn binds to on the node. Blank = TURN_HOST, which is right
+# whenever browsers dial the node's own NIC. Set it only when TURN_HOST is not
+# an address on the node — a cloud VM behind 1:1 NAT (AWS EIP, GCP external IP)
+# reaches the node on a private address, and binding the public one fails with
+# EADDRNOTAVAIL. Then: TURN_HOST=<public IP>, TURN_BIND_IP=<node private IP>.
+TURN_BIND_IP=
 TURN_PORT=3478
 TURN_AUTH_SECRET=
 # Pin coturn to a specific node (recommended — TURN_HOST is the node IP).


### PR DESCRIPTION
`coturn.yaml` passed `$TURN_HOST` to `--listening-ip`, `--relay-ip` and `--external-ip` alike. On a LAN node those are the same address; behind 1:1 NAT they are not — a cloud VM's public IP lives on the gateway, never on the node's NIC, so coturn fails the bind and exits 255:

```
WARNING: Trying to bind fd 27 to <public-ip:3478>: errno=99
ERROR: Fatal final failure: cannot bind TLS/TCP listener socket to addr public-ip:3478
```

Found on a single-node cloud install that had been crash-looping for months (22k+ restarts), with WebRTC live view dead the whole time.

## Changes

- `TURN_BIND_IP` (new, defaults to `TURN_HOST`) is what coturn binds; `TURN_HOST` only advertises. Where the two differ, `--external-ip` renders coturn's `PUBLIC/PRIVATE` NAT form. LAN installs configure one value as before and render byte-identical args.
- A readiness probe on 3478. A bare Deployment reports a CrashLooping pod as `1/1 Running` between restarts, which is why this stayed invisible for months; now an unbindable address surfaces as a failed rollout during install.

## Verified

`install.sh --render-only` both ways: with `TURN_BIND_IP` set it renders `--listening-ip=<private>` / `--external-ip=<public>/<private>`; left blank it renders the single-address form unchanged.