### PR TITLE
docs: add files:read to Slack bot scopes

### DIFF
--- a/docs-site/src/content/docs/guides/5-trigger-agents.md
+++ b/docs-site/src/content/docs/guides/5-trigger-agents.md
@@ -112,7 +112,7 @@ Same shape, more credential work up front. Create an app in Slack, enable Socket
 - **Bot Token** (`xoxb-...`) — from OAuth & Permissions
 - **App Token** (`xapp-...`) — from Basic Information, with scope `connections:write`
 
-The Bot Token needs `chat:write`, `channels:history`, `channels:read` and `app_mentions:read`.
+The Bot Token needs `chat:write`, `channels:history`, `channels:read`, `app_mentions:read` and `files:read`.
 
 Fill both in, create the Slack Connector, then attach a Route: the channel to listen on (only channels the bot has joined appear) and the target workspace.
 

--- a/web/src/docs/inline-help/en-US/connector-slack.md
+++ b/web/src/docs/inline-help/en-US/connector-slack.md
@@ -9,7 +9,7 @@ Connect a Slack Workspace so the platform can receive Slack events (e.g. @mentio
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new App
 2. Enable **Socket Mode**
-3. Under **OAuth & Permissions**, add Bot Token Scopes: `chat:write`, `channels:history`, `channels:read`, `app_mentions:read`
+3. Under **OAuth & Permissions**, add Bot Token Scopes: `chat:write`, `channels:history`, `channels:read`, `app_mentions:read`, `files:read`
 4. Under **Basic Information**, create an App-Level Token (scope: `connections:write`)
 5. Install the App to your Workspace
 

--- a/web/src/docs/inline-help/zh-CN/connector-slack.md
+++ b/web/src/docs/inline-help/zh-CN/connector-slack.md
@@ -9,7 +9,7 @@
 
 1. 前往 [api.slack.com/apps](https://api.slack.com/apps) 创建新 App
 2. 开启 **Socket Mode**
-3. 在 **OAuth & Permissions** 添加 Bot Token Scopes：`chat:write`, `channels:history`, `channels:read`, `app_mentions:read`
+3. 在 **OAuth & Permissions** 添加 Bot Token Scopes：`chat:write`, `channels:history`, `channels:read`, `app_mentions:read`, `files:read`
 4. 在 **Basic Information** 创建 App-Level Token（scope: `connections:write`）
 5. 安装 App 到 workspace
 


### PR DESCRIPTION
## Summary

Add the missing `files:read` scope to the Slack connector documentation.

The Slack connector uses the bot token to download files from `url_private`, which requires the `files:read` scope.

## Changes

- Update the docs-site Slack setup guide
- Update the English inline Slack connector help
- Update the Chinese inline Slack connector help

Refs #236