### PR TITLE
Special-case Reflect schedules in the Schedules UI

### DIFF
--- a/web/src/components/workspace/ScheduleDialog.tsx
+++ b/web/src/components/workspace/ScheduleDialog.tsx
@@ -93,14 +93,20 @@ export function ScheduleDialog({
               },
             )
           } else {
-            createMutation.mutate(data, {
-              onSuccess: (created) => {
-                toast.success(t('components.configSchedules.toasts.created'))
-                onOpenChange(false)
-                onSaved?.(created.id)
+            // Creation never targets a Reflect schedule (those are only ever
+            // server-created), so `data.prompt` is always populated here —
+            // the fallback just satisfies the stricter create-payload type.
+            createMutation.mutate(
+              { ...data, prompt: data.prompt ?? '' },
+              {
+                onSuccess: (created) => {
+                  toast.success(t('components.configSchedules.toasts.created'))
+                  onOpenChange(false)
+                  onSaved?.(created.id)
+                },
+                onError: (err) => toast.error(err.message),
               },
-              onError: (err) => toast.error(err.message),
-            })
+            )
           }
         }}
       />

--- a/web/src/components/workspace/ScheduleFields.tsx
+++ b/web/src/components/workspace/ScheduleFields.tsx
@@ -45,6 +45,8 @@ export function ScheduleFields({
   mode,
   onModeChange,
   modeDisabled,
+  promptLocked,
+  promptLockedNote,
   idPrefix = 'schedule',
 }: {
   value: ScheduleFieldsValue
@@ -52,6 +54,9 @@ export function ScheduleFields({
   mode: ScheduleMode
   onModeChange?: (m: ScheduleMode) => void
   modeDisabled?: boolean
+  /** Hide the prompt editor for a platform-managed prompt (e.g. a Reflect schedule) the API rejects edits to. */
+  promptLocked?: boolean
+  promptLockedNote?: string
   idPrefix?: string
 }) {
   const { t } = useTranslation()
@@ -112,19 +117,28 @@ export function ScheduleFields({
         <TimezoneSelect value={value.timezone} onChange={(timezone) => onChange({ timezone })} />
       </div>
 
-      <PromptField
-        label={t('components.configSchedules.form.prompt')}
-        promptId={value.prompt_id}
-        content={value.prompt}
-        onChange={(patch) =>
-          onChange({
-            ...(patch.promptId !== undefined ? { prompt_id: patch.promptId } : {}),
-            ...(patch.content !== undefined ? { prompt: patch.content } : {}),
-          })
-        }
-        placeholder={t('components.configSchedules.form.placeholders.prompt')}
-        previewMaxHeight="200px"
-      />
+      {promptLocked ? (
+        <div className="space-y-2">
+          <Label>{t('components.configSchedules.form.prompt')}</Label>
+          <p className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-muted-foreground text-xs">
+            {promptLockedNote}
+          </p>
+        </div>
+      ) : (
+        <PromptField
+          label={t('components.configSchedules.form.prompt')}
+          promptId={value.prompt_id}
+          content={value.prompt}
+          onChange={(patch) =>
+            onChange({
+              ...(patch.promptId !== undefined ? { prompt_id: patch.promptId } : {}),
+              ...(patch.content !== undefined ? { prompt: patch.content } : {}),
+            })
+          }
+          placeholder={t('components.configSchedules.form.placeholders.prompt')}
+          previewMaxHeight="200px"
+        />
+      )}
     </div>
   )
 }

--- a/web/src/components/workspace/ScheduleForm.tsx
+++ b/web/src/components/workspace/ScheduleForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/workspace/ScheduleFields'
 import type { Schedule } from '@/lib/api/types'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 // Re-exported so existing importers (ScheduleDialog) keep their import path.
 export { detectScheduleMode }
@@ -30,10 +31,16 @@ export function ScheduleForm({
     cron?: string | null
     run_at?: string | null
     timezone: string
-    prompt: string
+    prompt?: string
     prompt_id?: string | null
   }) => void
 }) {
+  const { t } = useTranslation()
+  // A Reflect-managed schedule's prompt is platform-controlled: the API
+  // rejects a PATCH body that even contains `prompt`/`prompt_id` keys, so
+  // those keys must be omitted from the submit payload entirely rather than
+  // sent unchanged.
+  const isReflect = initial?.origin === 'reflect'
   const [name, setName] = useState(initial?.name ?? '')
   const [cron, setCron] = useState(initial?.cron ?? '0 9 * * *')
   const [runAt, setRunAt] = useState<string>(
@@ -52,14 +59,16 @@ export function ScheduleForm({
       id={formId}
       onSubmit={(e) => {
         e.preventDefault()
+        const promptFields = isReflect
+          ? {}
+          : { prompt: promptId ? '' : prompt, prompt_id: promptId }
         if (mode === 'recurring') {
           onSubmit({
             name,
             cron,
             run_at: null,
             timezone,
-            prompt: promptId ? '' : prompt,
-            prompt_id: promptId,
+            ...promptFields,
           })
         } else {
           // datetime-local has no tz suffix; interpret as local wall-clock and
@@ -70,8 +79,7 @@ export function ScheduleForm({
             cron: null,
             run_at: runAtIso,
             timezone,
-            prompt: promptId ? '' : prompt,
-            prompt_id: promptId,
+            ...promptFields,
           })
         }
       }}
@@ -90,6 +98,8 @@ export function ScheduleForm({
         mode={mode}
         onModeChange={onModeChange}
         modeDisabled={isCompleted}
+        promptLocked={isReflect}
+        promptLockedNote={t('components.automation.reflect.promptLocked')}
       />
     </form>
   )

--- a/web/src/components/workspace/WorkspaceAutomationPanel.tsx
+++ b/web/src/components/workspace/WorkspaceAutomationPanel.tsx
@@ -85,6 +85,11 @@ function ScheduleCard({
   const runMutation = useRunSchedule(workspaceId)
   const onError = (err: Error) => toast.error(err.message)
   const isTemplate = schedule.origin === 'template'
+  const isReflect = schedule.origin === 'reflect'
+  // Reflect schedules are edited like normal ones (name/cron/timezone/enabled
+  // stay writable — see ScheduleForm's isReflect branch for the prompt lock),
+  // just never forked and never deleted from here: the API rejects DELETE for
+  // this origin (the scheduler self-heals it if its store ever disappears).
 
   const promptPreview = previewText(schedule.prompt_content ?? schedule.prompt)
   const lastRun = schedule.last_run_at
@@ -131,14 +136,18 @@ function ScheduleCard({
       name={schedule.name}
       description={promptPreview || undefined}
       type={
-        isTemplate ? (
+        isTemplate || isReflect ? (
           <span className="flex items-center gap-1.5">
             {typeChip}
             <Badge
               variant="muted-soft"
               className="rounded-md px-1.5 py-0 font-normal text-[11px] leading-5"
             >
-              {t('components.automation.badges.template')}
+              {t(
+                isTemplate
+                  ? 'components.automation.badges.template'
+                  : 'components.automation.badges.reflect',
+              )}
             </Badge>
           </span>
         ) : (
@@ -221,21 +230,24 @@ function ScheduleCard({
               >
                 <Pencil className="h-3 w-3" />
               </Button>
-              <ConfirmButton
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 text-muted-foreground hover:text-destructive"
-                disabled={deleteMutation.isPending}
-                onConfirm={() =>
-                  deleteMutation.mutate(schedule.id, {
-                    onSuccess: () => toast.success(t('components.configSchedules.toasts.deleted')),
-                    onError,
-                  })
-                }
-                icon={<Trash2 className="h-3 w-3" />}
-                tooltip={t('components.configCommands.actions.delete')}
-              />
+              {!isReflect && (
+                <ConfirmButton
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                  disabled={deleteMutation.isPending}
+                  onConfirm={() =>
+                    deleteMutation.mutate(schedule.id, {
+                      onSuccess: () =>
+                        toast.success(t('components.configSchedules.toasts.deleted')),
+                      onError,
+                    })
+                  }
+                  icon={<Trash2 className="h-3 w-3" />}
+                  tooltip={t('components.configCommands.actions.delete')}
+                />
+              )}
             </>
           )}
         </>

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -3695,8 +3695,12 @@
         "enabled": "Enabled",
         "disabled": "Disabled"
       },
+      "reflect": {
+        "promptLocked": "Managed by Reflect — the prompt is platform-controlled and can't be edited here."
+      },
       "badges": {
-        "template": "Template"
+        "template": "Template",
+        "reflect": "Built-in"
       },
       "fields": {
         "enabledDefault": "Enabled by default"

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -3719,8 +3719,12 @@
         "enabled": "已启用",
         "disabled": "已停用"
       },
+      "reflect": {
+        "promptLocked": "由 Reflect 管理，prompt 由平台维护，无法在此编辑。"
+      },
       "badges": {
-        "template": "模板"
+        "template": "模板",
+        "reflect": "内置"
       },
       "fields": {
         "enabledDefault": "默认启用"


### PR DESCRIPTION
## Summary
- `WorkspaceAutomationPanel`'s schedule card now special-cases `origin === 'reflect'`: a "Built-in" badge and no delete button (the API already rejects DELETE for this origin — this just stops it from surfacing as a raw 400).
- `ScheduleForm`/`ScheduleFields` lock the prompt field to a read-only note for a Reflect schedule and omit `prompt`/`prompt_id` from the PATCH payload entirely (the API rejects a body containing either key for this origin, regardless of value). `name`/`cron`/`timezone`/`enabled` stay editable.
- Added the two new i18n strings (`en-US`/`zh-CN`).

Follow-up to #277 (Reflect schedules — control-plane + scheduler side).

## Test plan
- [x] `npx tsc --noEmit` in `web`
- [x] `biome check` (pre-commit hook)
- [ ] Manual check in a browser against a workspace with a real Reflect schedule (not verified — needs a live backend/cluster)
