### PR TITLE
fix(codex,scheduler): bound codex log database growth and surface its errors

### DIFF
--- a/agents/codex/src/config.ts
+++ b/agents/codex/src/config.ts
@@ -6,7 +6,17 @@
  * and MCP servers via ACP session/new.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { dirname, join } from 'node:path'
 import type { McpServer } from '@agentclientprotocol/sdk'
 import { SkillManager } from '../../../internal/agent-skills/src/index.js'
@@ -98,6 +108,59 @@ let _userMcpServers: Record<string, UserMcpServerConfig> = {}
 // config) can still render the platform skill with the user's display name.
 let _userDisplayName: string | undefined
 
+/** Size at which the codex log database is dropped, in bytes. Kept well under
+ *  the ~200 MB where upstream reports write-lock contention crashing codex
+ *  outright (openai/codex#29237). */
+const CODEX_LOG_DB_MAX_BYTES = Number(process.env.CODEX_LOG_DB_MAX_BYTES) || 128 * 1024 * 1024
+
+const CODEX_LOG_FILE = /^logs_\d+\.sqlite(-wal|-shm)?$/
+
+/**
+ * Drop the codex log database when it grows past the cap.
+ *
+ * Codex logs every turn to `~/.codex/logs_<n>.sqlite` and never rotates it, so
+ * a long-lived workspace grows it without bound. Opening a database that large
+ * — and replaying its write-ahead log — costs more memory than the workspace
+ * container is allowed, so codex exits at startup with "failed to initialize
+ * state runtime" and every turn fails with no usable error. Codex recreates
+ * the database on its next run; session state lives in `state_<n>.sqlite` and
+ * `sessions/`, which this leaves alone.
+ *
+ * Only safe to call while no codex process is running. Unlinking a file codex
+ * still holds open reclaims nothing on the NFS-backed workspace volume — the
+ * kernel silly-renames it to `.nfsXXXX` and codex keeps writing to it.
+ */
+export function pruneCodexLogs(
+  codexDir: string = join(process.env.HOME || '/root', '.codex'),
+): void {
+  let names: string[]
+  try {
+    names = readdirSync(codexDir).filter((n) => CODEX_LOG_FILE.test(n))
+  } catch {
+    return
+  }
+  const total = names.reduce((sum, name) => {
+    try {
+      return sum + statSync(join(codexDir, name)).size
+    } catch {
+      return sum
+    }
+  }, 0)
+  if (total <= CODEX_LOG_DB_MAX_BYTES) return
+
+  for (const name of names) {
+    try {
+      rmSync(join(codexDir, name))
+    } catch (e) {
+      console.warn(`[agent] Failed to prune codex log ${name}:`, e)
+    }
+  }
+  const mb = (bytes: number) => Math.round(bytes / 1024 / 1024)
+  console.log(
+    `[agent] Pruned codex log database (${mb(total)}MB over ${mb(CODEX_LOG_DB_MAX_BYTES)}MB cap)`,
+  )
+}
+
 export async function loadConfig(): Promise<boolean> {
   if (!CP_URL || !WORKSPACE_ID) {
     console.log(
@@ -151,6 +214,7 @@ export async function loadConfig(): Promise<boolean> {
   const home = process.env.HOME || '/root'
   const codexDir = join(home, '.codex')
   mkdirSync(codexDir, { recursive: true })
+  pruneCodexLogs(codexDir)
 
   // Store MCP config as JSON for loadAcpMcpServers() (ACP adapter)
   writeFileSync(join(codexDir, 'mcp.json'), JSON.stringify({ mcpServers }, null, 2))

--- a/agents/codex/src/index.ts
+++ b/agents/codex/src/index.ts
@@ -10,8 +10,15 @@ import {
   loadCredentials,
   loadRuntimeConfig,
   loadSkills,
+  pruneCodexLogs,
 } from './config.js'
-import { app, injectWebSocket, setBridgeFactory, setRestartBridge } from './server.js'
+import {
+  app,
+  getLiveBridgeCount,
+  injectWebSocket,
+  setBridgeFactory,
+  setRestartBridge,
+} from './server.js'
 
 writePlatformPrompt({
   agentKind: 'codex',
@@ -104,6 +111,27 @@ setRestartBridge(async () => {
   const rc = loadRuntimeConfig()
   if (rc) applyProviderEnv(rc)
 })
+
+// ── Keep the codex log database bounded ──
+
+// The boot-time prune in loadConfig() only bounds growth across restarts, and
+// codex fills this database fast enough (~0.75 GB/day under steady scheduled
+// load, per openai/codex#26374) that a long-lived pod would blow past the cap
+// and stay there. So re-check on an interval — but only act between sessions:
+// a live bridge means a live codex process holding the files open, and
+// unlinking them then reclaims nothing. Deliberately best effort. A workspace
+// that never goes idle is never pruned, which is the right trade: the boot
+// path still catches it, and no turn is ever interrupted to reclaim disk.
+const LOG_PRUNE_INTERVAL_MS = Number(process.env.CODEX_LOG_PRUNE_INTERVAL_MS) || 10 * 60 * 1000
+
+setInterval(() => {
+  if (getLiveBridgeCount() > 0) return
+  try {
+    pruneCodexLogs()
+  } catch (e) {
+    console.warn('[agent] Codex log prune failed:', e)
+  }
+}, LOG_PRUNE_INTERVAL_MS).unref()
 
 // ── Start HTTP server ──
 

--- a/agents/codex/src/server.ts
+++ b/agents/codex/src/server.ts
@@ -19,7 +19,7 @@ import {
 
 let _restartBridge: (() => Promise<void>) | undefined
 
-const { app, injectWebSocket, setBridgeFactory } = createAcpAgentApp({
+const { app, injectWebSocket, setBridgeFactory, getLiveBridgeCount } = createAcpAgentApp({
   agentType: 'codex',
   capabilities: {
     system_prompt: true,
@@ -70,4 +70,4 @@ function setRestartBridge(fn: () => Promise<void>) {
   _restartBridge = fn
 }
 
-export { app, injectWebSocket, setBridgeFactory, setRestartBridge }
+export { app, injectWebSocket, setBridgeFactory, setRestartBridge, getLiveBridgeCount }

--- a/internal/acp-adapter/acp-server.ts
+++ b/internal/acp-adapter/acp-server.ts
@@ -879,5 +879,9 @@ export function createAcpAgentApp(config: AcpAgentServerConfig) {
     return c.json({ success: true, removed })
   })
 
-  return { app, injectWebSocket, setBridgeFactory }
+  /** Number of live agent child processes (1 bridge : 1 session). Zero means
+   *  no session is holding the agent's on-disk state open. */
+  const getLiveBridgeCount = () => sessionBridges.size
+
+  return { app, injectWebSocket, setBridgeFactory, getLiveBridgeCount }
 }

--- a/scheduler/src/handler.ts
+++ b/scheduler/src/handler.ts
@@ -211,6 +211,7 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
           }
         : undefined
 
+    const failure: { message?: string } = {}
     let sseResult = await startAndConsumeSession(
       chatEndpoint,
       workspace_id,
@@ -222,6 +223,7 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
       images,
       streamSink,
       bindThreadSession,
+      failure,
     )
 
     // If resuming failed, fallback to a fresh session
@@ -238,10 +240,15 @@ async function executeJob(job: Job<JobData>): Promise<JobResult> {
         images,
         streamSink,
         bindThreadSession,
+        failure,
       )
     }
 
-    if (!sseResult) throw new Error(`SSE stream failed for job=${job.id}`)
+    if (!sseResult) {
+      throw new Error(
+        `SSE stream failed for job=${job.id}${failure.message ? `: ${failure.message}` : ''}`,
+      )
+    }
 
     // If we only got a session_id but the stream failed, treat as error
     if (!sseResult.final_message && sseResult.error) {
@@ -502,6 +509,7 @@ async function startAndConsumeSession(
   images?: Array<{ data: string; media_type: string }>,
   streamSink?: StreamSink | null,
   onSessionStarted?: (sessionId: string) => void,
+  failure?: { message?: string },
 ): Promise<JobResult | null> {
   const body = JSON.stringify({
     message: prompt,
@@ -591,6 +599,10 @@ async function startAndConsumeSession(
   if (finalSessionId) {
     return { session_id: finalSessionId, error: errMsg }
   }
+  // The caller only sees `null` here, which says nothing about why the turn
+  // failed. Hand it the agent's own error so the job's failure message names
+  // the cause instead of restating that the stream did not produce a session.
+  if (failure) failure.message = errMsg
   return null
 }
 


### PR DESCRIPTION
Draft — opening for a look at the approach before polishing.

## The failure

Codex logs every turn to `~/.codex/logs_<n>.sqlite` and never rotates it. On a long-lived workspace it grows without bound; one workspace reached **27.8 GB** with a 1.4 GB write-ahead log:

```
-rw-r--r-- 1 node node 27809120256 logs_2.sqlite
-rw-r--r-- 1 node node  1402159632 logs_2.sqlite-wal
```

Opening a database that size and replaying its WAL costs more memory than the workspace container is allowed (`DEFAULT_WORKSPACE_RESOURCES.memory_limit` is `1Gi`), so codex is OOM-killed at startup:

```
Codex process has exited with code 1:
Error: failed to initialize sqlite state runtime under /workspace/.home/.codex
```

Every scheduled turn on that workspace then fails. Over 7 days that was 163 `SSE stream failed` jobs plus a further ~4.9k `503 Workspace is busy` as the restart loop backed up — 93% of them from the two most heavily used workspaces.

## Upstream

This is a known, unresolved family of bugs, and it shapes the fix:

- [openai/codex#26374](https://github.com/openai/codex/issues/26374) — the log database grows unbounded with no retention or rotation, ~0.75 GB/day under steady headless load. `feedback_log_body` dominates; TRACE from `codex_api::endpoint::responses_websocket` is the main writer.
- [openai/codex#30236](https://github.com/openai/codex/issues/30236) — `RUST_LOG` does not gate these writes; there is **no setting that caps or disables the log database**, so pruning from outside is the only lever.
- [openai/codex#27741](https://github.com/openai/codex/issues/27741) — the startup failure above, including the misdirection: the error names the *state* runtime, but the culprit is the log database. Deleting `logs_N.sqlite*` is confirmed safe — the app-server recreates it empty and threads, goals, memories and config are untouched.
- [openai/codex#29237](https://github.com/openai/codex/issues/29237) — codex crashes with SIGTRAP once the database passes **~200 MB**, via WAL write-lock contention → `SQLITE_BUSY` → `.unwrap()` → abort. The cap has to sit well below this, not merely below the OOM point.

## The fix

**`agents/codex/src/config.ts`** — drop the log database when it exceeds `CODEX_LOG_DB_MAX_BYTES`, defaulting to **128 MB** (under the ~200 MB crash zone). Codex recreates it on the next run; `state_<n>.sqlite` and `sessions/` are left alone.

**`agents/codex/src/index.ts`** — the prune runs at boot and then every `CODEX_LOG_PRUNE_INTERVAL_MS` (10 min default), **but only while no bridge is live**. One bridge is one codex process holding the files open, and unlinking them then reclaims nothing: on the NFS-backed workspace volume the kernel silly-renames the file to `.nfsXXXX` and codex keeps writing to it. Confirmed the hard way while clearing the 27.8 GB database by hand — the `rm` succeeded and freed zero bytes until the pod restarted.

This is best effort by design. A workspace that never goes idle is never pruned; the boot path still catches it, and no turn is interrupted to reclaim disk.

**`internal/acp-adapter/acp-server.ts`** — expose `getLiveBridgeCount()` so the idle check has something to ask. Additive; goose and dsh are unaffected.

**`scheduler/src/handler.ts`** — `startAndConsumeSession` logged the agent's real error and then returned a bare `null`, so the job failed with `SSE stream failed for job=<id>` and no cause. It now hands that message back. This is why the incident read as an SSE/streaming problem for as long as it did.

## Not included

`DEFAULT_WORKSPACE_RESOURCES.memory_limit: '1Gi'` (`internal/k8s-provider/workspace-spec.ts:68`) is low for heavy workspaces and made this fail earlier than it had to. Changing a default that affects every workspace felt like a separate call.

## Testing

`npx tsc --noEmit` clean in `agents/codex`, `agents/goose`, `agents/dsh` and `scheduler`. The prune path has not yet been exercised against a real oversized log database.