### PR TITLE
docs: quote LDAP_SEARCH_FILTER in configuration example

### DIFF
--- a/docs-site/src/content/docs/self-host/ldap.mdx
+++ b/docs-site/src/content/docs/self-host/ldap.mdx
@@ -34,7 +34,7 @@ The control plane ships a default schema oriented around `inetOrgPerson`. If you
 Example: a directory whose user DNs look like `cn=jdoe,ou=user,ou=corp,dc=example,dc=com`, with the login name on `cn`, the real name on `sn`, and an objectClass that may not include `inetOrgPerson`. Configure it like this:
 
 ```bash
-LDAP_SEARCH_FILTER=(objectClass=person)
+LDAP_SEARCH_FILTER='(objectClass=person)'
 LDAP_ATTR_USERNAME=cn
 LDAP_ATTR_NAME=sn
 LDAP_ATTR_EMAIL=mail

--- a/docs-site/src/content/docs/zh-cn/self-host/ldap.mdx
+++ b/docs-site/src/content/docs/zh-cn/self-host/ldap.mdx
@@ -34,7 +34,7 @@ LDAP 是可选模块，默认关闭。在 `values.env` 中把 `LDAP_ENABLED` 设
 示例：某目录的用户 DN 形如 `cn=jdoe,ou=user,ou=corp,dc=example,dc=com`，登录名在 `cn` 上，真实姓名在 `sn` 上，objectClass 可能不包含 `inetOrgPerson`。这样配置：
 
 ```bash
-LDAP_SEARCH_FILTER=(objectClass=person)
+LDAP_SEARCH_FILTER='(objectClass=person)'
 LDAP_ATTR_USERNAME=cn
 LDAP_ATTR_NAME=sn
 LDAP_ATTR_EMAIL=mail


### PR DESCRIPTION
## Summary

Quotes the `LDAP_SEARCH_FILTER` value in LDAP configuration examples.

In `values.env`, unquoted parentheses in `LDAP_SEARCH_FILTER=(objectClass=person)` cause a bash syntax error (`syntax error near unexpected token '('`) when the file is sourced by shell scripts during installation. Wrapping it in single quotes ensures the shell interprets it as a literal string.

## Related issues

None

## Changes

- Wrapped `LDAP_SEARCH_FILTER` value in single quotes in the LDAP configuration example.

## Testing

- Verified in bash shell that sourcing `LDAP_SEARCH_FILTER='(objectClass=person)'` succeeds without syntax errors.

## Checklist

- [x] PR is scoped to a single logical change
- [ ] Type-check passes (`npx tsc --noEmit`) for the affected component(s)
- [ ] Lint/format passes (`npx biome check .`)
- [ ] Tests added/updated where it makes sense, and passing
- [x] Docs updated if behavior or configuration changed