### PR TITLE
fix(slack): forward generic file attachments to agents

### DIFF
--- a/channel-gateway/src/connectors/slack.test.ts
+++ b/channel-gateway/src/connectors/slack.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { extractSlackText } from './slack'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NapClient } from '../../../internal/client/src/index'
+import {
+  appendAttachmentPaths,
+  extractSlackText,
+  genericSlackFiles,
+  slackAttachmentPath,
+  stageGenericFiles,
+} from './slack'
+
+afterEach(() => vi.unstubAllGlobals())
 
 describe('extractSlackText', () => {
   it('returns text when present', () => {
@@ -110,5 +119,118 @@ describe('extractSlackText', () => {
       }
       expect(extractSlackText(msg)).toBe('please summarize this document')
     })
+  })
+})
+
+describe('generic Slack attachments', () => {
+  it('keeps generic files out of the image and audio paths', () => {
+    expect(
+      genericSlackFiles([
+        { id: 'F1', name: 'report.pdf', mimetype: 'application/pdf' },
+        { id: 'F2', name: 'photo.png', mimetype: 'image/png' },
+        { id: 'F3', name: 'voice.m4a', mimetype: 'audio/mp4' },
+      ]),
+    ).toEqual([{ id: 'F1', name: 'report.pdf', mimetype: 'application/pdf' }])
+  })
+
+  it('uses a safe, deterministic workspace path', () => {
+    expect(slackAttachmentPath({ id: 'F/1', name: '../report.pdf' })).toBe(
+      '.attachments/slack/F_1/_report.pdf',
+    )
+  })
+
+  it('tells the agent about staged paths and download failures', () => {
+    expect(
+      appendAttachmentPaths(
+        'summarize these',
+        ['.attachments/slack/F1/report.pdf'],
+        ['missing.csv — attachment download failed: 403'],
+      ),
+    ).toBe(
+      'summarize these\n<attachments>\n- /workspace/.attachments/slack/F1/report.pdf\n- missing.csv — attachment download failed: 403\n</attachments>',
+    )
+  })
+
+  it('streams a downloaded file through the route-owner client', async () => {
+    const calls: string[] = []
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url) === 'https://slack.test/report') {
+        calls.push('download')
+        return new Response('report body')
+      }
+      calls.push('write')
+      expect(String(url)).toBe(
+        'https://nap.test/api/workspaces/ws1/agent/files?path=.attachments%2Fslack%2FF1%2Freport.pdf',
+      )
+      expect(init?.body).toBeInstanceOf(ReadableStream)
+      expect((init as RequestInit & { duplex?: string }).duplex).toBe('half')
+      expect(init?.headers).toMatchObject({
+        Authorization: 'Bearer route-owner-token',
+        'Content-Type': 'application/pdf',
+      })
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await stageGenericFiles(
+      [
+        {
+          id: 'F1',
+          name: 'report.pdf',
+          mimetype: 'application/pdf',
+          url_private: 'https://slack.test/report',
+        },
+      ],
+      new NapClient({ baseUrl: 'https://nap.test', serviceToken: 'route-owner-token' }),
+      'ws1',
+      'xoxb-test',
+    )
+
+    expect(result).toEqual({ paths: ['.attachments/slack/F1/report.pdf'], failures: [] })
+    expect(calls).toEqual(['download', 'write'])
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://slack.test/report', {
+      headers: { Authorization: 'Bearer xoxb-test' },
+    })
+  })
+
+  it('reports download failures without attempting a workspace write', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 403 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      stageGenericFiles(
+        [{ id: 'F1', name: 'report.pdf', url_private: 'https://slack.test/report' }],
+        new NapClient({ baseUrl: 'https://nap.test', serviceToken: 'route-owner-token' }),
+        'ws1',
+        'xoxb-test',
+      ),
+    ).resolves.toEqual({
+      paths: [],
+      failures: ['report.pdf — attachment download failed: 403'],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces workspace staging errors and does not hide the 503 message', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('report body'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Workspace is stopped and auto-start is disabled' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      stageGenericFiles(
+        [{ id: 'F1', name: 'report.pdf', url_private: 'https://slack.test/report' }],
+        new NapClient({ baseUrl: 'https://nap.test', serviceToken: 'route-owner-token' }),
+        'ws1',
+        'xoxb-test',
+      ),
+    ).rejects.toThrow('Workspace is stopped and auto-start is disabled')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/channel-gateway/src/connectors/slack.ts
+++ b/channel-gateway/src/connectors/slack.ts
@@ -44,6 +44,81 @@ export function extractSlackText(msg: Record<string, unknown>): string {
 const SUPPORTED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
 
 type SlackImage = { data: string; media_type: string; filename?: string }
+type SlackFile = { id?: string; mimetype?: string; url_private?: string; name?: string }
+
+export function genericSlackFiles(files: SlackFile[] | undefined): SlackFile[] {
+  return (files || []).filter(
+    (file) =>
+      !SUPPORTED_IMAGE_TYPES.has(file.mimetype || '') && !file.mimetype?.startsWith('audio/'),
+  )
+}
+
+export function slackAttachmentPath(file: SlackFile): string | null {
+  if (!file.id) return null
+  const segment = (value: string, fallback: string) =>
+    value.replaceAll(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+/, '') || fallback
+  return `.attachments/slack/${segment(file.id, 'file')}/${segment(file.name || 'attachment', 'attachment')}`
+}
+
+export function appendAttachmentPaths(text: string, paths: string[], failures: string[]): string {
+  if (!paths.length && !failures.length) return text
+  return [
+    text.trim(),
+    '<attachments>',
+    ...paths.map((path) => `- /workspace/${path}`),
+    ...failures.map((failure) => `- ${failure}`),
+    '</attachments>',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+export async function stageGenericFiles(
+  files: SlackFile[],
+  client: NapClient,
+  workspaceId: string,
+  botToken: string,
+): Promise<{ paths: string[]; failures: string[] }> {
+  const paths: string[] = []
+  const failures: string[] = []
+  for (const file of files) {
+    const name = file.name || file.id || 'attachment'
+    const path = slackAttachmentPath(file)
+    if (!path || !file.url_private) {
+      failures.push(`${name} — attachment download failed: missing file id or URL`)
+      continue
+    }
+    let response: Response
+    try {
+      response = await fetch(file.url_private, {
+        headers: { Authorization: `Bearer ${botToken}` },
+      })
+    } catch (e) {
+      failures.push(
+        `${name} — attachment download failed: ${e instanceof Error ? e.message : String(e)}`,
+      )
+      continue
+    }
+    if (!response.ok || !response.body) {
+      failures.push(
+        `${name} — attachment download failed: ${response.ok ? 'empty response' : response.status}`,
+      )
+      continue
+    }
+    try {
+      await client.workspaces.writeFile(
+        workspaceId,
+        path,
+        response.body,
+        file.mimetype || 'application/octet-stream',
+      )
+    } catch (e) {
+      throw new Error(`${name}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+    paths.push(path)
+  }
+  return { paths, failures }
+}
 
 /** Active socket connections keyed by connector ID */
 const activeConnectors = new Map<string, SocketModeClient>()
@@ -82,6 +157,7 @@ export async function startOne(connectorId: string) {
     console.log(`[Slack] Skipped connector ${connector.name}: missing app_token or bot_token`)
     return
   }
+  const botToken = creds.bot_token
 
   const platformToken = await db.getPlatformToken(connector.user_id)
   if (!platformToken) {
@@ -138,11 +214,7 @@ export async function startOne(connectorId: string) {
     }
   }
 
-  async function downloadSlackImage(file: {
-    mimetype?: string
-    url_private?: string
-    name?: string
-  }): Promise<SlackImage | null> {
+  async function downloadSlackImage(file: SlackFile): Promise<SlackImage | null> {
     if (!file.url_private || !file.mimetype || !SUPPORTED_IMAGE_TYPES.has(file.mimetype)) {
       return null
     }
@@ -275,19 +347,14 @@ Indexes are 1-based and match the attached images order.
    *  Slack `files[].url_private` requires the bot token to download. Anthropic supports
    *  jpeg/png/gif/webp; other types (PDF, etc.) are skipped here. */
   async function fetchImageAttachments(event: Record<string, unknown>): Promise<SlackImage[]> {
-    const files = event.files as
-      | Array<{ mimetype?: string; url_private?: string; name?: string }>
-      | undefined
+    const files = event.files as SlackFile[] | undefined
     if (!files?.length) return []
     return (await pMap(files, downloadSlackImage, { concurrency: 8 })).filter(
       (img): img is SlackImage => img !== null,
     )
   }
 
-  interface SlackAudioFile {
-    url_private?: string
-    mimetype?: string
-    name?: string
+  interface SlackAudioFile extends SlackFile {
     transcription?: { status?: string; preview?: { content?: string } }
   }
 
@@ -418,6 +485,48 @@ Indexes are 1-based and match the attached images order.
       cleanText = [cleanText, ...voice.texts].filter(Boolean).join('\n')
     }
 
+    const jobClient = await resolveRouteClient(
+      `[Slack] ${connector.name}`,
+      route,
+      connector,
+      napClient,
+    )
+    if (!jobClient) return
+
+    let attachmentPaths: string[] = []
+    let attachmentFailures: string[] = []
+    try {
+      const staged = await stageGenericFiles(
+        genericSlackFiles(event.files as SlackFile[] | undefined),
+        jobClient,
+        route.workspace_id,
+        botToken,
+      )
+      attachmentPaths = staged.paths
+      attachmentFailures = staged.failures
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e)
+      await web.chat
+        .postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: `Attachment staging failed: ${error}\nThe job was not started. Please retry.`,
+        })
+        .catch((replyError) =>
+          console.warn(
+            `[Slack] ${connector.name}: failed to send staging-error reply:`,
+            replyError,
+          ),
+        )
+      await db
+        .updateEvent(eventId, { status: 'error', error })
+        .catch((updateError) =>
+          console.warn(`[Slack] ${connector.name}: failed to record staging error:`, updateError),
+        )
+      return
+    }
+    cleanText = appendAttachmentPaths(cleanText, attachmentPaths, attachmentFailures)
+
     // Chat API requires non-empty message; substitute a placeholder when the user sent only images.
     if (!cleanText && images.length) cleanText = '[image]'
 
@@ -456,14 +565,6 @@ Indexes are 1-based and match the attached images order.
     if (threadContext) threadContext += imageReminder(allImages.length)
     // Chat API requires non-empty message; substitute a placeholder when the user sent only images.
     if (!cleanText && allImages.length) cleanText = '[image]'
-
-    const jobClient = await resolveRouteClient(
-      `[Slack] ${connector.name}`,
-      route,
-      connector,
-      napClient,
-    )
-    if (!jobClient) return
 
     try {
       const result = await jobClient.jobs.create(route.workspace_id, {

--- a/control-plane/src/routes/workspaces/agent.ts
+++ b/control-plane/src/routes/workspaces/agent.ts
@@ -14,6 +14,7 @@ import {
 } from '../../services/db/export-tokens'
 import type { Workspace } from '../../services/db/types'
 import { getWorkspace } from '../../services/db/workspaces'
+import { WorkspaceStartError, ensureWorkspaceRunning } from '../../services/workspace-autostart'
 import { canManage } from './_shared'
 
 type UpgradeWebSocket = ReturnType<typeof createNodeWebSocket>['upgradeWebSocket']
@@ -332,7 +333,20 @@ export function createAgentRoutes(deps: { upgradeWebSocket: UpgradeWebSocket }) 
     })
     agent.openapi(writeFileRoute, async (c) => {
       const { id } = c.req.valid('param')
-      const resolved = await resolveWorkspace(id, c.get('user'))
+      let resolved = await resolveWorkspace(id, c.get('user'))
+      if ('error' in resolved && resolved.error === 'not-running' && routeNoun === 'files') {
+        const workspace = await getWorkspace(id)
+        if (!workspace || !canManage(workspace, c.get('user'))) {
+          return c.json({ error: 'Workspace not found' }, 404)
+        }
+        try {
+          await ensureWorkspaceRunning(workspace)
+        } catch (e) {
+          if (e instanceof WorkspaceStartError) return c.json({ error: e.message }, 503)
+          throw e
+        }
+        resolved = { workspace, address: getWorkspaceAddress(workspace.id) }
+      }
       if ('error' in resolved) {
         if (resolved.error === 'not-found') return c.json({ error: 'Workspace not found' }, 404)
         return c.json({ error: 'Workspace not running' }, 503)

--- a/docs-site/src/content/docs/zh-cn/guides/5-trigger-agents.md
+++ b/docs-site/src/content/docs/zh-cn/guides/5-trigger-agents.md
@@ -114,7 +114,7 @@ Slack 的接入流程类似，但凭证更复杂一些——需要先在 Slack �
 - **Bot Token**（`xoxb-...`） ——OAuth & Permissions 页
 - **App Token**（`xapp-...`） ——Basic Information 页，scope 为 `connections:write`
 
-Bot Token 需要的 scope：`chat:write`、`channels:history`、`channels:read`、`app_mentions:read`。
+Bot Token 需要的 scope：`chat:write`、`channels:history`、`channels:read`、`app_mentions:read`、`files:read`。
 
 填好 token 创建 Slack 连接器后，给它挂路由——选监听的 channel（仅列出 bot 已加入的）和目标 Workspace。
 

--- a/internal/client/src/http.ts
+++ b/internal/client/src/http.ts
@@ -33,14 +33,17 @@ export class HttpClient {
     }
 
     if (this.serviceToken) {
-      headers['Authorization'] = `Bearer ${this.serviceToken}`
+      headers.Authorization = `Bearer ${this.serviceToken}`
     } else if (this.token) {
-      headers['Cookie'] = `token=${this.token}`
+      headers.Cookie = `token=${this.token}`
     }
 
+    const isStream = typeof ReadableStream !== 'undefined' && init?.body instanceof ReadableStream
     const res = await fetch(`${this.baseUrl}${path}`, {
       ...init,
       headers: { ...headers, ...(init?.headers as Record<string, string>) },
+      // @ts-expect-error -- Node.js fetch requires duplex when sending a streaming body
+      duplex: isStream ? 'half' : undefined,
     })
 
     if (!res.ok) {

--- a/internal/client/src/workspaces.ts
+++ b/internal/client/src/workspaces.ts
@@ -89,4 +89,17 @@ export class WorkspacesApi {
       body: JSON.stringify(sessionId ? { sessionId } : {}),
     })
   }
+
+  async writeFile(
+    id: string,
+    path: string,
+    data: BodyInit,
+    contentType = 'application/octet-stream',
+  ): Promise<void> {
+    await this.http.fetch(`/api/workspaces/${id}/agent/files?path=${encodeURIComponent(path)}`, {
+      method: 'PUT',
+      body: data,
+      headers: { 'Content-Type': contentType },
+    })
+  }
 }


### PR DESCRIPTION
## Summary

- Download non-image/non-audio Slack attachments with the bot token, stream them into the routed workspace, and include their workspace paths in the agent prompt.
- Reuse `ensureWorkspaceRunning()` only for `PUT /api/workspaces/:id/agent/files`, preserving the existing behavior of all read, preview, directory, delete, and move routes.
- Use the route owner's client for both staging and job dispatch. Surface download failures to the agent, and reply in the Slack thread without starting a job when workspace staging fails.
- Add the internal client `writeFile` helper and document the missing `files:read` scope in the Chinese Slack guide.

## Behavior and scope

- Existing image handling and audio transcription paths are unchanged.
- `WorkspaceStartError` is returned as HTTP 503 with its original message. This includes the `auto_start=false` opt-out.
- Uploading a generic file to a stopped workspace can now cold-start it and wait for readiness (up to about 90 seconds) instead of failing immediately.
- `GET files`, `GET preview`, `GET dirs`, `GET dirs/zip`, `DELETE files`, `POST dirs`, and `POST move` do not auto-start the workspace.
- Attachment bodies are streamed rather than buffered in full.

## Testing

Validated with Node.js 22.23.2:

- `channel-gateway`: TypeScript check passed; 4 test files / 35 tests passed.
- `control-plane`: TypeScript check passed; 46 test files / 564 tests passed.
- Node 22-targeted builds passed for both components.
- Biome checks for all changed source files and `git diff --check` passed.

Closes #236