### PR TITLE
feat(asr): let the funasr provider authenticate with a Bearer API key

### DIFF
--- a/control-plane/src/services/asr/providers/funasr.ts
+++ b/control-plane/src/services/asr/providers/funasr.ts
@@ -8,13 +8,21 @@ const name = 'funasr'
 // /v1/audio/transcriptions endpoint it serves a richer native /asr endpoint
 // (hotwords, char-level timestamps, duration). We use /asr so the caller's
 // `hint` can be forwarded as hotwords and the reported duration kept.
-// Auth is HTTP Basic, not Bearer — the server rejects a Bearer token, so an
-// OpenAI-compatible client cannot talk to it directly.
-const configSchema = z.object({
-  base_url: z.string().url().default('http://localhost:8899'),
-  username: z.string().min(1).default('funasr'),
-  password: z.string().min(1),
-})
+// Auth depends on how the server is fronted: a direct vLLM deployment guards it
+// with HTTP Basic (it rejects a Bearer token, so an OpenAI-compatible client
+// cannot talk to it directly), while behind the inference gateway the same
+// server takes a Bearer API key. Set `api_key` for the gateway, or
+// `username`/`password` for a direct deployment.
+const configSchema = z
+  .object({
+    base_url: z.string().url().default('http://localhost:8899'),
+    username: z.string().min(1).default('funasr'),
+    password: z.string().min(1).optional(),
+    api_key: z.string().min(1).optional(),
+  })
+  .refine((c) => Boolean(c.api_key || c.password), {
+    message: 'funasr needs either api_key (gateway) or password (basic auth)',
+  })
 
 type Config = z.infer<typeof configSchema>
 
@@ -36,7 +44,9 @@ interface AsrResponse {
 }
 
 function create(config: Config): AsrProvider {
-  const authHeader = `Basic ${Buffer.from(`${config.username}:${config.password}`).toString('base64')}`
+  const authHeader = config.api_key
+    ? `Bearer ${config.api_key}`
+    : `Basic ${Buffer.from(`${config.username}:${config.password}`).toString('base64')}`
 
   return {
     name,


### PR DESCRIPTION
## What

The `funasr` ASR provider hard-coded HTTP Basic auth. That is right for a
directly exposed vLLM deployment, but the same Fun-ASR server fronted by an
inference gateway authenticates with a Bearer API key, so a gateway-hosted
deployment could not be configured at all.

The provider config now takes an optional `api_key` next to `username` /
`password`:

- `api_key` set → `Authorization: Bearer <key>`
- otherwise → `Authorization: Basic <user:pass>`
- neither → rejected at schema validation, with a message naming both options,
  instead of surfacing as a 401 on the first transcription

`password` becomes optional for the same reason; the pair is enforced by a
`refine` rather than by either field alone.

Nothing else changes: the request still targets the native `/asr` endpoint with
`hotwords` / `language` / `timestamp`, and the response handling is untouched.

## Admin UI

No change needed. `api_key` already matches the system-settings secret-field
pattern, so it is stripped from GET responses and preserved when the scrubbed
payload is PUT back.

## Verification

Against a gateway-fronted Fun-ASR server, using the provider module itself:

- `/openapi.json` on both a direct and a gateway-fronted deployment reports the
  same title, the same two endpoints (`/asr`, `/v1/audio/transcriptions`) and the
  same `/asr` form fields
- the same 16 kHz mono WAV returns an identical transcript and duration through
  both auth paths
- a config carrying neither `api_key` nor `password` fails `configSchema.parse`

`npx tsc --noEmit` and `npx biome check` are clean.