### PR TITLE
self-host: hand services a pre-built DATABASE_URL instead of a raw password

### DIFF
--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -320,19 +320,46 @@ check_app_prefix() {
 
 # --- Render templates ------------------------------------------------------
 
+# Percent-encode a string for the userinfo of a connection URI (RFC 3986
+# unreserved set kept verbatim, everything else escaped byte by byte).
+# LC_ALL=C makes the loop iterate bytes, so a multi-byte character encodes as
+# the sequence of its UTF-8 bytes rather than one out-of-range escape.
+urlencode() {
+  local LC_ALL=C s="$1" i c out=''
+  for (( i = 0; i < ${#s}; i++ )); do
+    c=${s:i:1}
+    case "$c" in
+      [A-Za-z0-9._~-]) out+="$c" ;;
+      # & 0xFF: printf reads a byte >= 0x80 as a negative number, and the
+      # escape has to carry the byte's own value.
+      *) printf -v c '%%%02X' "$(( $(printf '%d' "'$c") & 0xFF ))"; out+="$c" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 render_manifests() {
   log "Rendering manifests to $RENDERED_DIR ..."
   rm -rf "$RENDERED_DIR"
   mkdir -p "$RENDERED_DIR"
 
+  # The pg Secret carries a ready-made DATABASE_URL so no consumer has to
+  # assemble one from a raw password: a password is free-form and a URI is not,
+  # and this is the last place that still holds the plaintext and can encode it.
+  # Assembling downstream is where an unencoded '@' or ':' silently reparses the
+  # URL — and each driver disagrees about how.
+  export PG_USERNAME_ENC PG_PASSWORD_ENC
+  PG_USERNAME_ENC="$(urlencode "${PG_USERNAME}")"
+  PG_PASSWORD_ENC="$(urlencode "${PG_PASSWORD}")"
+
   # Explicit variable list — prevents envsubst from replacing k8s $(VAR)
-  # references like $(POSTGRES_PASSWORD)
+  # references like $(TURN_AUTH_SECRET)
   local VARS='${NAMESPACE}${REGISTRY}${IMAGE_TAG}${APP_PREFIX}${PLATFORM_IMAGE_PREFIX}${DB_NAME}${NAP_HOST}${NAP_NODE_PORT}'
   VARS+='${IMAGE_PULL_SECRET}'
   VARS+='${POSTGRES_IMAGE}${GOTENBERG_IMAGE}${COTURN_IMAGE}${NFS_SERVER_IMAGE}'
   VARS+='${RUNTIME_NODE_IMAGE}${RUNTIME_PYTHON_IMAGE}${RUNTIME_GOLANG_IMAGE}${PAUSE_IMAGE}'
   VARS+='${AFS_IMAGE}'
-  VARS+='${PG_USERNAME}${PG_PASSWORD}${PG_INSTANCES}${PG_STORAGE_SIZE}${PG_STORAGE_CLASS}'
+  VARS+='${PG_USERNAME}${PG_PASSWORD}${PG_USERNAME_ENC}${PG_PASSWORD_ENC}${PG_INSTANCES}${PG_STORAGE_SIZE}${PG_STORAGE_CLASS}'
   VARS+='${NFS_SERVER}${NFS_PATH}${NFS_STORAGE_CLASS}'
   VARS+='${JWT_SECRET}${CREDENTIAL_ENCRYPTION_KEY}${PLATFORM_SERVICE_KEY}'
   VARS+='${AGENT_IMAGE_PREFIX}${AGENT_IMAGE_TAG}${AGENT_STORAGE_CLASS}${AGENT_NODE_SELECTOR}'

--- a/self-host/manifests/browser-service.yaml
+++ b/self-host/manifests/browser-service.yaml
@@ -25,13 +25,11 @@ spec:
           env:
             - name: PORT
               value: "3005"
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/self-host/manifests/channel-gateway.yaml
+++ b/self-host/manifests/channel-gateway.yaml
@@ -25,13 +25,11 @@ spec:
           env:
             - name: PORT
               value: "3002"
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/self-host/manifests/control-plane.yaml
+++ b/self-host/manifests/control-plane.yaml
@@ -100,13 +100,11 @@ spec:
               value: "${IMAGE_PULL_SECRET}"
             - name: AGENT_NODE_SELECTOR
               value: "${AGENT_NODE_SELECTOR}"
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             - name: CONTROL_PLANE_URL
               value: "http://${APP_PREFIX}-cp.${NAMESPACE}.svc.cluster.local:3000"
             - name: BROWSER_SERVICE_URL

--- a/self-host/manifests/env-runner-k8s.yaml
+++ b/self-host/manifests/env-runner-k8s.yaml
@@ -93,13 +93,11 @@ spec:
               value: "afs-controller.${NAMESPACE}.svc:9100"
             - name: MEMORY_FUSE_IMAGE
               value: "${PLATFORM_IMAGE_PREFIX}-memory-fuse:${IMAGE_TAG}"
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
           resources:
             requests:
               memory: "128Mi"

--- a/self-host/manifests/sandbox-service.yaml
+++ b/self-host/manifests/sandbox-service.yaml
@@ -25,13 +25,11 @@ spec:
           env:
             - name: PORT
               value: "3006"
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/self-host/manifests/scheduler.yaml
+++ b/self-host/manifests/scheduler.yaml
@@ -20,13 +20,11 @@ spec:
           image: ${PLATFORM_IMAGE_PREFIX}-scheduler:${IMAGE_TAG}
           imagePullPolicy: Always
           env:
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             - name: NAP_API_URL
               value: "http://${APP_PREFIX}-cp:3000"
             - name: CG_API_URL

--- a/self-host/manifests/secrets.yaml
+++ b/self-host/manifests/secrets.yaml
@@ -7,6 +7,11 @@ type: kubernetes.io/basic-auth
 stringData:
   username: ${PG_USERNAME}
   password: ${PG_PASSWORD}
+  # The same credentials as a connection URI, userinfo percent-encoded at render
+  # time. Every service reads this key rather than rebuilding a URL from the
+  # password, so a password containing URI syntax ('@', ':', '/') stays a
+  # password instead of reparsing into a host.
+  connection-url: "postgresql://${PG_USERNAME_ENC}:${PG_PASSWORD_ENC}@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
 ---
 apiVersion: v1
 kind: Secret

--- a/self-host/manifests/seed-admin-job.yaml
+++ b/self-host/manifests/seed-admin-job.yaml
@@ -20,10 +20,8 @@ spec:
             - "--display-name"
             - "${ADMIN_DISPLAY_NAME}"
           env:
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url

--- a/self-host/manifests/seed-mcp-job.yaml
+++ b/self-host/manifests/seed-mcp-job.yaml
@@ -13,13 +13,11 @@ spec:
           image: ${PLATFORM_IMAGE_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-mcp-catalog-core.js"]
           env:
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             # Prefix-aware host for the platform MCP catalog URL. Without it the
             # seed writes http://nap-cp:3000/mcp, which only resolves when
             # APP_PREFIX is "nap". Keep in sync with control-plane.yaml.

--- a/self-host/manifests/seed-oauth-clients-job.yaml
+++ b/self-host/manifests/seed-oauth-clients-job.yaml
@@ -13,13 +13,11 @@ spec:
           image: ${PLATFORM_IMAGE_PREFIX}-cp:${IMAGE_TAG}
           command: ["node", "dist/seed-oauth-clients.js"]
           env:
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             # Empty for disabled modules — the seed script skips those clients.
             - name: SANDBOX_OAUTH_REDIRECT_URI
               value: "${SANDBOX_OAUTH_REDIRECT_URI}"

--- a/self-host/manifests/skills-content-service.yaml
+++ b/self-host/manifests/skills-content-service.yaml
@@ -29,13 +29,11 @@ spec:
           env:
             - name: PORT
               value: "3008"
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: ${APP_PREFIX}-pg-user
-                  key: password
-            - name: DATABASE_URL
-              value: "postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@${APP_PREFIX}-pg-rw:5432/${DB_NAME}"
+                  key: connection-url
             - name: CACHE_DIR
               value: /var/cache/skills-content
           volumeMounts:


### PR DESCRIPTION
## What

`render_manifests` percent-encodes `PG_USERNAME` / `PG_PASSWORD` and the pg Secret gains a `connection-url` key holding the finished URI. All ten DB consumers (cp, scheduler, channel-gateway, browser, sandbox, skills-content, env-runner, and the three seed jobs) now read that key by `secretKeyRef` and no longer receive `POSTGRES_PASSWORD` at all. The `password` key stays for the CNPG bootstrap.

## Why

Each manifest built its own connection string as `postgresql://${PG_USERNAME}:$(POSTGRES_PASSWORD)@...`, with the password arriving from the Secret through kubelet's env expansion — nowhere that could percent-encode it. A password is free-form and a URI is not, so any password containing URI syntax reparsed the URL, and drivers disagreed about how:

- **libpq** splits the userinfo at the **first** `@` — a password containing one turns the remainder into the hostname
- **node-postgres** splits at the **last** and connects normally

So the application stack can be healthy while a psql-based maintenance job fails to resolve a host it never meant to use, reporting it as "the database is not there". Encoding once, at the only step that still holds the plaintext, removes the class rather than restricting what a password may contain.

## Testing

Rendered the Secret for user `na:p`, password `p@ss/w0rd#1` → `postgresql://na%3Ap:p%40ss%2Fw0rd%231@nap-pg-rw:5432/nap`:

- libpq (`postgres:16` image) resolves the host as `nap-pg-rw`
- `pg-connection-string` returns `user=na:p`, `password=p@ss/w0rd#1`, `host=nap-pg-rw`
- `urlencode` matches Python `quote(safe='')` across ASCII, space, `%`, and multi-byte UTF-8
- `bash -n` clean; every manifest still renders with the envsubst allow-list